### PR TITLE
feat: 전투 시스템 전면 개선 — 스킬 파싱/역할군 패시브/칸 버프/UI 강화

### DIFF
--- a/docs/01-plan/features/champion-ability-audit.plan.md
+++ b/docs/01-plan/features/champion-ability-audit.plan.md
@@ -1,161 +1,183 @@
-# Champion Ability Audit Plan
+# Plan: Set 17 챔피언 스킬 전수 감사 (Ability Audit)
 
 ## Executive Summary
 
 | 관점 | 내용 |
 |------|------|
-| **Problem** | 116챔피언 중 다수가 JSON description과 ability.ts 구현이 불일치 — 시뮬레이션 정확도 저하 |
-| **Solution** | 자동 감사 스크립트 + 배치 수정으로 전 챔피언 ability 구현을 description 기준으로 검증·교정 |
-| **Function UX Effect** | 시뮬레이션 결과가 실제 게임과 일치하여 분석 도구로서의 신뢰도 확보 |
-| **Core Value** | 시뮬레이션 정확도 > 그래픽 — 프로젝트 핵심 철학 실현 |
+| **Problem** | 대부분 챔피언의 AbilityConfig가 스킬 설명과 불일치 — DOT를 즉발로 처리, 다회 타격 횟수 미반영, 패시브/스킬 분리 안 됨, % 최대체력 피해 미구현 등 |
+| **Solution** | 72명 전수 조사 후 AbilityConfig에 hitCount/dot 필드 추가, combatLoop에 DOT 시스템 + 다회 타격 곱연산 구현 |
+| **Function UX Effect** | 모든 챔피언의 스킬이 실제 게임 설명대로 동작하여 시뮬레이션 결과가 신뢰 가능 |
+| **Core Value** | 시뮬레이터 핵심 — 전투 피해/CC/회복 계산 정확도 복구 |
 
 ---
 
-## 1. 현황 분석
+## 1. 전수 감사 결과 요약
 
-### 1.1 데이터 규모
+### 72명 중 상태 분류
 
-| 항목 | 수치 |
-|------|------|
-| TFT16 챔피언 (JSON) | 106명 |
-| ability.ts 등록 | 87개 |
-| **미등록** | **19개** |
-
-### 1.2 미등록 챔피언 분류
-
-**특수 유닛 (구현 불필요)** — 8개:
-- `AnnieTibbers` (소환수), `AzirSoldier` (모래 병사), `MalzaharVoidling` (공허충)
-- `FreljordProp` (장식물), `PiltoverInvention` (발명품), `RiftHerald` (전령)
-- `BaronNashor` (내셔 남작), `THex` (T-헥스)
-
-**실제 챔피언 미등록** — 11개:
-| 챔피언 | 설명 요약 | 예상 난이도 |
-|--------|----------|------------|
-| Blitzcrank | 보호막 + 후킹(가장 먼 적 끌어오기) | High (위치 변경) |
-| Atakhan | 패시브 흡혈 + AOE | Medium |
-| Azir | 모래 병사 소환 + 패시브 | High (소환 메카닉) |
-| Bard | 주변 적에게 정령 발사 | Medium |
-| Kobuko | 유미 합체 패시브 | High (합체 메카닉) |
-| Mel | 회전 찬란 + 스킬 발동 | High (패시브 메카닉) |
-| Nautilus | 패시브 CC + 앵커 던지기 | Medium |
-| Sion | 패시브 HP 성장 + AOE 시전 | Medium |
-| Thresh | 패시브 주변 DOT + 후킹 | High (위치 변경) |
-| Viego | 패시브 AS 버프 + 강화 공격 | Medium |
-| Yorick | 체력 회복 + 구울 소환 | High (소환 메카닉) |
-
-### 1.3 기등록 챔피언 잠재적 불일치 유형
-
-| 불일치 유형 | 예시 | 영향도 |
-|------------|------|--------|
-| **패턴 오류** | description은 AOE인데 single로 등록 | Critical |
-| **효과 누락** | description에 쉴드/힐/스턴이 있는데 미구현 | Major |
-| **수치 오류** | maxTargets, radius, stunDuration 불일치 | Major |
-| **대상 선택 오류** | "가장 먼 적" vs "가장 가까운 적" | Major |
-| **패시브 미구현** | `<spellPassive>` 기반 효과 미반영 | Minor (MVP 범위 외 가능) |
-| **버프/디버프 누락** | 공속 버프, 방관 디버프 등 미적용 | Minor |
+| 상태 | 수 | 챔피언 |
+|------|---|--------|
+| ✅ 정상 | 14 | 이즈리얼, 레오나, 렉사이, 밀리오, 마오카이, 오른, 룰루, 사미라, 라아스트, 마스터이, 피오라, 제드, 아트록스, 뽀삐 |
+| ❌ 높음 (즉시 수정) | 16 | 아래 상세 |
+| ⚠️ 중간 (후속) | 22 | 아래 상세 |
+| 피해 없는 스킬 | 5 | 뽀삐, 잭스, 갈리오, 제드, 소형블랙홀 |
+| PVE/특수 | 7 | Minion, Raptor, Krug 등 |
 
 ---
 
-## 2. 감사 전략
+## 2. ❌ 높음 우선순위 — 16명 상세
 
-### 2.1 Phase 1 — 자동 감사 스크립트 (`scripts/audit-abilities.ts`)
+### 유형 A: DOT → 즉발 오류 (7명)
 
-JSON description에서 키워드를 추출하여 ability.ts 구현과 자동 비교:
+스킬이 매초 지속 피해인데 1회 즉발 피해로 계산됨.
 
-**검출 가능한 불일치:**
+| 챔피언 | 변수 | 지속시간 | 현재 처리 |
+|--------|------|---------|----------|
+| 탈론 | `ADBleedDamage`(460/690) | 18초 출혈 | 즉발 1회 |
+| 모데카이저 | `DamagePerProc`(45/70) | 4초 매초 | 즉발 1회 |
+| 판테온 | `TrueDamagePerSecond`(45) | 4초 매초 | 즉발 1회 |
+| 아우렐리온 솔 | `DamagePerSecond`(280) | 3초 매초 | 즉발 1회 |
+| 바드 | `DamagePerSecond`(220) | 4초 매초 | 즉발 1회 |
+| 모르가나 | `TetherDamagePerSecond`(75) | 5초 DOT + 최종 폭발 | 즉발 1회 |
+| 빅토르 | `Damage`(220) | 4초 매초 | 즉발 1회 |
 
-| 검출 항목 | description 키워드 | ability.ts 대응 필드 |
-|----------|-------------------|---------------------|
-| 스턴 누락 | `기절`, `StunDuration` | `stun` |
-| 힐 누락 | `회복`, `Heal` | `heal: true` |
-| 쉴드 누락 | `보호막`, `Shield` | `getAbilityShield()` |
-| 패턴 불일치 | `주변 적`, `범위 내` → AOE | `pattern` |
-| 대시 누락 | `돌진`, `도약`, `날아가` | `dash` |
-| 다수 대상 | `@NumTargets@`, `적 N명` | `maxTargets` |
-| 디버프 누락 | `방어력 감소`, `마법 저항력` | `debuff` |
-| 버프 누락 | `공격 속도`, `공격력` 증가 | `selfBuff`, `allyBuff` |
+### 유형 B: 다수 피해 미반영 (5명)
 
-**스크립트 출력 형식:**
+피해 = base × 횟수인데, base만 적용되어 극도로 낮음.
+
+| 챔피언 | base 피해 | 횟수 | 실제 총 피해 | 현재 |
+|--------|----------|------|------------|------|
+| 벨베스 | 20 | ×12 | 240 | 20 |
+| 아칼리 | 4 | ×5 단검 | 20 | 4 |
+| 징크스 | 27 | ×N 로켓 | 27×N | 27 |
+| 카이사 | 32 | ×16 미사일 | 512 | 32 |
+| 코르키 | MissileAD × 21 | ×21 | — | 배율값 사용 |
+
+### 유형 C: 특수 피해 계산 (4명)
+
+| 챔피언 | 문제 | 설명 |
+|--------|------|------|
+| 초가스 | `PercentMaximumHealthDamage` — % 최대체력 피해 | 고정값 아님, 적 HP 비례 |
+| 블리츠크랭크 | 3단계 분리 필요 (패시브/띄움/폭발) | 현재 `BoltDamage`만 적용 |
+| 다이애나 | `BaseAttackDamagePercent`(0.5) — %AD 피해 | 일반 계산 불가 |
+| 르블랑 | 패시브(기본공격 대체) + 분신 5명 + 투사체 | 복합 미구현 |
+
+---
+
+## 3. 수정 방안
+
+### Phase 1: AbilityConfig 확장
+
+```typescript
+interface AbilityConfig {
+  // 기존...
+  /** 다회 타격 횟수 (벨베스 12, 아칼리 5, 카이사 16 등) */
+  hitCount?: number;
+  /** DOT 지속 피해 */
+  dot?: { duration: number };
+  /** 피해 변수 오버라이드 (parseAbility 대신 직접 지정) */
+  damageVar?: string;
+  /** 2차 피해 변수 (폭발, 추가 타격 등) */
+  secondaryDamageVar?: string;
+}
 ```
-[CRITICAL] TFT16_Rumble: description에 보호막(Shield) 있음 → ability.ts에 shield 미구현
-[MAJOR]    TFT16_Bard: ability.ts에 미등록
-[MAJOR]    TFT16_Lulu: description에 StunDuration=1.5 → ability.ts stun=2.0 (수치 불일치)
-[MINOR]    TFT16_Garen: description에 '주변' 키워드 → radius 확인 필요
+
+### Phase 2: combatLoop — hitCount 곱연산
+
+```typescript
+// 스킬 피해 계산 시
+let totalDmg = abilityDmg;
+if (config.hitCount && config.hitCount > 1) {
+  totalDmg = abilityDmg * config.hitCount;
+}
 ```
 
-### 2.2 Phase 2 — 수동 검증 (배치별)
+### Phase 3: combatLoop — DOT 시스템
 
-자동 감사에서 잡지 못하는 케이스를 챔피언 10~15명씩 묶어서 검증:
+스킬 시전 시 대상에 DOT statusEffect 추가 → 매 틱 피해 적용:
 
-| 배치 | 대상 | 기준 |
-|------|------|------|
-| Batch 1 | 1코스트 챔피언 (~18명) | 코스트순 |
-| Batch 2 | 2코스트 챔피언 (~20명) | 코스트순 |
-| Batch 3 | 3코스트 챔피언 (~20명) | 코스트순 |
-| Batch 4 | 4코스트 챔피언 (~18명) | 코스트순 |
-| Batch 5 | 5코스트 챔피언 (~15명) | 코스트순 |
-| Batch 6 | 미등록 11명 + 특수 유닛 | 신규 등록 |
+```typescript
+if (config.dot) {
+  const dotTicks = Math.round(config.dot.duration * TICKS_PER_SECOND);
+  target.statusEffects.push({
+    type: 'burn',  // 기존 burn 타입 재활용
+    sourceId: unit.id,
+    remainingTicks: dotTicks,
+    value: abilityDmg / config.dot.duration,  // 초당 피해
+  });
+}
+```
 
-### 2.3 Phase 3 — 배치 수정
+### Phase 4: 특수 챔피언 개별 처리
 
-같은 유형의 불일치를 묶어서 일괄 수정:
-
-| 수정 유형 | 작업 내용 |
-|----------|----------|
-| 미등록 추가 | 11개 챔피언 ability.ts 등록 |
-| 효과 추가 | stun/heal/shield/dash 필드 추가 |
-| 패턴 변경 | pattern 타입 변경 (single→aoe 등) |
-| 수치 교정 | radius, maxTargets, stunDuration 수정 |
-| 신규 메카닉 | 소환/합체/위치변경 등 (MVP 범위 판단 후) |
+combatLoop에서 apiName 분기:
+- 초가스: `damage = targetMaxHp * percentValue`
+- 블리츠크랭크: 패시브(2초 주기) + 띄움(1명) + 폭발(3칸) 분리
+- 다이애나: `damage = casterAD * percentValue`
 
 ---
 
-## 3. 구현 범위
+## 4. 챔피언별 AbilityConfig 수정 목록
 
-### 3.1 In-Scope (이번에 하는 것)
+### hitCount 추가
 
-- [ ] 감사 스크립트 작성 (`scripts/audit-abilities.ts`)
-- [ ] 전체 불일치 리포트 생성
-- [ ] 기등록 87개 챔피언 패턴/효과 교정
-- [ ] 미등록 11개 챔피언 중 단순 패턴 챔피언 등록
-- [ ] 쉴드/힐/스턴/디버프/버프 효과 누락분 추가
+| 챔피언 | hitCount | 비고 |
+|--------|----------|------|
+| 벨베스 | 12 | `BaseNumSlashes` |
+| 아칼리 | 5 | `NumShurikens` |
+| 카이사 | 16 | `BaseNumMissiles` |
+| 코르키 | 21 | `BaseMissiles` |
 
-### 3.2 Out-of-Scope (이번에 안 하는 것)
+### dot 추가
 
-- 소환 메카닉 (Azir 모래병사, Yorick 구울) — 별도 feature로 분리
-- 위치 변경 메카닉 (Blitzcrank 후킹, Thresh 후킹) — 별도 feature로 분리
-- 합체 메카닉 (Kobuko+유미) — 별도 feature로 분리
-- 패시브 효과 전체 구현 (`<spellPassive>` 기반) — 별도 feature로 분리
-- 특수 유닛 8개 — 소환수/장식물이라 ability 등록 불필요
+| 챔피언 | duration | 비고 |
+|--------|----------|------|
+| 탈론 | 18 | 출혈 |
+| 모데카이저 | 4 | 매초 피해 |
+| 판테온 | 4 | 매초 고정 피해 |
+| 아우렐리온 솔 | 3 | 광선 |
+| 바드 | 4 | 비행접시 |
+| 모르가나 | 5 | 사슬 |
+| 빅토르 | 4 | 폭풍 |
 
----
+### damageVar 오버라이드
 
-## 4. 수정 대상 파일
+| 챔피언 | damageVar | 이유 |
+|--------|-----------|------|
+| 블리츠크랭크 | `ExplosionDamage` | 주요 피해는 폭발 |
+| 누누 | `InitialDamage` | ✅ 이미 잡힘 |
+| 징크스 | `ADDamage` | ✅ 이미 잡힘 |
 
-| 파일 | 변경 내용 |
-|------|----------|
-| `scripts/audit-abilities.ts` | 신규 — 감사 스크립트 |
-| `src/lib/simulator/systems/ability.ts` | 수정 — 패턴/효과 교정, 미등록 추가 |
-| `src/lib/simulator/engine/combatLoop.ts` | 수정 — 쉴드/힐/디버프 적용 로직 보강 (필요 시) |
+### stunTargets 수정
 
----
-
-## 5. 성공 기준
-
-| 항목 | 목표 |
-|------|------|
-| 등록률 | 플레이어블 챔피언 100% 등록 (특수 유닛 제외) |
-| 패턴 정확도 | description과 pattern 불일치 0건 |
-| 효과 커버리지 | 스턴/힐/쉴드/대시 description 대비 90% 이상 구현 |
-| 빌드 통과 | `pnpm lint && pnpm typecheck && pnpm build` 전부 통과 |
+| 챔피언 | 현재 | 올바른 값 |
+|--------|------|----------|
+| 블리츠크랭크 | 전원(3칸) | stunTargets: 1 (띄움 1명만) |
 
 ---
 
-## 6. 작업 순서
+## 5. 수정 파일
 
-1. 감사 스크립트 작성 및 실행
-2. 불일치 리포트 분석 및 우선순위 분류
-3. Critical/Major 불일치 일괄 수정
-4. 미등록 챔피언 추가 (단순 패턴)
-5. 빌드 검증
-6. 복잡 메카닉 챔피언은 별도 Plan으로 분리
+| # | 파일 | 변경 |
+|---|------|------|
+| 1 | `src/lib/simulator/systems/ability.ts` | AbilityConfig 확장 + 챔피언별 설정 수정 |
+| 2 | `src/lib/simulator/engine/combatLoop.ts` | hitCount 곱연산 + DOT 시스템 + 특수 챔피언 |
+| 3 | `src/types/index.ts` | StatusEffectType 확장 (필요 시) |
+
+---
+
+## 6. 구현 순서
+
+| Phase | 내용 | 영향 챔피언 수 | 난이도 |
+|-------|------|-------------|--------|
+| 1 | hitCount 다수 피해 | 4~5명 | 낮 |
+| 2 | DOT 지속 피해 시스템 | 7명 | 중 |
+| 3 | damageVar/stunTargets 교정 | 3~5명 | 낮 |
+| 4 | 특수 챔피언 (초가스/블리츠/다이애나) | 3~4명 | 높 |
+| 5 | ⚠️ 중간 우선순위 22명 | 22명 | 중~높 |
+
+---
+
+*Updated: 2026-04-16*
+*Feature: champion-ability-audit*
+*Phase: Plan*

--- a/docs/01-plan/features/role-passive.plan.md
+++ b/docs/01-plan/features/role-passive.plan.md
@@ -1,120 +1,157 @@
-# Plan: 역할군 패시브 능력 구현
+# Plan: 역할군 패시브 능력 구현 (Set 17 업데이트)
 
 ## Executive Summary
 
-| 항목 | 내용 |
-|------|------|
-| Feature | 역할군 패시브 능력 구현 |
-| 작성일 | 2026-03-23 |
-| 상태 | Plan |
-
 | 관점 | 내용 |
 |------|------|
-| **Problem** | 역할군별 고유 패시브(암살자 후열 점프, 전사/암살자 비타겟 피해 감소 등)가 미구현. 타겟팅 가중치만 구현되어 실제 게임과 전투 양상이 다름 |
-| **Solution** | 각 역할군의 패시브 능력을 전투 엔진에 추가. 암살자 점프, 전사/암살자 피해 감소, 마법사 CC 마나 중단 등 |
-| **Function UX Effect** | 암살자가 전투 시작 시 적 후열로 이동하고, 전사/암살자가 비타겟에게 받는 피해가 감소하여 실제 게임과 동일한 전투 흐름 재현 |
-| **Core Value** | 역할군 특성이 전투에 반영되어 시뮬레이션 정확도가 대폭 향상. 조합별 시너지 분석의 신뢰도 증가 |
+| **Problem** | Set 17에서 AD/AP 역할 분화(12종) 도입 + 전사 공격속도 패시브(5~30%), 암살자 후열 점프가 미구현. lolchess.gg 역할군 설명과 시뮬레이션 결과가 불일치 |
+| **Solution** | 전사 스테이지별 AS 패시브 추가, 암살자 후열 점프 구현, AD/AP 역할 구분을 UI에 표시, 역할군 설명 데이터 정비 |
+| **Function UX Effect** | 전사가 실제 게임처럼 AS 보너스를 받고, 암살자가 후열로 점프하며, 역할군 설명이 정확히 일치 |
+| **Core Value** | lolchess.gg 공식 역할군 스펙과 시뮬레이션 완전 일치 → 전투 결과 신뢰도 확보 |
 
 ---
 
-## 1. 현재 구현 상태
+## 1. lolchess.gg 역할군 공식 스펙 (Set 17)
 
-### 1.1 구현 완료
+### 1.1 역할군별 마나 + 패시브
 
-| 역할군 | 항목 | 상태 |
-|--------|------|:----:|
-| **모든 역할군** | 타겟팅 가중치 Tank(3) > Fighter/Assassin(2) > Marksman/Caster/Specialist(1) | OK |
-| **Tank** | 피격 시 마나 획득 (HP 비율 비례, 최대 42.5) | OK |
-| **Fighter** | 12% 옴니뱀프 | OK |
-| **Caster** | 초당 마나 2 재생 | OK |
-| **Caster** | CC(스턴) 시 공격·마나 획득 중단 | OK |
+| 역할군 | 공격당 마나 | 초당 마나 | 피격 시 마나 | 패시브 |
+|--------|-----------|---------|------------|--------|
+| **탱커** (Tank) | 5 | 0 | ✅ | 대상 지정 확률 증가 |
+| **전사** (Fighter) | 10 | 0 | ❌ | AS 5~30% (스테이지 비례), 비타겟 피해 15% 감소 |
+| **원거리 딜러** (Carry) | 10 | 0 | ❌ | (없음) |
+| **마법사** (Caster) | 7 | 2 | ❌ | CC 시 마나 획득 중단 |
+| **암살자** (Reaper) | 10 | 0 | ❌ | 후열 점프, 비타겟 피해 15% 감소 |
+| **전문가** (Specialist) | 특수 | 특수 | 특수 | 고유 자원 생성 방식 |
+| **혼합 전사** (HFighter) | 10 | 0 | ❌ | 전사와 동일 |
 
-### 1.2 미구현
+### 1.2 AD/AP 분화
 
-| # | 역할군 | 패시브 | 설명 | 난이도 |
-|---|--------|--------|------|:------:|
-| 1 | **Assassin** | 후열 점프 | 전투 시작 시 적 후열(가장 먼 적 근처)로 순간이동 | 중 |
-| 2 | **Assassin** | 비타겟 피해 감소 15% | 현재 공격 대상이 아닌 적에게 받는 피해 15% 감소 | 중 |
-| 3 | **Fighter** | 비타겟 피해 감소 15% | 현재 공격 대상이 아닌 적에게 받는 피해 15% 감소 | 중 |
+Set 17에서는 각 역할이 AD/AP로 분화됨 (예: ADFighter, APFighter). **마나 수치와 패시브는 동일** — 차이는 스킬 피해 타입(물리/마법)과 추천 아이템뿐.
 
----
-
-## 2. 상세 규칙
-
-### 2.1 암살자 후열 점프
-
-**시점**: 전투 시작 직후 (tick 0)
-**동작**:
-- 아군 암살자 유닛이 적 후열의 빈 칸으로 순간이동
-- "후열"의 정의: 적 팀에서 가장 뒤(높은 row)에 있는 유닛 근처
-- 점프 목표: 적 팀의 가장 먼 유닛(Marksman/Caster 우선) 인접 빈 칸
-- 빈 칸이 없으면 이동하지 않음
-- 전투 로그에 `[역할군] {챔피언}이(가) 적 후열로 점프!` 기록
-
-### 2.2 비타겟 피해 감소 (Fighter, Assassin 공통)
-
-**대상**: Fighter, Assassin 역할군 유닛
-**조건**: 피해를 입힌 적이 이 유닛의 현재 `target`이 아닌 경우
-**효과**: 받는 피해 15% 감소
-**적용 위치**: 데미지 계산부에서 `target.damageReduction` 대신 별도 로직으로 처리
-- 일반 공격 피해 계산부 (combatLoop.ts)
-- 어빌리티 피해 계산부 (combatLoop.ts)
-
+데이터 내 GameRole 종류 (12개):
 ```
-if (target.role === 'Fighter' || target.role === 'Assassin') {
-  if (target.target !== unit.id) {
-    finalDamage *= 0.85; // 비타겟 15% 감소
+APTank(18), APCaster(13), ADFighter(10), ADTank(8), ADCarry(5),
+APFighter(4), ADCaster(4), APCarry(3), APReaper(2), ADSpecialist(2),
+ADReaper(2), HFighter(1)
+```
+
+---
+
+## 2. 현재 구현 상태
+
+### 2.1 구현 완료 ✅
+
+| 항목 | 위치 | 상태 |
+|------|------|------|
+| 마나 수치 (Tank 5, Fighter/Marksman/Assassin 10, Caster 7) | `mana.ts:22-28` | ✅ |
+| 마나 재생 (Caster 초당 2) | `mana.ts:51-60` | ✅ |
+| 탱커 피격 시 마나 획득 | `mana.ts:66-72` | ✅ |
+| Caster CC 시 마나 중단 | `mana.ts:40-41` | ✅ |
+| 타게팅 가중치 Tank(3) > Fighter/Assassin(2) > 나머지(1) | `unit.ts:18-26` | ✅ |
+| Fighter 옴니뱀프 12% | `unit.ts:9-16` | ✅ |
+| Fighter/Assassin 비타겟 피해 감소 15% | `combatLoop.ts:458-459` | ✅ |
+| GameRole → UnitRole 매핑 (AD/AP 구분 없이) | `types/index.ts:39-48` | ✅ |
+
+### 2.2 미구현 ❌
+
+| # | 항목 | 영향도 | 난이도 |
+|---|------|--------|--------|
+| 1 | **전사 AS 패시브 (5~30%, 스테이지 비례)** | 높음 — 전사 DPS 직결 | 낮음 |
+| 2 | **암살자 후열 점프 제거** | 높음 — Set 17에 없는 기능이 잘못 구현됨 | 낮음 |
+| 3 | **역할군 설명 UI** (역할군별 패시브 툴팁) | 낮음 — 표시용 | 낮음 |
+
+---
+
+## 3. 구현 범위
+
+### 3.1 전사 AS 패시브 (스테이지별 보너스)
+
+**규칙**: 전사(Fighter, HFighter) 역할군은 전투 시작 시 스테이지에 비례한 AS 보너스를 획득.
+
+| 스테이지 | AS 보너스 |
+|---------|----------|
+| 1 | 5% |
+| 2 | 10% |
+| 3 | 15% |
+| 4 | 20% |
+| 5 | 25% |
+| 6+ | 30% |
+
+**구현 위치**: `combatLoop.ts` — CombatUnit 생성 후, 시너지 버프 적용 전에 Fighter AS 보너스 적용.
+
+**스테이지 입력**: SimulateOptions에 `stageNumber?: number` 추가 (기본값 4). UI에서 스테이지 선택 드롭다운 추가.
+
+```typescript
+function applyFighterASBonus(units: CombatUnit[], stageNumber: number): void {
+  const asBonus = Math.min(0.30, 0.05 * stageNumber);
+  for (const unit of units) {
+    if (unit.role === 'Fighter') {
+      unit.stats.attackSpeed *= (1 + asBonus);
+    }
   }
 }
 ```
 
----
+### 3.2 암살자 후열 점프 제거
 
-## 3. 수정 파일
+**현황**: `applyAssassinJump` 함수가 combatLoop에 구현되어 있으나, Set 17 lolchess.gg 역할군 가이드에는 후열 점프 패시브가 없음. 이전 세트의 잔재이므로 제거.
 
-| 파일 | 변경 내용 |
-|------|----------|
-| `src/lib/simulator/engine/combatLoop.ts` | 전투 시작 시 암살자 점프 로직, 비타겟 피해 감소 로직 |
-| `src/lib/simulator/systems/movement.ts` | 점프 목표 칸 탐색 헬퍼 (필요 시) |
+- `applyAssassinJump` 함수 삭제
+- 호출부 2곳 삭제
+- 암살자는 배치 위치에서 전투 시작, 이동으로 접근
 
-### 변경하지 않는 것
+### 3.3 스테이지 입력 UI
 
-- `targeting.ts`: 타겟팅 가중치는 이미 수정 완료
-- `mana.ts`: 마나 규칙 이미 정상
-- `unit.ts`: 추가 필드 불필요 (기존 `target`, `role` 활용)
-
----
-
-## 4. 구현 순서
-
-| Step | 내용 |
-|------|------|
-| 1 | 암살자 후열 점프 — 전투 시작 직후 (메인 루프 진입 전) 암살자 유닛을 적 후열 빈 칸으로 이동 + 로그 |
-| 2 | 비타겟 피해 감소 — 일반 공격 데미지 계산부에 Fighter/Assassin 비타겟 15% 감소 추가 |
-| 3 | 비타겟 피해 감소 — 어빌리티 데미지 계산부에도 동일 적용 |
-| 4 | 빌드 검증 |
+SimulatorContent의 BattleControls 영역에 스테이지 선택 드롭다운 추가:
+- 기본값: Stage 4
+- 범위: 1~7
+- 전사 AS 보너스 미리보기 표시
 
 ---
 
-## 5. MVP 범위
+## 4. 수정 파일 목록
 
-### 포함
-
-- 암살자 후열 점프 (가장 먼 적 근처 빈 칸으로 이동)
-- Fighter/Assassin 비타겟 피해 감소 15%
-
-### 제외 (후순위)
-
-- Marksman 크리티컬 확률 보너스 (데이터 확인 필요)
-- Specialist 고유 패시브 (챔피언마다 다름)
-- 암살자 점프 애니메이션 (현재 순간이동으로 처리)
+| # | 파일 | 변경 |
+|---|------|------|
+| 1 | `src/lib/simulator/engine/combatLoop.ts` | `applyFighterASBonus`, `applyAssassinJump`, SimulateOptions.stageNumber |
+| 2 | `src/lib/simulator/models/unit.ts` | 전사 AS 보너스 상수 테이블 |
+| 3 | `src/app/simulator/page.tsx` | stageNumber 상태 + simulateCombat에 전달 |
+| 4 | `src/components/battle/BattleControls.tsx` | 스테이지 선택 드롭다운 |
 
 ---
 
-## 6. 수용 기준
+## 5. 구현 순서
 
-1. 암살자가 전투 시작 시 적 후열 빈 칸으로 이동하고, 전투 로그에 점프 이벤트 기록
-2. Fighter/Assassin이 비타겟에게 받는 피해가 15% 감소
-3. 기존 타겟팅·마나·옴니뱀프 동작에 영향 없음
-4. `pnpm lint && pnpm typecheck && pnpm build` 통과
-5. 결정론적 — 동일 시드에서 동일 결과
+### Phase 1: 전사 AS 패시브
+1. SimulateOptions에 `stageNumber` 추가
+2. `applyFighterASBonus` 함수 구현 (CombatUnit 생성 후 호출)
+3. page.tsx에서 stageNumber 상태 관리 + simulateCombat 전달
+
+### Phase 2: 암살자 후열 점프
+4. `applyAssassinJump` 함수 구현 (전투 시작 직후, tick 루프 전)
+5. 점프 로그 기록
+
+### Phase 3: UI
+6. BattleControls에 스테이지 선택 드롭다운
+7. 역할군 툴팁에 패시브 설명 표시 (후순위)
+
+---
+
+## 6. 검증 기준
+
+| 시나리오 | 예상 결과 |
+|---------|----------|
+| Stage 4 전사 시뮬레이션 | AS +20% 적용 |
+| Stage 1 전사 시뮬레이션 | AS +5% 적용 |
+| 암살자 전투 시작 | 적 후열 근처로 점프, 로그에 기록 |
+| 암살자 빈 칸 없음 | 점프 안 함, 제자리 |
+| 마법사 CC 중 | 마나 획득/재생 없음 (기존 동작 유지) |
+| 탱커 피격 | 피격 시 마나 획득 (기존 동작 유지) |
+| lolchess.gg 설명과 비교 | 모든 수치 일치 |
+
+---
+
+*Updated: 2026-04-16*
+*Feature: role-passive*
+*Phase: Plan*

--- a/docs/02-design/features/role-passive.design.md
+++ b/docs/02-design/features/role-passive.design.md
@@ -1,158 +1,186 @@
-# Design: 역할군 패시브 능력 구현
+# Design: 역할군 패시브 능력 구현 (Set 17 업데이트)
 
-## Executive Summary
+## 1. 현재 구현 현황
 
-| 항목 | 내용 |
-|------|------|
-| Feature | 역할군 패시브 능력 구현 |
-| Plan 참조 | `docs/01-plan/features/role-passive.plan.md` |
-| 작성일 | 2026-03-23 |
-| 상태 | Design |
+| 항목 | 상태 | 위치 |
+|------|:----:|------|
+| Fighter/Assassin 비타겟 피해 감소 15% | ✅ | `combatLoop.ts:458-459, 1617-1619, 1797-1799` |
+| 마나 수치 6종 | ✅ | `mana.ts:22-28` |
+| Caster 초당 마나 2 재생 | ✅ | `mana.ts:51-60` |
+| Tank 피격 시 마나 / 타게팅 가중치 / Fighter 옴니뱀프 | ✅ | 각각 구현 완료 |
+| **암살자 후열 점프 — 잘못된 구현** | ⚠️ 제거 필요 | `combatLoop.ts:462-524` |
+| **전사 AS 패시브 (5~30%, 스테이지 비례)** | ❌ | — |
+| **스테이지 번호 입력 UI** | ❌ | — |
 
----
+### 1.1 잘못된 구현: 암살자 후열 점프
 
-## 1. 암살자 후열 점프
-
-### 1.1 시점
-
-`simulateCombat()` 내에서 메인 루프 진입 전, Warden 보호막/프렐요드 포탑 소환 이후.
-
-```typescript
-// combatLoop.ts — 기존 순서:
-// 1. CombatUnit 생성
-// 2. Trait 옴니뱀프/보호막 적용
-// 3. Freljord 포탑 소환
-// 4. ← 여기에 암살자 점프 삽입
-// 5. 메인 전투 루프 시작
-```
-
-### 1.2 점프 목표 결정 알고리즘
-
-```typescript
-function applyAssassinJump(
-  teamUnits: CombatUnit[],
-  enemyUnits: CombatUnit[],
-  allUnits: CombatUnit[],
-  logs: CombatLog[],
-): void
-```
-
-**각 암살자 유닛에 대해:**
-
-1. 적 팀에서 가장 먼 유닛(현재 암살자 위치 기준 `hexDistance` 최대) 찾기
-   - 동거리 시 Marksman/Caster 우선 (딜러/마법사를 노리는 것이 암살자의 본질)
-2. 해당 유닛의 인접 빈 칸(`getNeighbors()`) 중 하나 선택
-   - 빈 칸 판별: `allUnits`의 현재 위치를 `occupiedPositions` Set으로 관리
-   - 여러 빈 칸 중 적 딜러에 가장 가까운 칸 선택
-3. 빈 칸이 없으면 점프하지 않음 (로그도 남기지 않음)
-4. 점프 시 위치 업데이트: `unit.position = targetHex`
-5. 전투 로그: `[역할군] {챔피언}이(가) 적 후열로 점프!`
-
-### 1.3 호출 위치
-
-```typescript
-// combatLoop.ts — applyWardenShields 이후, 메인 루프 전
-applyWardenShields(playerActiveTraits, playerUnits);
-applyWardenShields(enemyActiveTraits, enemies);
-
-const allUnits = [...playerUnits, ...enemies];
-
-// Freljord 포탑 소환
-// ...
-
-// 암살자 후열 점프 (포탑 소환 후, 점유 위치가 확정된 시점)
-applyAssassinJump(playerUnits, enemies, allUnits, logs);
-applyAssassinJump(enemies, playerUnits, allUnits, logs);
-```
+`applyAssassinJump` (combatLoop.ts:462-524)는 Set 17 역할군 패시브에 존재하지 않는 기능.
+lolchess.gg 기준 암살자 패시브는 **비타겟 피해 감소 15%만** 해당.
+후열 점프는 이전 세트의 잔재이므로 **제거해야 함**.
 
 ---
 
-## 2. 비타겟 피해 감소 (Fighter/Assassin 15%)
+## 2. 전사 AS 패시브 구현
 
-### 2.1 로직
-
-피해를 받는 유닛이 Fighter 또는 Assassin이고, 피해를 입히는 적이 자신의 현재 `target`이 아닌 경우 → 받는 피해 15% 감소.
+### 2.1 상수 테이블 (`src/lib/simulator/models/unit.ts`)
 
 ```typescript
-const NON_TARGET_DAMAGE_REDUCTION = 0.15;
+/** 전사 스테이지별 AS 보너스 (lolchess.gg: 5~30%) */
+export const FIGHTER_AS_BY_STAGE: number[] = [
+  0,     // stage 0 (미사용)
+  0.05,  // stage 1: +5%
+  0.10,  // stage 2: +10%
+  0.15,  // stage 3: +15%
+  0.20,  // stage 4: +20%
+  0.25,  // stage 5: +25%
+  0.30,  // stage 6: +30%
+  0.30,  // stage 7: +30% (상한)
+];
 
-// damageReduction 적용 직후에 추가
-if ((target.role === 'Fighter' || target.role === 'Assassin') && target.target !== unit.id) {
-  finalDamage *= (1 - NON_TARGET_DAMAGE_REDUCTION);
+export function getFighterASBonus(stageNumber: number): number {
+  const clamped = Math.max(1, Math.min(stageNumber, 7));
+  return FIGHTER_AS_BY_STAGE[clamped];
 }
 ```
 
-### 2.2 적용 위치 (2곳)
-
-**일반 공격 데미지** — `combatLoop.ts` line ~842 (damageReduction 이후)
+### 2.2 SimulateOptions 확장 (`combatLoop.ts`)
 
 ```typescript
-// Apply target's damage reduction from augments
-if (target.damageReduction > 0) {
-  finalDamage *= (1 - target.damageReduction);
-}
-
-// Fighter/Assassin 비타겟 피해 감소 15%
-if ((target.role === 'Fighter' || target.role === 'Assassin') && target.target !== unit.id) {
-  finalDamage *= (1 - NON_TARGET_DAMAGE_REDUCTION);
+export interface SimulateOptions {
+  // 기존...
+  /** 현재 스테이지 번호 (전사 AS 패시브, 기본값 4) */
+  stageNumber?: number;
 }
 ```
 
-**어빌리티 데미지** — `combatLoop.ts` line ~949 (damageReduction 이후)
+### 2.3 전투 시작 시 적용 함수 (`combatLoop.ts`)
 
 ```typescript
-if (t.damageReduction > 0) {
-  effectiveDmg *= (1 - t.damageReduction);
-}
+import { getFighterASBonus } from '@/lib/simulator/models/unit';
 
-// Fighter/Assassin 비타겟 피해 감소 15%
-if ((t.role === 'Fighter' || t.role === 'Assassin') && t.target !== unit.id) {
-  effectiveDmg *= (1 - NON_TARGET_DAMAGE_REDUCTION);
+function applyFighterASBonus(units: CombatUnit[], stageNumber: number): void {
+  const bonus = getFighterASBonus(stageNumber);
+  if (bonus <= 0) return;
+  for (const unit of units) {
+    if (unit.role === 'Fighter') {
+      unit.stats.attackSpeed *= (1 + bonus);
+    }
+  }
 }
 ```
 
-### 2.3 주의사항
+### 2.4 호출 위치
 
-- `target.target`은 피해를 받는 유닛의 현재 공격 대상 ID
-- `unit.id`는 피해를 입히는 유닛의 ID
-- `target.target !== unit.id` → "나를 타겟하지 않은 적에게 받는 피해" 감소
-- 전투 시작 전(target이 null인 경우)에는 모든 피해에 감소 적용 (null !== unit.id = true)
-  → 이건 의도적. 전투 초반 암살자가 점프한 직후 아직 타겟을 잡지 않은 상태에서 보호
+시너지 버프 적용 직후, 칸 버프 전 (현재 ~1431줄):
 
----
+```
+applySet17SynergyBuffs(playerActiveTraits, playerUnits);
+applySet17SynergyBuffs(enemyActiveTraits, enemies);
 
-## 3. 수정 파일
+const stageNumber = options.stageNumber ?? 4;          ← 추가
+applyFighterASBonus(playerUnits, stageNumber);          ← 추가
+applyFighterASBonus(enemies, stageNumber);              ← 추가
 
-| 파일 | 변경 내용 |
-|------|----------|
-| `src/lib/simulator/engine/combatLoop.ts` | `applyAssassinJump()` 함수 추가, 비타겟 피해 감소 로직 2곳 추가, 상수 `NON_TARGET_DAMAGE_REDUCTION` 추가 |
-
-### 변경하지 않는 것
-
-- `targeting.ts`: 가중치는 이미 수정 완료
-- `movement.ts`: `getNeighbors()`, `coordKey()` 이미 존재, 추가 불필요
-- `unit.ts`: 추가 필드 불필요
-- `mana.ts`: 이미 정상
+if (options.playerHexBuffs?.length) applyHexBuffs(...);
+```
 
 ---
 
-## 4. 구현 순서
+## 3. 스테이지 번호 입력 UI
 
-| Step | 내용 |
-|------|------|
-| 1 | `NON_TARGET_DAMAGE_REDUCTION` 상수 추가 |
-| 2 | `applyAssassinJump()` 함수 구현 |
-| 3 | `simulateCombat()` 내 암살자 점프 호출 추가 |
-| 4 | 일반 공격 데미지 계산부에 비타겟 피해 감소 추가 |
-| 5 | 어빌리티 데미지 계산부에 비타겟 피해 감소 추가 |
-| 6 | `pnpm lint && pnpm typecheck && pnpm build` 통과 확인 |
+### 3.1 page.tsx 상태
+
+```typescript
+const [stageNumber, setStageNumber] = useState(4);
+```
+
+### 3.2 simulateCombat에 전달
+
+두 곳 (runSimulation, runMultiple) 모두:
+```typescript
+simulateCombat(mappedPlayer, tm.enemyTeam, {
+  // 기존...
+  stageNumber,
+});
+```
+
+useCallback 의존성 배열에 `stageNumber` 추가.
+
+### 3.3 드롭다운 UI 위치
+
+시뮬레이션 버튼 영역(팀 설정 패널)에 배치:
+
+```tsx
+<div className="flex items-center gap-2">
+  <label className="text-xs text-gray-400">스테이지</label>
+  <select
+    value={stageNumber}
+    onChange={e => setStageNumber(Number(e.target.value))}
+    className="bg-[#1f2937] text-gray-200 text-sm rounded px-2 py-1 border border-gray-600"
+  >
+    {[1,2,3,4,5,6,7].map(s => (
+      <option key={s} value={s}>
+        Stage {s} (전사 AS +{s <= 6 ? s * 5 : 30}%)
+      </option>
+    ))}
+  </select>
+</div>
+```
 
 ---
 
-## 5. 수용 기준
+## 4. 암살자 후열 점프 제거
 
-1. 암살자가 전투 시작 시 적 후열 빈 칸으로 이동, 로그에 `[역할군]` 점프 이벤트 기록
-2. Fighter/Assassin이 비타겟에게 받는 피해 15% 감소 (일반 공격 + 어빌리티 모두)
-3. 기존 타겟팅·마나·옴니뱀프 동작에 영향 없음
-4. 결정론적 — 동일 시드에서 동일 결과
-5. 빌드 통과
+### 4.1 제거 대상
+
+- `applyAssassinJump` 함수 (combatLoop.ts:462-524)
+- 호출부 2곳 (combatLoop.ts:1501-1502)
+
+### 4.2 주의사항
+
+- 함수 제거 후 `getTargetingWeight` import가 이 함수에서만 사용되는지 확인
+- 제거 후 암살자는 일반 유닛과 동일하게 배치 위치에서 전투 시작 (이동으로 접근)
+
+---
+
+## 5. 수정 파일 목록
+
+| # | 파일 | 변경 |
+|---|------|------|
+| 1 | `src/lib/simulator/models/unit.ts` | `FIGHTER_AS_BY_STAGE` 배열, `getFighterASBonus` 함수 추가 |
+| 2 | `src/lib/simulator/engine/combatLoop.ts` | `applyAssassinJump` 제거, `SimulateOptions.stageNumber`, `applyFighterASBonus` 추가 |
+| 3 | `src/app/simulator/page.tsx` | `stageNumber` 상태, simulateCombat 전달, 드롭다운 UI |
+
+---
+
+## 6. 구현 순서
+
+### Phase 1: 잘못된 구현 제거
+1. `combatLoop.ts` — `applyAssassinJump` 함수 + 호출부 제거
+
+### Phase 2: 전사 AS 패시브 (엔진)
+2. `unit.ts` — `FIGHTER_AS_BY_STAGE` + `getFighterASBonus`
+3. `combatLoop.ts` — `SimulateOptions.stageNumber` + `applyFighterASBonus` + 호출
+
+### Phase 3: UI
+4. `page.tsx` — `stageNumber` 상태 + simulateCombat 전달 + 드롭다운
+
+---
+
+## 7. 테스트 체크리스트
+
+- [ ] 암살자 전투 시작 → 후열 점프 없음 (배치 위치에서 시작)
+- [ ] Stage 1 전사 → AS × 1.05
+- [ ] Stage 4 전사 (기본값) → AS × 1.20
+- [ ] Stage 7 전사 → AS × 1.30 (상한)
+- [ ] 비전사 유닛 → AS 보너스 없음
+- [ ] stageNumber 미입력 → 기본값 4 적용
+- [ ] 100전 시뮬 → stageNumber 일관 적용
+- [ ] 비타겟 피해 감소 → 기존 동작 유지
+
+---
+
+*Updated: 2026-04-16*
+*Feature: role-passive*
+*Phase: Design*
+*References: role-passive.plan.md*

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,9 @@ import '@/styles/globals.css';
 export const metadata: Metadata = {
   title: 'TFT 시뮬레이터',
   description: 'TFT 데미지 계산기, 전투 시뮬레이션',
+  verification: {
+    google: 'NPET5rApTEI6h8DEKsJSMMYm4CDmUMV-LrINNcEqmxs',
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -77,6 +77,7 @@ function SimulatorContent() {
   const [showTeamCode, setShowTeamCode] = useState(false);
   const [logFilter, setLogFilter] = useState<CombatLog['type'] | 'all'>('all');
   const [isRunning, setIsRunning] = useState(false);
+  const [stageNumber, setStageNumber] = useState(4);
 
   // Filtered champions for pool
   const filteredChampions = useMemo(() => {
@@ -137,6 +138,7 @@ function SimulatorContent() {
         enemyGalio: tm.enemyGalio,
         playerHexBuffs,
         enemyHexBuffs,
+        stageNumber,
       });
       replay.setCombatResult(result);
       setIsRunning(false);
@@ -144,7 +146,7 @@ function SimulatorContent() {
       replay.setReplayTick(0);
       replay.setIsPlaying(true);
     }, 100);
-  }, [tm.playerTeam, tm.enemyTeam, traits, tm.playerAugments, tm.playerAugmentStacks, tm.enemyAugments, tm.enemyAugmentStacks, tm.playerBilgewaterStats, tm.enemyBilgewaterStats, tm.playerPiltoverModules, tm.enemyPiltoverModules, tm.playerIoniaPath, tm.enemyIoniaPath, tm.playerGalio, tm.enemyGalio, playerHexBuffs, enemyHexBuffs, items, toEightRowCoords, replay]);
+  }, [tm.playerTeam, tm.enemyTeam, traits, tm.playerAugments, tm.playerAugmentStacks, tm.enemyAugments, tm.enemyAugmentStacks, tm.playerBilgewaterStats, tm.enemyBilgewaterStats, tm.playerPiltoverModules, tm.enemyPiltoverModules, tm.playerIoniaPath, tm.enemyIoniaPath, tm.playerGalio, tm.enemyGalio, playerHexBuffs, enemyHexBuffs, stageNumber, items, toEightRowCoords, replay]);
 
   const runMultiple = useCallback(() => {
     if (tm.playerTeam.length === 0 || tm.enemyTeam.length === 0) return;
@@ -171,6 +173,7 @@ function SimulatorContent() {
           enemyGalio: tm.enemyGalio,
           playerHexBuffs,
           enemyHexBuffs,
+          stageNumber,
         });
         if (r.winner === 'player') playerWins++;
         else if (r.winner === 'enemy') enemyWins++;
@@ -185,7 +188,7 @@ function SimulatorContent() {
       replay.setViewMode('replay');
       replay.setReplayTick(lastResult ? lastResult.snapshots.length - 1 : 0);
     }, 100);
-  }, [tm.playerTeam, tm.enemyTeam, traits, tm.playerAugments, tm.playerAugmentStacks, tm.enemyAugments, tm.enemyAugmentStacks, tm.playerBilgewaterStats, tm.enemyBilgewaterStats, tm.playerPiltoverModules, tm.enemyPiltoverModules, tm.playerIoniaPath, tm.enemyIoniaPath, tm.playerGalio, tm.enemyGalio, playerHexBuffs, enemyHexBuffs, items, toEightRowCoords, replay]);
+  }, [tm.playerTeam, tm.enemyTeam, traits, tm.playerAugments, tm.playerAugmentStacks, tm.enemyAugments, tm.enemyAugmentStacks, tm.playerBilgewaterStats, tm.enemyBilgewaterStats, tm.playerPiltoverModules, tm.enemyPiltoverModules, tm.playerIoniaPath, tm.enemyIoniaPath, tm.playerGalio, tm.enemyGalio, playerHexBuffs, enemyHexBuffs, stageNumber, items, toEightRowCoords, replay]);
 
   const filteredLogs = useMemo(() => {
     if (!replay.combatResult) return [];
@@ -242,6 +245,17 @@ function SimulatorContent() {
             >
               팀 코드
             </button>
+            <select
+              value={stageNumber}
+              onChange={e => setStageNumber(Number(e.target.value))}
+              className="bg-[#1f2937] text-gray-300 text-[10px] lg:text-xs rounded-lg px-2 py-1.5 lg:px-2 lg:py-2 border border-gray-600"
+            >
+              {[1,2,3,4,5,6,7].map(s => (
+                <option key={s} value={s}>
+                  Stage {s}
+                </option>
+              ))}
+            </select>
             <button
               onClick={runSimulation}
               disabled={isRunning || tm.playerTeam.length === 0 || tm.enemyTeam.length === 0}
@@ -387,7 +401,7 @@ function SimulatorContent() {
 
               {/* Left: Both Synergy panels + Selected unit (desktop) */}
               <div className="order-3 lg:order-1 lg:w-52 lg:shrink-0 space-y-3">
-                <SynergyPanel activeTraits={tm.enemyTraits} team="enemy" items={items} piltoverModules={tm.enemyPiltoverModules} bilgewaterStats={tm.enemyBilgewaterStats} ioniaPath={tm.enemyIoniaPath} onIoniaPathChange={tm.setEnemyIoniaPath} />
+                <SynergyPanel activeTraits={tm.enemyTraits} team="enemy" items={items} champions={champions} piltoverModules={tm.enemyPiltoverModules} bilgewaterStats={tm.enemyBilgewaterStats} ioniaPath={tm.enemyIoniaPath} onIoniaPathChange={tm.setEnemyIoniaPath} />
                 <PiltoverModulePanel
                   modules={tm.enemyPiltoverModules}
                   allItems={items}
@@ -395,7 +409,7 @@ function SimulatorContent() {
                   onAddModule={(item) => tm.handleAddPiltoverModule('enemy', item)}
                   onRemoveModule={(idx) => tm.handleRemovePiltoverModule('enemy', idx)}
                 />
-                <SynergyPanel activeTraits={tm.playerTraits} team="player" items={items} piltoverModules={tm.playerPiltoverModules} bilgewaterStats={tm.playerBilgewaterStats} ioniaPath={tm.playerIoniaPath} onIoniaPathChange={tm.setPlayerIoniaPath} />
+                <SynergyPanel activeTraits={tm.playerTraits} team="player" items={items} champions={champions} piltoverModules={tm.playerPiltoverModules} bilgewaterStats={tm.playerBilgewaterStats} ioniaPath={tm.playerIoniaPath} onIoniaPathChange={tm.setPlayerIoniaPath} />
                 <PiltoverModulePanel
                   modules={tm.playerPiltoverModules}
                   allItems={items}

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -368,8 +368,8 @@ function SimulatorContent() {
                           <div className="bg-[#1a1f2e] border border-gray-600 rounded-lg px-3 py-2 shadow-xl max-w-[240px]">
                             <div className="font-bold text-yellow-400 text-xs mb-1">
                               {hoverUnit.placed.champion.name}
-                              <span className="text-gray-500 ml-1 font-normal">
-                                {hoverUnit.placed.champion.ability.name}
+                              <span className="text-gray-500 ml-1 font-normal text-[10px]">
+                                {hoverUnit.placed.champion.traits.join(' · ')}
                               </span>
                             </div>
                             <div className="text-[10px] text-gray-300 leading-relaxed whitespace-pre-line">

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -14,6 +14,8 @@ import { getItemCategory, isDisabledItem } from '@/lib/simulator/systems/item';
 import { isBilgewaterStatItem } from '@/data/traitModules';
 import { resolveBilgewaterStatEffects } from '@/lib/simulator/systems/stat';
 import { resolveHexBuffs } from '@/data/augmentHexBuffs';
+import { resolveDescription } from '@/lib/utils/text';
+import { hexCenter, HEX_R } from '@/components/battle/HexBoard';
 import ChampionGrid from '@/components/builder/ChampionGrid';
 import SetupBoard from '@/components/battle/SetupBoard';
 import DroppableHexCell from '@/components/battle/DroppableHexCell';
@@ -78,6 +80,7 @@ function SimulatorContent() {
   const [logFilter, setLogFilter] = useState<CombatLog['type'] | 'all'>('all');
   const [isRunning, setIsRunning] = useState(false);
   const [stageNumber, setStageNumber] = useState(4);
+  const [hoverUnit, setHoverUnit] = useState<{ placed: PlacedChampion; row: number; col: number } | null>(null);
 
   // Filtered champions for pool
   const filteredChampions = useMemo(() => {
@@ -347,9 +350,38 @@ function SimulatorContent() {
                               placedUnit={placed ? { team, position: placed.position } : null}
                               onClick={cellClick}
                               onContextMenu={cellContextMenu}
+                              onMouseEnter={placed ? () => setHoverUnit({ placed, row, col }) : undefined}
+                              onMouseLeave={() => setHoverUnit(null)}
                             />
                           );
                         })
+                      )}
+                      {hoverUnit && (
+                        <div
+                          className="absolute pointer-events-none z-50"
+                          style={{
+                            left: hexCenter(hoverUnit.row, hoverUnit.col).cx,
+                            top: hexCenter(hoverUnit.row, hoverUnit.col).cy - HEX_R - 8,
+                            transform: 'translate(-50%, -100%)',
+                          }}
+                        >
+                          <div className="bg-[#1a1f2e] border border-gray-600 rounded-lg px-3 py-2 shadow-xl max-w-[240px]">
+                            <div className="font-bold text-yellow-400 text-xs mb-1">
+                              {hoverUnit.placed.champion.name}
+                              <span className="text-gray-500 ml-1 font-normal">
+                                {hoverUnit.placed.champion.ability.name}
+                              </span>
+                            </div>
+                            <div className="text-[10px] text-gray-300 leading-relaxed whitespace-pre-line">
+                              {resolveDescription(
+                                hoverUnit.placed.champion.ability.desc,
+                                Object.fromEntries(
+                                  (hoverUnit.placed.champion.ability.variables ?? []).map(v => [v.name, v.value?.[hoverUnit.placed.starLevel] ?? 0])
+                                )
+                              )}
+                            </div>
+                          </div>
+                        </div>
                       )}
                       </div>
                     </div>

--- a/src/components/battle/DroppableHexCell.tsx
+++ b/src/components/battle/DroppableHexCell.tsx
@@ -13,9 +13,11 @@ interface DroppableHexCellProps {
   onClick?: () => void;
   onDoubleClick?: () => void;
   onContextMenu?: (e: MouseEvent) => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
 }
 
-export default function DroppableHexCell({ id, row, col, placedUnit, onClick, onDoubleClick, onContextMenu }: DroppableHexCellProps) {
+export default function DroppableHexCell({ id, row, col, placedUnit, onClick, onDoubleClick, onContextMenu, onMouseEnter, onMouseLeave }: DroppableHexCellProps) {
   const { isOver, setNodeRef: setDropRef } = useDroppable({ id });
   const dragData: DragData | undefined = placedUnit
     ? { type: 'placed-unit', team: placedUnit.team, position: placedUnit.position }
@@ -39,6 +41,8 @@ export default function DroppableHexCell({ id, row, col, placedUnit, onClick, on
       onClick={onClick}
       onDoubleClick={onDoubleClick}
       onContextMenu={onContextMenu}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       style={{
         position: 'absolute',
         left: cx - size / 2,

--- a/src/components/builder/SynergyPanel.tsx
+++ b/src/components/builder/SynergyPanel.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { ActiveTrait, TRAIT_STYLE_COLORS, RawItem } from '@/types';
-import { getTraitImage } from '@/data/imageMap';
+import { ActiveTrait, TRAIT_STYLE_COLORS, RawItem, RawChampion, COST_COLORS } from '@/types';
+import { getTraitImage, getChampionImage } from '@/data/imageMap';
 import { resolveDescription } from '@/lib/utils/text';
 import Tooltip from '@/components/ui/Tooltip';
 import Image from 'next/image';
@@ -47,15 +47,20 @@ interface SynergyPanelProps {
   activeTraits: ActiveTrait[];
   team: 'player' | 'enemy';
   items: RawItem[];
+  champions?: RawChampion[];
   piltoverModules?: RawItem[];
   bilgewaterStats?: Record<string, number>;
   ioniaPath?: IoniaPathType | null;
   onIoniaPathChange?: (path: IoniaPathType) => void;
 }
 
-function TraitTooltipContent({ at }: { at: ActiveTrait }) {
+function TraitTooltipContent({ at, champions = [] }: { at: ActiveTrait; champions?: RawChampion[] }) {
+  const traitChampions = champions
+    .filter(c => c.traits.includes(at.trait.name))
+    .sort((a, b) => a.cost - b.cost);
+
   return (
-    <div className="max-w-[260px]">
+    <div className="max-w-[280px]">
       <div className="font-bold text-yellow-400 mb-1">{at.trait.name}</div>
       {at.trait.desc && (
         <div className="text-xs text-gray-300 mb-2 leading-relaxed whitespace-pre-line">
@@ -90,6 +95,28 @@ function TraitTooltipContent({ at }: { at: ActiveTrait }) {
           );
         })}
       </div>
+      {traitChampions.length > 0 && (
+        <>
+          <div className="border-t border-gray-600 mt-2 pt-2">
+            <div className="flex flex-wrap gap-1.5">
+              {traitChampions.map(c => (
+                <div key={c.apiName} className="flex items-center gap-1">
+                  <Image
+                    src={getChampionImage(c.apiName)}
+                    alt={c.name}
+                    width={20}
+                    height={20}
+                    className="rounded-full shrink-0"
+                    style={{ border: `1.5px solid ${COST_COLORS[c.cost] ?? '#6b7280'}` }}
+                    unoptimized
+                  />
+                  <span className="text-[10px] text-gray-300">{c.name}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -143,7 +170,7 @@ function PiltoverModulesSummary({ modules }: { modules: RawItem[] }) {
   );
 }
 
-export default function SynergyPanel({ activeTraits, team, items, piltoverModules = [], bilgewaterStats = {}, ioniaPath, onIoniaPathChange }: SynergyPanelProps) {
+export default function SynergyPanel({ activeTraits, team, items, champions = [], piltoverModules = [], bilgewaterStats = {}, ioniaPath, onIoniaPathChange }: SynergyPanelProps) {
   const [collapsed, setCollapsed] = useState(false);
   const teamLabel = team === 'player' ? 'TEAM A' : 'TEAM B';
   const teamColor = team === 'player' ? 'text-blue-400' : 'text-red-400';
@@ -191,7 +218,7 @@ export default function SynergyPanel({ activeTraits, team, items, piltoverModule
 
           return (
             <div key={at.trait.apiName}>
-              <Tooltip content={<TraitTooltipContent at={at} />}>
+              <Tooltip content={<TraitTooltipContent at={at} champions={champions} />}>
                 <div
                   className={`flex items-center gap-2 px-2 py-1 rounded ${isActive ? '' : 'opacity-60'}`}
                   style={isActive ? { backgroundColor: `${color}20` } : { backgroundColor: '#111827' }}

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -1687,7 +1687,9 @@ export function simulateCombat(
             const { damage: rawAbilityDmg, type: dmgType } = getAbilityDamage(
               unit.champion, unit.starLevel, unit.stats.ap, 0, config.damageVar
             );
-            const abilityDmg = config.hitCount ? rawAbilityDmg * config.hitCount : rawAbilityDmg;
+            // hitCount: single은 곱연산, AOE/multi는 총 피해를 타겟 수로 분배 (후술)
+            const hitCountTotal = config.hitCount ? rawAbilityDmg * config.hitCount : rawAbilityDmg;
+            const isSplitDamage = config.hitCount && config.pattern !== 'single';
             const opposingTeam = unit.team === 'player' ? enemies : playerUnits;
 
             // 대쉬 이동 (config.dash가 있으면 대상 인접 칸으로 이동)
@@ -1718,16 +1720,23 @@ export function simulateCombat(
 
             // 다중 타겟 피해 루프
             let totalAbilityDmg = 0;
+            const aliveTargets = abilityTargets.filter(t => t.state !== 'dead');
+            const abilityDmg = isSplitDamage && aliveTargets.length > 0
+              ? hitCountTotal / aliveTargets.length
+              : hitCountTotal;
 
             // DOT 스킬: 즉발 대신 burn statusEffect로 지속 피해 적용
             if (config.dot) {
               const dotTicks = Math.round(config.dot.duration * TICKS_PER_SECOND);
-              const dotDmgPerTick = abilityDmg / config.dot.duration * TICK_DURATION;
-              for (const t of abilityTargets) {
-                if (t.state === 'dead') continue;
+              for (const t of aliveTargets) {
+                // DOT도 방어력/피해감소 적용
+                const resistance = dmgType === 'magic' ? t.stats.magicResist : dmgType === 'physical' ? t.stats.armor : 0;
+                const pen = dmgType === 'magic' ? unit.stats.magicPen : dmgType === 'physical' ? unit.stats.armorPen : 0;
+                const mitigated = dmgType === 'true' ? abilityDmg * (1 + unit.damageAmp) : applyResistance(abilityDmg * (1 + unit.damageAmp), resistance, pen);
+                const perTickDmg = mitigated / config.dot.duration * TICK_DURATION;
                 t.statusEffects.push({
                   type: 'burn', sourceId: unit.id,
-                  remainingTicks: dotTicks, value: dotDmgPerTick * (1 + unit.damageAmp),
+                  remainingTicks: dotTicks, value: perTickDmg,
                 });
               }
               const dotLog: CombatLog = {
@@ -1926,7 +1935,8 @@ export function simulateCombat(
           const { damage: rawOORDmg, type: dmgType } = getAbilityDamage(
             unit.champion, unit.starLevel, unit.stats.ap, 0, outOfRangeConfig.damageVar
           );
-          const abilityDmg = outOfRangeConfig.hitCount ? rawOORDmg * outOfRangeConfig.hitCount : rawOORDmg;
+          const oorHitTotal = outOfRangeConfig.hitCount ? rawOORDmg * outOfRangeConfig.hitCount : rawOORDmg;
+          const oorIsSplit = outOfRangeConfig.hitCount && outOfRangeConfig.pattern !== 'single';
           const opposingTeam = unit.team === 'player' ? enemies : playerUnits;
 
           let abilityTarget = target;
@@ -1958,16 +1968,21 @@ export function simulateCombat(
 
           // 피해 적용
           let totalAbilityDmg = 0;
+          const oorAlive = abilityTargets.filter(t => t.state !== 'dead');
+          const abilityDmg = oorIsSplit && oorAlive.length > 0
+            ? oorHitTotal / oorAlive.length
+            : oorHitTotal;
 
           if (outOfRangeConfig.dot) {
-            // DOT: burn statusEffect
             const dotTicks = Math.round(outOfRangeConfig.dot.duration * TICKS_PER_SECOND);
-            const dotDmgPerTick = abilityDmg / outOfRangeConfig.dot.duration * TICK_DURATION;
-            for (const t of abilityTargets) {
-              if (t.state === 'dead') continue;
+            for (const t of oorAlive) {
+              const resistance = dmgType === 'magic' ? t.stats.magicResist : dmgType === 'physical' ? t.stats.armor : 0;
+              const pen = dmgType === 'magic' ? unit.stats.magicPen : dmgType === 'physical' ? unit.stats.armorPen : 0;
+              const mitigated = dmgType === 'true' ? abilityDmg * (1 + unit.damageAmp) : applyResistance(abilityDmg * (1 + unit.damageAmp), resistance, pen);
+              const perTickDmg = mitigated / outOfRangeConfig.dot.duration * TICK_DURATION;
               t.statusEffects.push({
                 type: 'burn', sourceId: unit.id,
-                remainingTicks: dotTicks, value: dotDmgPerTick * (1 + unit.damageAmp),
+                remainingTicks: dotTicks, value: perTickDmg,
               });
             }
           } else {

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -14,10 +14,10 @@ import { getHexesInRadius } from '@/lib/simulator/models/hex';
 import { TICK_DURATION, MAX_TICKS, TICKS_PER_SECOND, CAST_TICKS, SELF_BUFF_CAST_TICKS, INITIAL_ATTACK_DELAY } from '@/lib/simulator/models/constants';
 import { createRNG, SeededRNG } from '@/lib/simulator/engine/rng';
 import { captureSnapshot } from '@/lib/simulator/engine/replayEngine';
-import { findTarget, getTargetingWeight } from '@/lib/simulator/systems/targeting';
+import { findTarget } from '@/lib/simulator/systems/targeting';
 import { gainManaOnAttack, gainManaPerTick, gainManaOnDamageTaken } from '@/lib/simulator/systems/mana';
 import { EventBus } from '@/lib/simulator/events/eventBus';
-import { ROLE_OMNIVAMP } from '@/lib/simulator/models/unit';
+import { ROLE_OMNIVAMP, getFighterASBonus } from '@/lib/simulator/models/unit';
 import { resolveTraits } from '@/lib/simulator/systems/trait';
 import { resolveAugmentEffects, resolveInCombatAugmentEffects, resolvePerUnitMods, applyPerUnitMods, AugmentWithStacks } from '@/lib/simulator/systems/augment';
 import type { IoniaPathType } from '@/data/traitModules';
@@ -67,6 +67,8 @@ export interface SimulateOptions {
   /** 칸 버프 증강 */
   playerHexBuffs?: HexBuff[];
   enemyHexBuffs?: HexBuff[];
+  /** 현재 스테이지 번호 (전사 AS 패시브, 기본값 4) */
+  stageNumber?: number;
 }
 
 function createCombatUnit(
@@ -458,71 +460,6 @@ function applyIoniaPath(
 /** Fighter/Assassin 비타겟 피해 감소 비율 */
 const NON_TARGET_DAMAGE_REDUCTION = 0.15;
 
-/** 전투 시작 시 암살자 유닛을 적 후열로 점프시킴 */
-function applyAssassinJump(
-  teamUnits: CombatUnit[],
-  enemyUnits: CombatUnit[],
-  allUnits: CombatUnit[],
-  logs: CombatLog[],
-): void {
-  const assassins = teamUnits.filter(u => u.role === 'Assassin' && u.state !== 'dead');
-  if (assassins.length === 0) return;
-
-  const aliveEnemies = enemyUnits.filter(u => u.state !== 'dead');
-  if (aliveEnemies.length === 0) return;
-
-  const occupiedPositions = new Set(
-    allUnits.filter(u => u.state !== 'dead').map(u => coordKey(u.position))
-  );
-
-  for (const assassin of assassins) {
-    // 적 팀에서 가장 먼 유닛 찾기 (Marksman/Caster 우선)
-    let farthestDist = 0;
-    let farthestEnemy: CombatUnit | null = null;
-    for (const enemy of aliveEnemies) {
-      const dist = hexDistance(assassin.position, enemy.position);
-      if (dist > farthestDist) {
-        farthestDist = dist;
-        farthestEnemy = enemy;
-      } else if (dist === farthestDist && farthestEnemy) {
-        const enemyWeight = getTargetingWeight(enemy.role);
-        const currentWeight = getTargetingWeight(farthestEnemy.role);
-        if (enemyWeight < currentWeight) {
-          farthestEnemy = enemy;
-        }
-      }
-    }
-    if (!farthestEnemy) continue;
-
-    // 해당 유닛 인접 빈 칸 중 하나 선택
-    const neighbors = getNeighbors(farthestEnemy.position);
-    const freeNeighbors = neighbors.filter(n => !occupiedPositions.has(coordKey(n)));
-    if (freeNeighbors.length === 0) continue;
-
-    // 가장 가까운 빈 칸 선택 (적 딜러에 가장 가까운 칸)
-    let bestHex = freeNeighbors[0];
-    let bestDist = Infinity;
-    for (const hex of freeNeighbors) {
-      const dist = hexDistance(hex, farthestEnemy.position);
-      if (dist < bestDist) {
-        bestDist = dist;
-        bestHex = hex;
-      }
-    }
-
-    // 이전 위치 해제, 새 위치 점유
-    occupiedPositions.delete(coordKey(assassin.position));
-    assassin.position = bestHex;
-    occupiedPositions.add(coordKey(bestHex));
-
-    const log: CombatLog = {
-      tick: 0, time: 0, type: 'move',
-      sourceId: assassin.id,
-      message: `[역할군] ${assassin.champion.name}이(가) 적 후열로 점프!`,
-    };
-    logs.push(log);
-  }
-}
 
 function applyResistance(damage: number, resistance: number, penetration: number = 0): number {
   const effective = resistance * (1 - Math.min(penetration, 1));
@@ -1429,6 +1366,18 @@ export function simulateCombat(
   applySet17SynergyBuffs(playerActiveTraits, playerUnits);
   applySet17SynergyBuffs(enemyActiveTraits, enemies);
 
+  // === 전사 AS 패시브 (스테이지 비례 5~30%) ===
+  const stageNumber = options.stageNumber ?? 4;
+  const fighterASBonus = getFighterASBonus(stageNumber);
+  if (fighterASBonus > 0) {
+    for (const u of playerUnits) {
+      if (u.role === 'Fighter') u.stats.attackSpeed *= (1 + fighterASBonus);
+    }
+    for (const u of enemies) {
+      if (u.role === 'Fighter') u.stats.attackSpeed *= (1 + fighterASBonus);
+    }
+  }
+
   // === 칸 버프 증강 ===
   if (options.playerHexBuffs?.length) applyHexBuffs(playerUnits, options.playerHexBuffs);
   if (options.enemyHexBuffs?.length) applyHexBuffs(enemies, options.enemyHexBuffs);
@@ -1497,9 +1446,6 @@ export function simulateCombat(
   playerUnits.push(...playerTurrets);
   enemies.push(...enemyTurrets);
 
-  // 암살자 후열 점프 (전투 시작 직전)
-  applyAssassinJump(playerUnits, enemies, allUnits, logs);
-  applyAssassinJump(enemies, playerUnits, allUnits, logs);
 
   const snapshots: TickSnapshot[] = [];
   const moveTicks = getMoveTicks();

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -1684,9 +1684,10 @@ export function simulateCombat(
             // 스킬 시전 후 cast time — 이 시간 동안 공격 불가
             unit.attackCooldown = config.pattern === 'self_buff' ? SELF_BUFF_CAST_TICKS : CAST_TICKS;
 
-            const { damage: abilityDmg, type: dmgType } = getAbilityDamage(
-              unit.champion, unit.starLevel, unit.stats.ap
+            const { damage: rawAbilityDmg, type: dmgType } = getAbilityDamage(
+              unit.champion, unit.starLevel, unit.stats.ap, 0, config.damageVar
             );
+            const abilityDmg = config.hitCount ? rawAbilityDmg * config.hitCount : rawAbilityDmg;
             const opposingTeam = unit.team === 'player' ? enemies : playerUnits;
 
             // 대쉬 이동 (config.dash가 있으면 대상 인접 칸으로 이동)
@@ -1717,66 +1718,96 @@ export function simulateCombat(
 
             // 다중 타겟 피해 루프
             let totalAbilityDmg = 0;
-            for (let ti = 0; ti < abilityTargets.length; ti++) {
-              const t = abilityTargets[ti];
-              if (t.state === 'dead') continue;
 
-              let abilityDamageAmp = unit.damageAmp;
-              if (unit.inventionTankDamageAmp > 0 && t.role === 'Tank') {
-                abilityDamageAmp += unit.inventionTankDamageAmp;
+            // DOT 스킬: 즉발 대신 burn statusEffect로 지속 피해 적용
+            if (config.dot) {
+              const dotTicks = Math.round(config.dot.duration * TICKS_PER_SECOND);
+              const dotDmgPerTick = abilityDmg / config.dot.duration * TICK_DURATION;
+              for (const t of abilityTargets) {
+                if (t.state === 'dead') continue;
+                t.statusEffects.push({
+                  type: 'burn', sourceId: unit.id,
+                  remainingTicks: dotTicks, value: dotDmgPerTick * (1 + unit.damageAmp),
+                });
               }
-              let dmg = abilityDmg * (1 + abilityDamageAmp);
-              if (config.damageDecay && ti > 0) {
-                dmg *= Math.pow(1 - config.damageDecay, ti);
-              }
-
-              const resistance = dmgType === 'magic' ? t.stats.magicResist
-                : dmgType === 'physical' ? t.stats.armor : 0;
-              const pen = dmgType === 'magic' ? unit.stats.magicPen
-                : dmgType === 'physical' ? unit.stats.armorPen : 0;
-              let effectiveDmg = applyResistance(dmg, resistance, pen);
-
-              if (t.damageReduction > 0) {
-                effectiveDmg *= (1 - t.damageReduction);
-              }
-
-              // Fighter/Assassin 비타겟 피해 감소 15%
-              if ((t.role === 'Fighter' || t.role === 'Assassin') && t.target !== unit.id) {
-                effectiveDmg *= (1 - NON_TARGET_DAMAGE_REDUCTION);
-              }
-
-              effectiveDmg = applyShield(t, effectiveDmg, eventBus, tick);
-              if (t.statusEffects.some(e => e.type === 'invulnerable')) {
-                effectiveDmg = 0;
-              }
-
-              t.currentHp -= effectiveDmg;
-              t.totalDamageTaken += effectiveDmg;
-              unit.totalDamageDealt += effectiveDmg;
-              totalAbilityDmg += effectiveDmg;
-
-              const abilityLog: CombatLog = {
+              const dotLog: CombatLog = {
                 tick, time, type: 'ability',
-                sourceId: unit.id, targetId: t.id,
-                value: Math.round(effectiveDmg),
-                message: `${unit.champion.name}이(가) ${unit.champion.ability.name} 시전! ${t.champion.name}에게 ${Math.round(effectiveDmg)} ${dmgType === 'magic' ? '마법' : dmgType === 'physical' ? '물리' : '트루'} 피해`,
+                sourceId: unit.id, targetId: abilityTarget.id,
+                value: Math.round(abilityDmg),
+                message: `${unit.champion.name}이(가) ${unit.champion.ability.name} 시전! ${config.dot.duration}초 동안 ${Math.round(abilityDmg)} ${dmgType === 'magic' ? '마법' : '물리'} 지속 피해`,
               };
-              logs.push(abilityLog);
-              tickLogs.push(abilityLog);
+              logs.push(dotLog);
+              tickLogs.push(dotLog);
+            } else {
+              // 즉발 피해
+              for (let ti = 0; ti < abilityTargets.length; ti++) {
+                const t = abilityTargets[ti];
+                if (t.state === 'dead') continue;
 
-              // 타겟 사망 처리
-              if (t.currentHp <= 0) {
-                t.currentHp = 0;
-                t.state = 'dead';
-                unit.killCount++;
-                const deathLog: CombatLog = {
-                  tick, time, type: 'death',
-                  sourceId: t.id,
-                  message: `${t.champion.name} 사망! (${unit.champion.name}의 ${unit.champion.ability.name})`,
+                let abilityDamageAmp = unit.damageAmp;
+                if (unit.inventionTankDamageAmp > 0 && t.role === 'Tank') {
+                  abilityDamageAmp += unit.inventionTankDamageAmp;
+                }
+                // 초가스: % 최대체력 피해 추가
+                let baseDmg = abilityDmg;
+                if (unit.champion.apiName === 'TFT17_Chogath') {
+                  const pctVar = unit.champion.ability.variables?.find(v => v.name === 'PercentMaximumHealthDamage');
+                  const pctHp = pctVar?.value?.[unit.starLevel] ?? 0.08;
+                  baseDmg += t.maxHp * pctHp;
+                }
+                let dmg = baseDmg * (1 + abilityDamageAmp);
+                if (config.damageDecay && ti > 0) {
+                  dmg *= Math.pow(1 - config.damageDecay, ti);
+                }
+
+                const resistance = dmgType === 'magic' ? t.stats.magicResist
+                  : dmgType === 'physical' ? t.stats.armor : 0;
+                const pen = dmgType === 'magic' ? unit.stats.magicPen
+                  : dmgType === 'physical' ? unit.stats.armorPen : 0;
+                let effectiveDmg = applyResistance(dmg, resistance, pen);
+
+                if (t.damageReduction > 0) {
+                  effectiveDmg *= (1 - t.damageReduction);
+                }
+
+                // Fighter/Assassin 비타겟 피해 감소 15%
+                if ((t.role === 'Fighter' || t.role === 'Assassin') && t.target !== unit.id) {
+                  effectiveDmg *= (1 - NON_TARGET_DAMAGE_REDUCTION);
+                }
+
+                effectiveDmg = applyShield(t, effectiveDmg, eventBus, tick);
+                if (t.statusEffects.some(e => e.type === 'invulnerable')) {
+                  effectiveDmg = 0;
+                }
+
+                t.currentHp -= effectiveDmg;
+                t.totalDamageTaken += effectiveDmg;
+                unit.totalDamageDealt += effectiveDmg;
+                totalAbilityDmg += effectiveDmg;
+
+                const abilityLog: CombatLog = {
+                  tick, time, type: 'ability',
+                  sourceId: unit.id, targetId: t.id,
+                  value: Math.round(effectiveDmg),
+                  message: `${unit.champion.name}이(가) ${unit.champion.ability.name} 시전! ${t.champion.name}에게 ${Math.round(effectiveDmg)} ${dmgType === 'magic' ? '마법' : dmgType === 'physical' ? '물리' : '트루'} 피해`,
                 };
-                logs.push(deathLog);
-                tickLogs.push(deathLog);
-                eventBus.emit('on_death', { sourceId: t.id, tick });
+                logs.push(abilityLog);
+                tickLogs.push(abilityLog);
+
+                // 타겟 사망 처리
+                if (t.currentHp <= 0) {
+                  t.currentHp = 0;
+                  t.state = 'dead';
+                  unit.killCount++;
+                  const deathLog: CombatLog = {
+                    tick, time, type: 'death',
+                    sourceId: t.id,
+                    message: `${t.champion.name} 사망! (${unit.champion.name}의 ${unit.champion.ability.name})`,
+                  };
+                  logs.push(deathLog);
+                  tickLogs.push(deathLog);
+                  eventBus.emit('on_death', { sourceId: t.id, tick });
+                }
               }
             }
 
@@ -1892,9 +1923,10 @@ export function simulateCombat(
           unit.castCount++;
           unit.attackCooldown = outOfRangeConfig.pattern === 'self_buff' ? SELF_BUFF_CAST_TICKS : CAST_TICKS;
 
-          const { damage: abilityDmg, type: dmgType } = getAbilityDamage(
-            unit.champion, unit.starLevel, unit.stats.ap
+          const { damage: rawOORDmg, type: dmgType } = getAbilityDamage(
+            unit.champion, unit.starLevel, unit.stats.ap, 0, outOfRangeConfig.damageVar
           );
+          const abilityDmg = outOfRangeConfig.hitCount ? rawOORDmg * outOfRangeConfig.hitCount : rawOORDmg;
           const opposingTeam = unit.team === 'player' ? enemies : playerUnits;
 
           let abilityTarget = target;
@@ -1926,34 +1958,46 @@ export function simulateCombat(
 
           // 피해 적용
           let totalAbilityDmg = 0;
-          for (const t of abilityTargets) {
-            if (t.state === 'dead') continue;
-            const resistance = dmgType === 'magic' ? t.stats.magicResist : t.stats.armor;
-            const pen = dmgType === 'magic' ? unit.stats.magicPen : unit.stats.armorPen;
-            let dmg = dmgType === 'true' ? abilityDmg * (1 + unit.damageAmp) : applyResistance(abilityDmg * (1 + unit.damageAmp), resistance, pen);
-            if (t.damageReduction > 0) dmg *= (1 - t.damageReduction);
-            dmg = applyShield(t, dmg, eventBus, tick);
-            if (t.statusEffects.some(e => e.type === 'invulnerable')) dmg = 0;
-            t.currentHp -= dmg;
-            t.totalDamageTaken += dmg;
-            unit.totalDamageDealt += dmg;
-            totalAbilityDmg += dmg;
 
-            // 사망 처리
-            if (t.currentHp <= 0) {
-              t.state = 'dead';
-              t.currentHp = 0;
-              eventBus.emit('on_kill', { sourceId: unit.id, targetId: t.id, tick });
-              eventBus.emit('on_death', { sourceId: t.id, targetId: unit.id, tick });
-              logs.push({ tick, time, type: 'death', sourceId: t.id, message: `${t.champion.name} 사망!` });
+          if (outOfRangeConfig.dot) {
+            // DOT: burn statusEffect
+            const dotTicks = Math.round(outOfRangeConfig.dot.duration * TICKS_PER_SECOND);
+            const dotDmgPerTick = abilityDmg / outOfRangeConfig.dot.duration * TICK_DURATION;
+            for (const t of abilityTargets) {
+              if (t.state === 'dead') continue;
+              t.statusEffects.push({
+                type: 'burn', sourceId: unit.id,
+                remainingTicks: dotTicks, value: dotDmgPerTick * (1 + unit.damageAmp),
+              });
             }
+          } else {
+            for (const t of abilityTargets) {
+              if (t.state === 'dead') continue;
+              const resistance = dmgType === 'magic' ? t.stats.magicResist : t.stats.armor;
+              const pen = dmgType === 'magic' ? unit.stats.magicPen : unit.stats.armorPen;
+              let dmg = dmgType === 'true' ? abilityDmg * (1 + unit.damageAmp) : applyResistance(abilityDmg * (1 + unit.damageAmp), resistance, pen);
+              if (t.damageReduction > 0) dmg *= (1 - t.damageReduction);
+              dmg = applyShield(t, dmg, eventBus, tick);
+              if (t.statusEffects.some(e => e.type === 'invulnerable')) dmg = 0;
+              t.currentHp -= dmg;
+              t.totalDamageTaken += dmg;
+              unit.totalDamageDealt += dmg;
+              totalAbilityDmg += dmg;
 
-            // 스턴 (살아있을 때만)
-            if (outOfRangeConfig.stun && outOfRangeConfig.stun > 0 && t.currentHp > 0) {
-              const stunTicks = Math.round(outOfRangeConfig.stun * TICKS_PER_SECOND);
-              t.statusEffects.push({ type: 'stun', sourceId: unit.id, remainingTicks: stunTicks });
-              t.state = 'idle';
-              t.attackCooldown = 0;
+              if (t.currentHp <= 0) {
+                t.state = 'dead';
+                t.currentHp = 0;
+                eventBus.emit('on_kill', { sourceId: unit.id, targetId: t.id, tick });
+                eventBus.emit('on_death', { sourceId: t.id, targetId: unit.id, tick });
+                logs.push({ tick, time, type: 'death', sourceId: t.id, message: `${t.champion.name} 사망!` });
+              }
+
+              if (outOfRangeConfig.stun && outOfRangeConfig.stun > 0 && t.currentHp > 0) {
+                const stunTicks = Math.round(outOfRangeConfig.stun * TICKS_PER_SECOND);
+                t.statusEffects.push({ type: 'stun', sourceId: unit.id, remainingTicks: stunTicks });
+                t.state = 'idle';
+                t.attackCooldown = 0;
+              }
             }
           }
 

--- a/src/lib/simulator/models/unit.ts
+++ b/src/lib/simulator/models/unit.ts
@@ -15,6 +15,14 @@ export const ROLE_OMNIVAMP: Record<UnitRole, number> = {
   Specialist: 0,
 };
 
+/** 전사 스테이지별 AS 보너스 (lolchess.gg: 5~30%) */
+const FIGHTER_AS_BY_STAGE = [0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.30];
+
+export function getFighterASBonus(stageNumber: number): number {
+  const clamped = Math.max(1, Math.min(stageNumber, 7));
+  return FIGHTER_AS_BY_STAGE[clamped];
+}
+
 /** Role별 타게팅 가중치 — Tank(3) > Fighter/Assassin(2) > Marksman/Caster/Specialist(1) */
 export const TARGETING_WEIGHT: Record<UnitRole, number> = {
   Tank: 3,

--- a/src/lib/simulator/systems/ability.ts
+++ b/src/lib/simulator/systems/ability.ts
@@ -42,6 +42,12 @@ export interface AbilityConfig {
     mrReduction?: number;
     duration?: number;
   };
+  /** 다회 타격 횟수 — 총 피해 = base × hitCount (벨베스 12, 아칼리 5 등) */
+  hitCount?: number;
+  /** DOT 지속 피해 — 스킬 피해를 duration초에 걸쳐 매초 적용 */
+  dot?: { duration: number };
+  /** parseAbility 대신 사용할 피해 변수명 오버라이드 */
+  damageVar?: string;
 }
 
 /** 챔피언별 스킬 타게팅 패턴 매핑 */
@@ -165,16 +171,16 @@ export const CHAMPION_ABILITY_PATTERNS: Record<string, AbilityConfig> = {
   TFT17_Teemo:       { pattern: 'self_buff', selfBuff: { attackSpeed: 0.5, duration: 3 } },  // 패시브 추가 마법 + AS 버프
   TFT17_Nasus:       { pattern: 'aoe_circle', radius: 1, selfBuff: { durability: 0.2, duration: 6 } },  // 변신 + 주변 매초 피해
   TFT17_TwistedFate:  { pattern: 'single' },  // 카드 던지기 (단일 마법)
-  TFT17_Talon:       { pattern: 'single', dash: 'to_target' },  // 출혈 + 도약
+  TFT17_Talon:       { pattern: 'single', dash: 'to_target', dot: { duration: 18 } },  // 출혈 18초 DOT + 도약
   TFT17_Ezreal:      { pattern: 'single' },  // 파동 단일 물리
   TFT17_Leona:       { pattern: 'single', stun: 1.5, selfBuff: { durability: 0.3, duration: 4 } },  // 보호막 + 기절
-  TFT17_Chogath:     { pattern: 'single', heal: true },  // 체력흡수 + 영구 최대체력
+  TFT17_Chogath:     { pattern: 'single', heal: true, damageVar: 'BonusDamage' },  // %최대체력 + 고정 추가 피해 (combatLoop 특수 처리)
   TFT17_Lissandra:   { pattern: 'aoe_circle', radius: 1 },  // 단검 + 폭발 AOE
   TFT17_RekSai:      { pattern: 'aoe_circle', radius: 1, stun: 1.0, heal: true },  // 회복 + 인접 공중띄움
 
   // === 2코스트 ===
-  TFT17_Belveth:     { pattern: 'single' },  // 연속 베기
-  TFT17_Akali:       { pattern: 'line', maxTargets: 3, dash: 'to_target', debuff: { armorReduction: 15, duration: 4 } },  // 관통 단검 + 방어력 감소
+  TFT17_Belveth:     { pattern: 'single', hitCount: 12 },  // 연속 12회 베기
+  TFT17_Akali:       { pattern: 'line', maxTargets: 3, dash: 'to_target', debuff: { armorReduction: 15, duration: 4 }, hitCount: 5 },  // 단검 5개 관통 + 방어력 감소
   TFT17_Jinx:        { pattern: 'cone', radius: 2 },  // 원뿔 로켓
   TFT17_Gnar:        { pattern: 'line', maxTargets: 3, damageDecay: 0.3 },  // 부메랑 관통 + 감소
   TFT17_Pyke:        { pattern: 'aoe_circle', radius: 1, dash: 'to_target' },  // 작살 끌기 + 텔레포트 베기
@@ -184,8 +190,8 @@ export const CHAMPION_ABILITY_PATTERNS: Record<string, AbilityConfig> = {
   TFT17_Milio:       { pattern: 'bounce', maxTargets: 4 },  // 공 튕기기
   TFT17_Zoe:         { pattern: 'line', maxTargets: 4 },  // 통통별 관통 + 방향전환
   TFT17_IvernMinion: { pattern: 'aoe_circle', radius: 1, stun: 1.0, heal: true },  // 회복 + 강타 + 열 피해
-  TFT17_Mordekaiser: { pattern: 'aoe_circle', radius: 1, heal: true },  // 보호막 + 주변 매초 피해
-  TFT17_Pantheon:    { pattern: 'cone', radius: 2, selfBuff: { durability: 0.3, duration: 4 } },  // 보호막 + 원뿔 매초 피해
+  TFT17_Mordekaiser: { pattern: 'aoe_circle', radius: 1, heal: true, dot: { duration: 4 } },  // 보호막 + 주변 매초 피해 4초
+  TFT17_Pantheon:    { pattern: 'cone', radius: 2, selfBuff: { durability: 0.15, duration: 4 }, dot: { duration: 4 } },  // 보호막+내구력 + 원뿔 매초 고정 피해 4초
 
   // === 3코스트 ===
   TFT17_MissFortune: { pattern: 'multi', maxTargets: 3 },  // 모드에 따라 다름 (기본)
@@ -193,41 +199,41 @@ export const CHAMPION_ABILITY_PATTERNS: Record<string, AbilityConfig> = {
   TFT17_Aurora:      { pattern: 'aoe_circle', radius: 2 },  // 균열 해킹 + 저장 피해
   TFT17_Fizz:        { pattern: 'line', dash: 'to_target' },  // 관통 돌진 + 정령 소환
   TFT17_Maokai:      { pattern: 'aoe_circle', radius: 2, stun: 1.5 },  // X자 덩굴 + 기절
-  TFT17_Kaisa:       { pattern: 'aoe_circle', radius: 2, maxTargets: 16 },  // 미사일 16개 반경 2칸
-  TFT17_Urgot:       { pattern: 'cone', radius: 2, selfBuff: { durability: 0.2, duration: 4 } },  // 근접 폭발 원뿔 + 보호막
-  TFT17_Viktor:      { pattern: 'aoe_circle', radius: 1 },  // 초능력 폭풍 (커지는 AOE)
+  TFT17_Kaisa:       { pattern: 'aoe_circle', radius: 2, hitCount: 16 },  // 미사일 16개 반경 2칸 나누어 발사
+  TFT17_Urgot:       { pattern: 'cone', radius: 2, selfBuff: { durability: 0.2, duration: 3 }, damageVar: 'ShotgunDamage' },  // 보호막 + 원뿔 폭발 탄환
+  TFT17_Viktor:      { pattern: 'aoe_circle', radius: 1, dot: { duration: 4 } },  // 초능력 폭풍 4초 DOT (커지는 AOE)
   TFT17_Samira:      { pattern: 'single', stun: 1.0 },  // 탄환 + 공중띄움
   TFT17_Ornn:        { pattern: 'cone', radius: 2 },  // 보호막 + 원뿔 화염
   TFT17_Lulu:        { pattern: 'multi', maxTargets: 4 },  // 하늘에서 떨어뜨려 주변 적 타격
-  TFT17_Diana:       { pattern: 'aoe_circle', radius: 1, selfBuff: { attackSpeed: 0.5, duration: 4 } },  // 보호막 + 구체 회전
+  TFT17_Diana:       { pattern: 'aoe_circle', radius: 1, selfBuff: { attackSpeed: 0.5, duration: 4 }, damageVar: 'CleaveDamage', dot: { duration: 3 } },  // 보호막 + 3초 구체 회전 DOT
   TFT17_Rhaast:      { pattern: 'line', stun: 1.0, heal: true, selfBuff: { durability: 0.3, duration: 4 } },  // 내구력 + 회복 + 직선 베기
 
   // === 4코스트 ===
   TFT17_Rammus:      { pattern: 'line', maxTargets: 3, selfBuff: { durability: 0.3, duration: 4 } },  // 보호막 + 직선 3칸
-  TFT17_Corki:       { pattern: 'aoe_circle', radius: 2, dash: 'to_target' },  // 저공비행 + 미사일 AOE
+  TFT17_Corki:       { pattern: 'aoe_circle', radius: 2, dash: 'to_target', hitCount: 21, damageVar: 'MissileAD' },  // 저공비행 + 미사일 21개 AOE
   TFT17_Kindred:     { pattern: 'multi', maxTargets: 4, dash: 'to_farthest' },  // 도약 + 화살 다수
   TFT17_Karma:       { pattern: 'multi', maxTargets: 4 },  // 블랙홀 분배 피해
-  TFT17_AurelionSol: { pattern: 'line', damageDecay: 0.15 },  // 직선 광선 + 관통 감소
+  TFT17_AurelionSol: { pattern: 'line', damageDecay: 0.15, dot: { duration: 3 } },  // 직선 광선 3초 DOT + 관통 감소
   TFT17_Galio:       { pattern: 'aoe_circle', radius: 2, heal: true, selfBuff: { durability: 0.3, duration: 4 } },  // 방어 태세 + 충격파
   TFT17_MasterYi:    { pattern: 'self_buff', selfBuff: { attackSpeed: 0.8, duration: 5 } },  // 초필살 AS + 흡혈
   TFT17_Nami:        { pattern: 'aoe_circle', radius: 1 },  // 디스코 방울 + 작은 방울
-  TFT17_Nunu:        { pattern: 'aoe_circle', radius: 2, stun: 1.5 },  // 보호막 + 아스트롤라베 AOE + 띄움
+  TFT17_Nunu:        { pattern: 'aoe_circle', radius: 2, stun: 1.75, damageVar: 'InitialDamage' },  // 보호막 + 2칸 AOE + 띄움 1.75초
   TFT17_Riven:       { pattern: 'aoe_circle', radius: 1, dash: 'to_target' },  // 돌진 + 베기, 3회째 직선 파동
-  TFT17_Leblanc:     { pattern: 'multi', maxTargets: 3 },  // 분신 소환 + 투사체
+  TFT17_Leblanc:     { pattern: 'multi', maxTargets: 3, damageVar: 'BoltDamage', hitCount: 5 },  // 분신 5명 투사체 (BoltDamage × 5)
   TFT17_Xayah:       { pattern: 'multi', maxTargets: 4, selfBuff: { attackSpeed: 0.6, duration: 4 } },  // 튕기기 + AS버프 + 깃털 회수
   TFT17_TahmKench:   { pattern: 'aoe_circle', radius: 2, heal: true },  // 회복 + 2칸 혀 채찍
 
   // === 5코스트 ===
-  TFT17_Bard:        { pattern: 'aoe_circle', radius: 1 },  // 비행접시 DOT + 주변 분배
+  TFT17_Bard:        { pattern: 'aoe_circle', radius: 1, dot: { duration: 4 } },  // 비행접시 4초 DOT + 주변 분배
   TFT17_Fiora:       { pattern: 'single', dash: 'to_target', heal: true },  // 급소 돌진 + 회복
   TFT17_Jhin:        { pattern: 'multi', maxTargets: 3, debuff: { armorReduction: 15, duration: 4 } },  // 잔상 손 + 관통 사격
-  TFT17_Blitzcrank:  { pattern: 'aoe_circle', radius: 3, stun: 1.5 },  // 디스코 볼 + 띄움 + 폭발
+  TFT17_Blitzcrank:  { pattern: 'aoe_circle', radius: 3, stun: 1.5, stunTargets: 1, damageVar: 'ExplosionDamage' },  // 띄움 1명 + 폭발 3칸
   TFT17_Sona:        { pattern: 'multi', maxTargets: 3, stun: 1.0 },  // 자성 파편 + 기절
-  TFT17_Vex:         { pattern: 'aoe_circle', radius: 1 },  // 그림자 패시브 + 강화타격
+  TFT17_Vex:         { pattern: 'aoe_circle', radius: 1, damageVar: 'ShadowHandMagicDamage', hitCount: 3 },  // 강화 타격 3회
   TFT17_Shen:        { pattern: 'aoe_circle', radius: 2, selfBuff: { attackSpeed: 0.3, duration: 999 } },  // 보호막 + 균열 AOE + AS둔화
   TFT17_Zed:         { pattern: 'self_buff' },  // 분신 소환 (복제)
   TFT17_Graves:      { pattern: 'cone', radius: 2 },  // 원뿔 투사체 + 폭발 탄환
-  TFT17_Morgana:     { pattern: 'multi', maxTargets: 4, heal: true },  // 변신 + 사슬 DOT + 최종 폭발
+  TFT17_Morgana:     { pattern: 'multi', maxTargets: 3, heal: true, dot: { duration: 5 } },  // 변신 + 사슬 3명 5초 DOT + 최종 폭발
 
   // === 미등록 챔피언 추가 (2차 — audit 검출분) ===
   TFT16_Blitzcrank:  { pattern: 'aoe_circle', radius: 2 },               // 보호막 + 주변 적 데미지
@@ -318,23 +324,71 @@ export function findAbilityTargets(
   }
 }
 
-export function parseAbility(champion: RawChampion): ParsedAbility {
+/** 피해 타입 판별 — 한글 desc 우선, HTML 태그 폴백 */
+function detectDamageType(desc: string): DamageType {
+  if (desc.includes('고정 피해')) return 'true';
+  if (desc.includes('물리 피해')) return 'physical';
+  if (desc.includes('마법 피해')) return 'magic';
+  if (desc.includes('<trueDamage>')) return 'true';
+  if (desc.includes('<physicalDamage>')) return 'physical';
+  return 'magic';
+}
+
+/** 스케일링 판별 — 변수명 접미사 + desc 폴백 */
+function detectScaling(varName: string | null, desc: string): 'ap' | 'ad' | 'none' {
+  if (varName) {
+    if (/AD/.test(varName) && !/DAm/.test(varName)) return 'ad';
+    if (/AP/.test(varName)) return 'ap';
+  }
+  if (desc.includes('scaleAD')) return 'ad';
+  if (desc.includes('scaleAP')) return 'ap';
+  if (desc.includes('물리 피해')) return 'ad';
+  if (desc.includes('마법 피해')) return 'ap';
+  return 'ap';
+}
+
+/** 피해 변수 탐색 우선순위 목록 */
+const DAMAGE_VAR_PRIORITY = [
+  'Damage', 'MagicDamage', 'PhysicalDamage', 'TotalDamage',
+  'ADDamage', 'APDamage', 'DamageAD', 'DamageAP',
+  'BonusDamage', 'DamagePerTick', 'DamagePerSecond', 'DamagePerProc',
+  'PassiveDamage', 'SpellDamage', 'InitialDamage',
+];
+
+/** 피해 변수 찾기 — 우선순위 매칭 → 이름에 'Damage'/'damage' 포함 → null */
+function findDamageVariable(variables: RawChampion['ability']['variables']): RawChampion['ability']['variables'][0] | null {
+  if (!variables || variables.length === 0) return null;
+
+  // 1순위: 정확 매칭
+  for (const name of DAMAGE_VAR_PRIORITY) {
+    const v = variables.find(vr => vr.name === name);
+    if (v) return v;
+  }
+
+  // 2순위: 이름에 'Damage' 포함 (대소문자 구분)
+  const fuzzy = variables.find(v => v.name.includes('Damage') || v.name.includes('damage'));
+  if (fuzzy) return fuzzy;
+
+  // 피해 변수 없음 (보호막/유틸 스킬)
+  return null;
+}
+
+export function parseAbility(champion: RawChampion, damageVarOverride?: string): ParsedAbility {
   const desc = champion.ability.desc;
   const variables = champion.ability.variables;
 
-  let damageType: DamageType = 'magic';
-  if (desc.includes('<physicalDamage>')) damageType = 'physical';
-  else if (desc.includes('<trueDamage>')) damageType = 'true';
+  const damageType = detectDamageType(desc);
 
-  let scalingType: 'ap' | 'ad' | 'none' = 'none';
-  if (desc.includes('scaleAP')) scalingType = 'ap';
-  else if (desc.includes('scaleAD')) scalingType = 'ad';
-
-  const damageVarNames = ['Damage', 'MagicDamage', 'PhysicalDamage', 'TotalDamage', 'BonusDamage', 'DamagePerTick'];
-  let damageVar = variables.find(v => damageVarNames.includes(v.name));
-  if (!damageVar && variables.length > 0) {
-    damageVar = variables[0];
+  // damageVar 오버라이드: AbilityConfig.damageVar로 직접 지정된 경우
+  let damageVar: RawChampion['ability']['variables'][0] | null = null;
+  if (damageVarOverride) {
+    damageVar = variables.find(v => v.name === damageVarOverride) ?? null;
   }
+  if (!damageVar) {
+    damageVar = findDamageVariable(variables);
+  }
+
+  const scalingType = damageVar ? detectScaling(damageVar.name, desc) : 'none';
 
   return {
     damageType,
@@ -348,9 +402,10 @@ export function getAbilityDamage(
   champion: RawChampion,
   starLevel: number,
   ap: number,
-  bonusAdPercent: number = 0
+  bonusAdPercent: number = 0,
+  damageVarOverride?: string,
 ): { damage: number; type: DamageType } {
-  const parsed = parseAbility(champion);
+  const parsed = parseAbility(champion, damageVarOverride);
   const baseValue = parsed.damageValues[starLevel] ?? parsed.damageValues[1] ?? 0;
 
   let damage = baseValue;

--- a/src/lib/simulator/systems/ability.ts
+++ b/src/lib/simulator/systems/ability.ts
@@ -369,8 +369,8 @@ function findDamageVariable(variables: RawChampion['ability']['variables']): Raw
   const fuzzy = variables.find(v => v.name.includes('Damage') || v.name.includes('damage'));
   if (fuzzy) return fuzzy;
 
-  // 피해 변수 없음 (보호막/유틸 스킬)
-  return null;
+  // 3순위: variables[0] 폴백 (피해 텍스트가 있지만 변수명에 Damage가 없는 경우)
+  return variables[0];
 }
 
 export function parseAbility(champion: RawChampion, damageVarOverride?: string): ParsedAbility {


### PR DESCRIPTION
## Summary

- **챔피언 스킬 파싱 전면 수정**: Set 17 데이터 형식 대응 — 피해 변수 매칭(35명 추가), 한글 피해 타입 판별, AD/AP 스케일링 자동 감지
- **hitCount/DOT 시스템**: 다회 타격(벨베스×12, 아칼리×5 등) + 지속 피해(탈론 18초, 아솔 3초 등) 정확 계산
- **역할군 패시브**: 전사 AS 5~30%(스테이지 비례) 추가, 암살자 후열 점프 제거(Set 17에 없음), 스테이지 선택 UI
- **칸 버프 증강**: 야스오 황금 칸 등 10개 증강 보드 시각화 + 전투 스탯 적용
- **Dash/self_buff 시전 버그 수정**: 사거리 밖에서도 마나 충분 시 즉시 시전 (피즈, 다이애나 등 12명)
- **PR #7 Codex 리뷰 반영**: 팀 코드 1성 디코딩, 이즈리얼 드론 피해, MF 시너지 버프
- **UI 개선**: 시너지 툴팁 챔피언 목록, 보드 hover 스킬 툴팁(소속 시너지 포함), 증강 필터 설명

## Test plan

- [x] 전투 시뮬레이션 — 챔피언 스킬 피해가 실제 수치와 일치하는지 확인
- [x] DOT 챔피언(탈론, 아솔 등) — 지속 피해가 매 틱 적용되는지 확인
- [x] 다회 타격 챔피언(벨베스, 카이사 등) — 총 피해 = base × hitCount
- [x] 전사 AS 패시브 — Stage 드롭다운 변경 시 AS 보너스 반영
- [x] 칸 버프 증강 — 보드에 색상/라벨 표시, 전투 스탯 적용
- [x] 보드 hover 툴팁 — 챔피언 이름 + 시너지 + 스킬 설명 표시
- [x] 시너지 툴팁 — 하단에 소속 챔피언 아이콘/이름 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)