### PR TITLE
feat(actual-data): 아이템 편집 UX — 개별 슬롯 제거·드래그 교체·자석 제거기

### DIFF
--- a/docs/superpowers/plans/2026-04-24-item-edit-ux.md
+++ b/docs/superpowers/plans/2026-04-24-item-edit-ux.md
@@ -1,0 +1,897 @@
+# 아이템 편집 UX 개선 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/actual-data` 편집기에서 아이템을 **개별 슬롯 제거(×)**, **드래그 교체(A→B)**, **자석 제거기 드래그(전체 초기화)**로 편집하도록 지원한다.
+
+**Architecture:** 기존 `DragData` union을 확장해 `tool` 타입을 추가하고, `ActualBoard`에 유닛 위 HTML 오버레이로 슬롯 단위 droppable + X 버튼을 렌더한다. `actualDndHandlers`의 drop 라우팅을 슬롯 ID → 셀 ID 순서로 시도하고, 슬롯 히트 시 해당 인덱스에 교체한다. `ChampionItemSidebar`에 "도구" 탭을 추가해 자석 제거기를 드래그 소스로 노출. 중첩 droppable(작은 슬롯 in 큰 헥스) 매칭을 위해 DndContext의 `collisionDetection`을 `pointerWithin` → `rectIntersection` fallback으로 교체.
+
+**Tech Stack:** Next.js 15 App Router, TypeScript, Zustand (`actualDataSlice`), @dnd-kit/core, TailwindCSS, Vitest.
+
+---
+
+## 파일 구조
+
+| 파일 | 역할 |
+|---|---|
+| `src/types/index.ts` | `DragData` union에 `{ type: 'tool'; toolKind: 'remove-all' }` 추가 |
+| `src/components/actual-data/actualDndHandlers.ts` | `parseSlotId`, 슬롯 인덱스 기반 아이템 교체/설정, `tool: remove-all` drop 처리 |
+| `src/components/actual-data/ActualBoard.tsx` | 유닛 점유 헥스 위에 슬롯 오버레이(3칸 droppable + 채워진 슬롯 X 버튼) 추가 |
+| `src/components/actual-data/ChampionItemSidebar.tsx` | 탭 목록에 `도구`(tools) 추가, 자석 제거기 노출 |
+| `src/components/actual-data/DraggableItemRemoverTool.tsx` | 신규 — 자석 제거기 드래그 소스 컴포넌트 (@dnd-kit `useDraggable`) |
+| `src/components/actual-data/PvPRoundEditor.tsx` | `DndContext collisionDetection` 조정 (pointerWithin → rectIntersection fallback) |
+| `tests/unit/actualData/actualDndHandlers.test.ts` | 신규 — DnD handler 단위 테스트 (slot id 파싱, 교체, 제거기 동작) |
+
+---
+
+## Task 1: DragData union에 `tool` 타입 추가
+
+**Files:**
+- Modify: `src/types/index.ts:557-560`
+
+- [ ] **Step 1: 현재 DragData 확인 (읽기만)**
+
+  `src/types/index.ts:557-560`은 아래 형태.
+  ```ts
+  export type DragData =
+    | { type: 'champion'; champion: RawChampion }
+    | { type: 'placed-unit'; team: 'player' | 'enemy'; position: HexCoord }
+    | { type: 'item'; item: RawItem };
+  ```
+
+- [ ] **Step 2: `tool` 분기 추가**
+
+  `src/types/index.ts:557-560`을 다음으로 교체:
+  ```ts
+  export type DragData =
+    | { type: 'champion'; champion: RawChampion }
+    | { type: 'placed-unit'; team: 'player' | 'enemy'; position: HexCoord }
+    | { type: 'item'; item: RawItem }
+    | { type: 'tool'; toolKind: 'remove-all' };
+  ```
+
+- [ ] **Step 3: 타입체크로 기존 호환성 확인**
+
+  ```bash
+  pnpm typecheck
+  ```
+  Expected: 에러 없음 (기존 핸들러는 switch 없이 `dragData.type === 'x'` 체크만 해서 새 variant는 fall-through로 무시됨).
+
+- [ ] **Step 4: 커밋**
+
+  ```bash
+  git add src/types/index.ts
+  git commit -m "feat(actual-data): DragData union에 'tool' 타입 추가 (자석 제거기 준비)"
+  ```
+
+---
+
+## Task 2: 슬롯 ID 파서 + 슬롯 단위 아이템 헬퍼 (TDD)
+
+**Files:**
+- Modify: `src/components/actual-data/actualDndHandlers.ts`
+- Create: `tests/unit/actualData/actualDndHandlers.test.ts`
+
+- [ ] **Step 1: 실패하는 테스트 먼저 작성**
+
+  `tests/unit/actualData/actualDndHandlers.test.ts`를 새로 만든다.
+  ```ts
+  import { describe, it, expect } from 'vitest';
+  import {
+    parseSlotId,
+    setItemAtSlot,
+    clearUnitItems,
+  } from '@/components/actual-data/actualDndHandlers';
+  import type { PlacedUnit } from '@/lib/actualData/types';
+
+  const sampleItem = { apiName: 'TFT_Item_BFSword' } as const;
+
+  describe('parseSlotId', () => {
+    it('player 팀 슬롯 id 를 파싱한다', () => {
+      expect(parseSlotId('item-slot-player-1-2-0')).toEqual({
+        team: 'player', hex: { q: 1, r: 2 }, slotIdx: 0,
+      });
+    });
+
+    it('enemy 팀 음수 좌표도 파싱한다', () => {
+      expect(parseSlotId('item-slot-enemy--1-3-2')).toEqual({
+        team: 'enemy', hex: { q: -1, r: 3 }, slotIdx: 2,
+      });
+    });
+
+    it('잘못된 포맷은 null 을 반환한다', () => {
+      expect(parseSlotId('cell-4-3')).toBeNull();
+      expect(parseSlotId('item-slot-foo-1-2-0')).toBeNull();
+      expect(parseSlotId('item-slot-player-1-2-9')).toBeNull();
+    });
+  });
+
+  const unit = (items: (string | undefined)[]): PlacedUnit => ({
+    championId: 'TFT17_Ahri',
+    hex: { q: 0, r: 0 },
+    starLevel: 2,
+    items: [items[0], items[1], items[2]] as PlacedUnit['items'],
+  });
+
+  describe('setItemAtSlot', () => {
+    it('빈 슬롯을 지정된 인덱스에 채운다', () => {
+      const u = unit([undefined, undefined, undefined]);
+      const next = setItemAtSlot(u, 'TFT_Item_BFSword', 1);
+      expect(next.items).toEqual([undefined, 'TFT_Item_BFSword', undefined]);
+    });
+
+    it('채워진 슬롯을 덮어쓴다 (교체)', () => {
+      const u = unit(['TFT_Item_BFSword', 'TFT_Item_RecurveBow', undefined]);
+      const next = setItemAtSlot(u, 'TFT_Item_Rabadon', 0);
+      expect(next.items).toEqual(['TFT_Item_Rabadon', 'TFT_Item_RecurveBow', undefined]);
+    });
+
+    it('원본 객체를 mutate 하지 않는다', () => {
+      const u = unit(['A', undefined, undefined]);
+      setItemAtSlot(u, 'B', 0);
+      expect(u.items).toEqual(['A', undefined, undefined]);
+    });
+  });
+
+  describe('clearUnitItems', () => {
+    it('3칸 모두 undefined 로 만든다', () => {
+      const u = unit(['A', 'B', 'C']);
+      const next = clearUnitItems(u);
+      expect(next.items).toEqual([undefined, undefined, undefined]);
+    });
+
+    it('원본 객체를 mutate 하지 않는다', () => {
+      const u = unit(['A', 'B', 'C']);
+      clearUnitItems(u);
+      expect(u.items).toEqual(['A', 'B', 'C']);
+    });
+  });
+  ```
+
+- [ ] **Step 2: 테스트 실행해서 실패 확인**
+
+  ```bash
+  pnpm test tests/unit/actualData/actualDndHandlers.test.ts
+  ```
+  Expected: FAIL — `parseSlotId`, `setItemAtSlot`, `clearUnitItems` 모두 export 안 됨.
+
+- [ ] **Step 3: 최소 구현 추가**
+
+  `src/components/actual-data/actualDndHandlers.ts`의 `setItemInSlot` 함수 정의(32-41줄) 아래에 다음을 추가 (export 주의):
+  ```ts
+  /** Parse an item-slot droppable id `item-slot-{team}-{q}-{r}-{slotIdx}`. */
+  export function parseSlotId(id: string): { team: 'player' | 'enemy'; hex: HexCoord; slotIdx: 0 | 1 | 2 } | null {
+    const match = id.match(/^item-slot-(player|enemy)-(-?\d+)-(-?\d+)-(\d+)$/);
+    if (!match) return null;
+    const slotIdx = Number(match[4]);
+    if (slotIdx !== 0 && slotIdx !== 1 && slotIdx !== 2) return null;
+    return {
+      team: match[1] as 'player' | 'enemy',
+      hex: { q: Number(match[2]), r: Number(match[3]) },
+      slotIdx,
+    };
+  }
+
+  /** Replace or fill a specific slot (0..2) with the given item apiName. Returns a new unit. */
+  export function setItemAtSlot(u: PlacedUnit, itemApiName: string, slotIdx: 0 | 1 | 2): PlacedUnit {
+    const next = [...u.items] as PlacedUnit['items'];
+    next[slotIdx] = itemApiName;
+    return { ...u, items: next };
+  }
+
+  /** Clear all three item slots of a unit. Returns a new unit. */
+  export function clearUnitItems(u: PlacedUnit): PlacedUnit {
+    return { ...u, items: [undefined, undefined, undefined] as PlacedUnit['items'] };
+  }
+  ```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+  ```bash
+  pnpm test tests/unit/actualData/actualDndHandlers.test.ts
+  ```
+  Expected: PASS — 3개 describe 블록의 모든 it 통과.
+
+- [ ] **Step 5: 커밋**
+
+  ```bash
+  git add src/components/actual-data/actualDndHandlers.ts tests/unit/actualData/actualDndHandlers.test.ts
+  git commit -m "feat(actual-data): 슬롯 단위 아이템 조작 헬퍼 (parseSlotId, setItemAtSlot, clearUnitItems)"
+  ```
+
+---
+
+## Task 3: Drop 라우팅에 슬롯 교체 + 제거기 분기 추가 (TDD)
+
+**Files:**
+- Modify: `src/components/actual-data/actualDndHandlers.ts`
+- Modify: `tests/unit/actualData/actualDndHandlers.test.ts`
+
+- [ ] **Step 1: 통합 동작 테스트 추가 (실패 예상)**
+
+  `tests/unit/actualData/actualDndHandlers.test.ts` 파일 **상단 import 블록에 다음을 추가**:
+  ```ts
+  import { createActualDragEndHandler, type ActualDndContext } from '@/components/actual-data/actualDndHandlers';
+  import type { PvPRound, TeamSnapshot, OpponentSnapshot } from '@/lib/actualData/types';
+  import type { DragEndEvent } from '@dnd-kit/core';
+  ```
+
+  그리고 파일 **맨 아래**에 describe 블록 이어서 추가:
+  ```ts
+  const baseTeam = (units: PlacedUnit[]): TeamSnapshot => ({
+    units,
+    augments: [undefined, undefined, undefined, undefined],
+    level: 6,
+    hp: 100,
+    hexModifiers: [],
+  });
+  const baseOpponent = (units: PlacedUnit[]): OpponentSnapshot => ({ ...baseTeam(units) });
+
+  const makeRound = (playerUnits: PlacedUnit[], opponentUnits: PlacedUnit[] = []): PvPRound => ({
+    type: 'pvp',
+    roundName: '2-1',
+    videoStartTime: 0,
+    playerTeam: baseTeam(playerUnits),
+    opponent: baseOpponent(opponentUnits),
+    winner: 'player',
+  });
+
+  /** Minimal DragEndEvent stub with just what the handler reads. */
+  const makeEvent = (dragData: unknown, overId: string | null): DragEndEvent =>
+    ({
+      active: { data: { current: dragData }, id: 'active' },
+      over: overId ? { id: overId } : null,
+    } as unknown as DragEndEvent);
+
+  describe('createActualDragEndHandler - item slot routing', () => {
+    it('item drop 이 정확한 슬롯을 교체한다', () => {
+      const unitA: PlacedUnit = {
+        championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+        items: ['TFT_Item_BFSword', 'TFT_Item_RecurveBow', undefined],
+      };
+      let player: PlacedUnit[] = [unitA];
+      const ctx: ActualDndContext = {
+        round: makeRound(player),
+        roundIndex: 0,
+        updatePlayerTeam: (_i, patch) => { player = patch.units; },
+        updateOpponent: () => {},
+      };
+      const handler = createActualDragEndHandler(() => ctx);
+      handler(makeEvent(
+        { type: 'item', item: { apiName: 'TFT_Item_Rabadon' } },
+        'item-slot-player-0-3-0',
+      ));
+      expect(player[0].items).toEqual(['TFT_Item_Rabadon', 'TFT_Item_RecurveBow', undefined]);
+    });
+
+    it('item drop 이 지정된 빈 슬롯을 채운다', () => {
+      const unitA: PlacedUnit = {
+        championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+        items: ['TFT_Item_BFSword', undefined, undefined],
+      };
+      let player: PlacedUnit[] = [unitA];
+      const ctx: ActualDndContext = {
+        round: makeRound(player),
+        roundIndex: 0,
+        updatePlayerTeam: (_i, patch) => { player = patch.units; },
+        updateOpponent: () => {},
+      };
+      const handler = createActualDragEndHandler(() => ctx);
+      handler(makeEvent(
+        { type: 'item', item: { apiName: 'TFT_Item_Rabadon' } },
+        'item-slot-player-0-3-2',
+      ));
+      expect(player[0].items).toEqual(['TFT_Item_BFSword', undefined, 'TFT_Item_Rabadon']);
+    });
+
+    it('item drop 이 헥스 본체 (cell-*) 에서는 기존 자동 채움 동작 유지', () => {
+      const unitA: PlacedUnit = {
+        championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+        items: [undefined, undefined, undefined],
+      };
+      let player: PlacedUnit[] = [unitA];
+      const ctx: ActualDndContext = {
+        round: makeRound(player),
+        roundIndex: 0,
+        updatePlayerTeam: (_i, patch) => { player = patch.units; },
+        updateOpponent: () => {},
+      };
+      const handler = createActualDragEndHandler(() => ctx);
+      // cell id: player 팀은 row 4-7, q=0,r=3 → dataRow=3, col=q+floor(r/2)=0+1=1, display row=4+3=7
+      handler(makeEvent(
+        { type: 'item', item: { apiName: 'TFT_Item_Rabadon' } },
+        'cell-7-1',
+      ));
+      expect(player[0].items).toEqual(['TFT_Item_Rabadon', undefined, undefined]);
+    });
+  });
+
+  describe('createActualDragEndHandler - remove-all tool', () => {
+    it('점유된 헥스(cell) 위에 drop 하면 3칸 모두 비운다', () => {
+      const unitA: PlacedUnit = {
+        championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+        items: ['TFT_Item_BFSword', 'TFT_Item_RecurveBow', 'TFT_Item_Rabadon'],
+      };
+      let player: PlacedUnit[] = [unitA];
+      const ctx: ActualDndContext = {
+        round: makeRound(player),
+        roundIndex: 0,
+        updatePlayerTeam: (_i, patch) => { player = patch.units; },
+        updateOpponent: () => {},
+      };
+      const handler = createActualDragEndHandler(() => ctx);
+      handler(makeEvent({ type: 'tool', toolKind: 'remove-all' }, 'cell-7-1'));
+      expect(player[0].items).toEqual([undefined, undefined, undefined]);
+    });
+
+    it('점유된 유닛의 슬롯 위에 drop 해도 3칸 모두 비운다', () => {
+      const unitA: PlacedUnit = {
+        championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+        items: ['TFT_Item_BFSword', 'TFT_Item_RecurveBow', undefined],
+      };
+      let player: PlacedUnit[] = [unitA];
+      const ctx: ActualDndContext = {
+        round: makeRound(player),
+        roundIndex: 0,
+        updatePlayerTeam: (_i, patch) => { player = patch.units; },
+        updateOpponent: () => {},
+      };
+      const handler = createActualDragEndHandler(() => ctx);
+      handler(makeEvent({ type: 'tool', toolKind: 'remove-all' }, 'item-slot-player-0-3-1'));
+      expect(player[0].items).toEqual([undefined, undefined, undefined]);
+    });
+
+    it('빈 헥스에 drop 하면 아무 변화 없음', () => {
+      let player: PlacedUnit[] = [];
+      const ctx: ActualDndContext = {
+        round: makeRound(player),
+        roundIndex: 0,
+        updatePlayerTeam: (_i, patch) => { player = patch.units; },
+        updateOpponent: () => {},
+      };
+      const handler = createActualDragEndHandler(() => ctx);
+      handler(makeEvent({ type: 'tool', toolKind: 'remove-all' }, 'cell-7-1'));
+      expect(player).toEqual([]);
+    });
+  });
+  ```
+
+- [ ] **Step 2: 테스트 실행해서 실패 확인**
+
+  ```bash
+  pnpm test tests/unit/actualData/actualDndHandlers.test.ts
+  ```
+  Expected: 새로 추가한 5개 케이스 모두 FAIL (슬롯 라우팅/툴 미구현).
+
+- [ ] **Step 3: `createActualDragEndHandler` 내부 라우팅 수정**
+
+  `src/components/actual-data/actualDndHandlers.ts`의 `createActualDragEndHandler` 본체를 아래로 교체 (기존 `parseCellId` 호출부부터 함수 끝까지):
+
+  ```ts
+  export function createActualDragEndHandler(ctx: () => ActualDndContext | null) {
+    return (event: DragEndEvent) => {
+      const context = ctx();
+      if (!context) return;
+      const { round, roundIndex, updatePlayerTeam, updateOpponent } = context;
+
+      const { active, over } = event;
+      const dragData = active.data.current as DragData | undefined;
+      if (!dragData) return;
+
+      // Drop outside any cell
+      if (!over) {
+        if (dragData.type === 'placed-unit') {
+          const srcTeam = dragData.team;
+          const srcUnits = srcTeam === 'player' ? round.playerTeam.units : round.opponent.units;
+          const srcIdx = findUnitIndexAt(srcUnits, dragData.position);
+          if (srcIdx < 0) return;
+          const nextUnits = srcUnits.filter((_, i) => i !== srcIdx);
+          if (srcTeam === 'player') updatePlayerTeam(roundIndex, { units: nextUnits });
+          else updateOpponent(roundIndex, { units: nextUnits });
+        }
+        return;
+      }
+
+      // Resolve target: item slot first, then hex cell.
+      const slotInfo = parseSlotId(over.id as string);
+      const cellInfo = slotInfo ? null : parseCellId(over.id as string);
+      if (!slotInfo && !cellInfo) return;
+
+      const destTeam: 'player' | 'enemy' = slotInfo ? slotInfo.team : getTeamFromRow(cellInfo!.row);
+      const destHex: HexCoord = slotInfo ? slotInfo.hex : cellToHex(cellInfo!.row, cellInfo!.col);
+      const destUnits = destTeam === 'player' ? round.playerTeam.units : round.opponent.units;
+      const setDest = (nextUnits: PlacedUnit[]) => {
+        if (destTeam === 'player') updatePlayerTeam(roundIndex, { units: nextUnits });
+        else updateOpponent(roundIndex, { units: nextUnits });
+      };
+      const existingDestIdx = findUnitIndexAt(destUnits, destHex);
+
+      // Tool: remove-all — clears all items on the target unit.
+      if (dragData.type === 'tool' && dragData.toolKind === 'remove-all') {
+        if (existingDestIdx < 0) return;
+        const cleared = clearUnitItems(destUnits[existingDestIdx]);
+        setDest(destUnits.map((u, i) => (i === existingDestIdx ? cleared : u)));
+        return;
+      }
+
+      // Champion drop (sidebar → empty hex only). Slot drops are ignored for champion type.
+      if (dragData.type === 'champion') {
+        if (slotInfo) return;
+        if (existingDestIdx >= 0) return;
+        const newUnit: PlacedUnit = {
+          championId: dragData.champion.apiName,
+          hex: destHex,
+          starLevel: 2,
+          items: [undefined, undefined, undefined],
+        };
+        setDest([...destUnits, newUnit]);
+        return;
+      }
+
+      // Placed unit drag — movement only on hex cells, not item slots.
+      if (dragData.type === 'placed-unit') {
+        if (slotInfo) return;
+        const srcTeam = dragData.team;
+        const srcUnits = srcTeam === 'player' ? round.playerTeam.units : round.opponent.units;
+        const srcIdx = findUnitIndexAt(srcUnits, dragData.position);
+        if (srcIdx < 0) return;
+        const dragged = srcUnits[srcIdx];
+
+        if (srcTeam !== destTeam) {
+          if (existingDestIdx >= 0) return; // no cross-team swap
+          const nextSrc = srcUnits.filter((_, i) => i !== srcIdx);
+          const nextDest = [...destUnits, { ...dragged, hex: destHex }];
+          if (srcTeam === 'player') {
+            updatePlayerTeam(roundIndex, { units: nextSrc });
+            updateOpponent(roundIndex, { units: nextDest });
+          } else {
+            updateOpponent(roundIndex, { units: nextSrc });
+            updatePlayerTeam(roundIndex, { units: nextDest });
+          }
+          return;
+        }
+
+        // Same-team move / swap
+        if (existingDestIdx >= 0 && existingDestIdx !== srcIdx) {
+          const nextUnits = destUnits.map((u, i) => {
+            if (i === srcIdx) return { ...u, hex: destUnits[existingDestIdx].hex };
+            if (i === existingDestIdx) return { ...u, hex: destUnits[srcIdx].hex };
+            return u;
+          });
+          setDest(nextUnits);
+        } else if (existingDestIdx < 0) {
+          const nextUnits = destUnits.map((u, i) => (i === srcIdx ? { ...u, hex: destHex } : u));
+          setDest(nextUnits);
+        }
+        return;
+      }
+
+      // Item drop
+      if (dragData.type === 'item') {
+        if (existingDestIdx < 0) return;
+        const target = destUnits[existingDestIdx];
+        if (slotInfo) {
+          // Explicit slot → replace or fill that exact slot.
+          const updated = setItemAtSlot(target, dragData.item.apiName, slotInfo.slotIdx);
+          setDest(destUnits.map((u, i) => (i === existingDestIdx ? updated : u)));
+        } else {
+          // Hex body → first empty slot (legacy fast-attach).
+          const updated = setItemInSlot(target, dragData.item);
+          if (!updated) return;
+          setDest(destUnits.map((u, i) => (i === existingDestIdx ? updated : u)));
+        }
+      }
+    };
+  }
+  ```
+
+- [ ] **Step 4: 전체 테스트 통과 확인**
+
+  ```bash
+  pnpm test tests/unit/actualData/actualDndHandlers.test.ts
+  ```
+  Expected: 모든 케이스 PASS.
+
+- [ ] **Step 5: 기존 전체 테스트 회귀 확인**
+
+  ```bash
+  pnpm test
+  ```
+  Expected: 196+신규 케이스 모두 PASS.
+
+- [ ] **Step 6: 커밋**
+
+  ```bash
+  git add src/components/actual-data/actualDndHandlers.ts tests/unit/actualData/actualDndHandlers.test.ts
+  git commit -m "feat(actual-data): drop 라우팅에 슬롯 교체 + 자석 제거기 툴 분기 추가"
+  ```
+
+---
+
+## Task 4: ActualBoard에 슬롯 오버레이 (droppable + X 버튼)
+
+**Files:**
+- Modify: `src/components/actual-data/ActualBoard.tsx`
+
+- [ ] **Step 1: 신규 오버레이 서브컴포넌트 파일 만들기**
+
+  `PlacedChampion.items`는 `unitAdapter.toPlacedChampion` 단계에서 `undefined` 슬롯이 drop 되어 slot index 정보가 유실되므로, 오버레이는 **raw `PlacedUnit`** 을 받아야 한다.
+
+  `src/components/actual-data/ActualItemSlotsOverlay.tsx` 파일을 새로 만든다.
+
+  ```tsx
+  'use client';
+
+  import { useDroppable } from '@dnd-kit/core';
+  import { axialToOffset } from '@/types';
+  import { createHexLayout } from '@/components/battle/HexBoard';
+  import { BOARD_COLS } from '@/lib/simulator/models/constants';
+  import type { PlacedUnit } from '@/lib/actualData/types';
+
+  interface Props {
+    playerUnits: PlacedUnit[];
+    opponentUnits: PlacedUnit[];
+    cellSize: number;
+    onRemoveItem: (team: 'player' | 'enemy', hexKey: string, slotIdx: 0 | 1 | 2) => void;
+  }
+
+  const SLOT_SIZE = 18; // SetupBoardCore itemSize(16) + 2px padding
+  const SLOT_GAP = 2;
+
+  /**
+   * Overlays a droppable + click X button on each of the three item slots of every
+   * placed unit. Positioned to match SetupBoardCore's SVG item row exactly so the
+   * visual icon and the interactive zone overlap.
+   */
+  export default function ActualItemSlotsOverlay({ playerUnits, opponentUnits, cellSize, onRemoveItem }: Props) {
+    const { HEX_R, hexCenter } = createHexLayout(cellSize);
+    const entries: Array<{ team: 'player' | 'enemy'; u: PlacedUnit }> = [
+      ...opponentUnits.map(u => ({ team: 'enemy' as const, u })),
+      ...playerUnits.map(u => ({ team: 'player' as const, u })),
+    ];
+
+    return (
+      <>
+        {entries.map(({ team, u }) => {
+          const off = axialToOffset(u.hex);
+          const displayRow = team === 'player' ? off.row + 4 : off.row;
+          if (displayRow < 0 || displayRow > 7 || off.col < 0 || off.col >= BOARD_COLS) return null;
+          const { cx, cy } = hexCenter(displayRow, off.col);
+          const totalWidth = 3 * SLOT_SIZE + 2 * SLOT_GAP;
+          const startX = cx - totalWidth / 2;
+          const yCenter = cy + HEX_R - 12;
+
+          return [0, 1, 2].map((slotIdx) => {
+            const slotItemApi = u.items[slotIdx]; // string | null | undefined
+            const filled = !!slotItemApi;
+            const hexKey = `${u.hex.q},${u.hex.r}`;
+            const slotCenterX = startX + slotIdx * (SLOT_SIZE + SLOT_GAP) + SLOT_SIZE / 2;
+            return (
+              <SlotCell
+                key={`${team}-${hexKey}-${slotIdx}`}
+                team={team}
+                q={u.hex.q}
+                r={u.hex.r}
+                slotIdx={slotIdx as 0 | 1 | 2}
+                cx={slotCenterX}
+                cy={yCenter}
+                filled={filled}
+                onRemove={() => onRemoveItem(team, hexKey, slotIdx as 0 | 1 | 2)}
+              />
+            );
+          });
+        })}
+      </>
+    );
+  }
+
+  function SlotCell({ team, q, r, slotIdx, cx, cy, filled, onRemove }: {
+    team: 'player' | 'enemy';
+    q: number; r: number; slotIdx: 0 | 1 | 2;
+    cx: number; cy: number;
+    filled: boolean;
+    onRemove: () => void;
+  }) {
+    const id = `item-slot-${team}-${q}-${r}-${slotIdx}`;
+    const { isOver, setNodeRef } = useDroppable({ id });
+
+    return (
+      <div
+        ref={setNodeRef}
+        data-slot-id={id}
+        style={{
+          position: 'absolute',
+          left: cx - SLOT_SIZE / 2,
+          top: cy - SLOT_SIZE / 2,
+          width: SLOT_SIZE,
+          height: SLOT_SIZE,
+          pointerEvents: 'all',
+          // transparent outline that appears when a droppable hover occurs
+          outline: isOver ? '1.5px solid #fbbf24' : filled ? 'none' : '1px dashed rgba(156,163,175,0.35)',
+          borderRadius: 2,
+          boxSizing: 'border-box',
+          background: 'transparent',
+        }}
+        className="group"
+      >
+        {filled && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onRemove(); }}
+            aria-label={`슬롯 ${slotIdx + 1} 제거`}
+            className="absolute -top-1.5 -right-1.5 w-3.5 h-3.5 rounded-full bg-red-600 text-white text-[9px] leading-none flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+          >
+            ×
+          </button>
+        )}
+      </div>
+    );
+  }
+  ```
+
+- [ ] **Step 2: ActualBoard 에서 오버레이 사용**
+
+  `src/components/actual-data/ActualBoard.tsx`의 import 블록에 추가:
+  ```tsx
+  import ActualItemSlotsOverlay from './ActualItemSlotsOverlay';
+  import { clearUnitItems as _clear } from './actualDndHandlers'; // unused; remove if imported elsewhere
+  ```
+  (주: 두 번째 줄은 실제론 필요 없으면 넣지 말 것. clearUnitItems 는 이 파일에서 직접 쓰지 않음.)
+
+  `ActualBoard` 함수 안에 슬롯 제거 핸들러 추가 (기존 `handleRemoveUnit` 바로 아래, 57-67줄 부근):
+
+  ```tsx
+  /** Clear a single item slot on a unit at the given hex. */
+  const handleRemoveItemSlot = (team: 'player' | 'enemy', hexKey: string, slotIdx: 0 | 1 | 2) => {
+    const units = team === 'player' ? round.playerTeam.units : round.opponent.units;
+    const unitIdx = units.findIndex(u => `${u.hex.q},${u.hex.r}` === hexKey);
+    if (unitIdx < 0) return;
+    const target = units[unitIdx];
+    const nextItems = [...target.items] as PlacedUnit['items'];
+    nextItems[slotIdx] = undefined;
+    const nextUnits = units.map((u, i) => (i === unitIdx ? { ...u, items: nextItems } : u));
+    if (team === 'player') updatePlayerTeam(roundIndex, { units: nextUnits });
+    else updateOpponent(roundIndex, { units: nextUnits });
+  };
+  ```
+
+  `return (...)` 안 `<SetupBoardCore ... />` 바로 다음, 기존 droppable 오버레이 `<div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>...</div>` 블록 **다음에** 아래 두 번째 오버레이를 추가:
+
+  ```tsx
+        {/* Item slot overlay — placed on top so slot droppables win pointer events over the hex cell. */}
+        <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+          <ActualItemSlotsOverlay
+            playerUnits={round.playerTeam.units}
+            opponentUnits={round.opponent.units}
+            cellSize={cellSize}
+            onRemoveItem={handleRemoveItemSlot}
+          />
+        </div>
+  ```
+
+- [ ] **Step 3: 타입/린트 확인**
+
+  ```bash
+  pnpm typecheck && pnpm lint
+  ```
+  Expected: 에러 없음. `clearUnitItems` 잘못 import 했으면 지우기. `PlacedUnit` import 가 아직 없으면 기존 import 라인에 추가.
+
+- [ ] **Step 4: 개발 서버에서 수동 확인**
+
+  `pnpm dev` 상태에서 브라우저로 `/actual-data/<gameId>` 편집 페이지 열어서:
+  - 유닛 아래 3개 슬롯 영역에 (아이템 있을 때) 빨간 × 버튼 hover로 나타나는지
+  - × 클릭 시 해당 슬롯만 비워지고 다른 슬롯은 그대로인지
+
+- [ ] **Step 5: 커밋**
+
+  ```bash
+  git add src/components/actual-data/ActualItemSlotsOverlay.tsx src/components/actual-data/ActualBoard.tsx
+  git commit -m "feat(actual-data): 슬롯 단위 droppable 오버레이 + hover X 제거 버튼"
+  ```
+
+---
+
+## Task 5: DndContext collisionDetection 조정
+
+**Files:**
+- Modify: `src/components/actual-data/PvPRoundEditor.tsx`
+
+- [ ] **Step 1: collisionDetection 확인**
+
+  현재 `src/components/actual-data/PvPRoundEditor.tsx:79-89`의 `<DndContext>` 에는 `collisionDetection` prop 이 없음 → @dnd-kit 기본 `rectIntersection` 사용. 이 전략은 큰 헥스 droppable 이 작은 슬롯 droppable 을 덮을 때 헥스를 이기게 해서 슬롯 drop 이 잘 안 걸림.
+
+- [ ] **Step 2: `pointerWithin` → `rectIntersection` fallback 적용**
+
+  `src/components/actual-data/PvPRoundEditor.tsx` import 블록에서 `@dnd-kit/core` 라인에 아래 2개 추가 import:
+  ```tsx
+  import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors, pointerWithin, rectIntersection, type CollisionDetection } from '@dnd-kit/core';
+  ```
+
+  컴포넌트 함수 안(예: `const sensors = useSensors(...)` 아래)에 collision detection 함수 정의:
+
+  ```tsx
+  // pointerWithin 으로 작은 슬롯 drop 을 우선 매칭하고, 포인터가 헥스 밖으로 살짝 벗어나면
+  // rectIntersection 으로 fallback 해 기존 헥스 본체 drop 을 잃지 않는다.
+  const collisionDetection: CollisionDetection = (args) => {
+    const pointerHits = pointerWithin(args);
+    if (pointerHits.length > 0) return pointerHits;
+    return rectIntersection(args);
+  };
+  ```
+
+  `<DndContext sensors={sensors} ...>` 에 prop 추가:
+  ```tsx
+  <DndContext
+    sensors={sensors}
+    collisionDetection={collisionDetection}
+    onDragStart={...}
+    ...
+  ```
+
+- [ ] **Step 3: 타입체크 + 기존 유닛 드래그 회귀 없는지 수동 확인**
+
+  ```bash
+  pnpm typecheck
+  ```
+  수동: `pnpm dev`에서 유닛 드래그 이동 / 아이템 드래그로 빈 헥스 본체에 드롭 / 슬롯 위 드롭 모두 정상 동작.
+
+- [ ] **Step 4: 커밋**
+
+  ```bash
+  git add src/components/actual-data/PvPRoundEditor.tsx
+  git commit -m "feat(actual-data): DndContext collisionDetection을 pointerWithin+fallback으로 교체 (슬롯 drop 우선)"
+  ```
+
+---
+
+## Task 6: 사이드바 "도구" 탭 + 자석 제거기 드래그 소스
+
+**Files:**
+- Create: `src/components/actual-data/DraggableItemRemoverTool.tsx`
+- Modify: `src/components/actual-data/ChampionItemSidebar.tsx`
+
+- [ ] **Step 1: 드래그 가능한 툴 컴포넌트 생성**
+
+  `src/components/actual-data/DraggableItemRemoverTool.tsx` 파일 새로 만든다:
+  ```tsx
+  'use client';
+
+  import { useDraggable } from '@dnd-kit/core';
+  import type { DragData } from '@/types';
+
+  const ICON_SRC = '/data/images/items/tft_consumable_itemremover.tft_set13.png';
+
+  /**
+   * Drag source for the "자석 제거기" tool. Drop onto a placed unit (hex or slot)
+   * clears all three item slots via the `{ type: 'tool', toolKind: 'remove-all' }`
+   * branch in createActualDragEndHandler.
+   */
+  export default function DraggableItemRemoverTool({ size = 44 }: { size?: number }) {
+    const data: DragData = { type: 'tool', toolKind: 'remove-all' };
+    const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+      id: 'tool-remove-all',
+      data,
+    });
+
+    return (
+      <div
+        ref={setNodeRef}
+        {...listeners}
+        {...attributes}
+        style={{ width: size, height: size, opacity: isDragging ? 0.4 : 1, touchAction: 'none' }}
+        className="relative cursor-grab active:cursor-grabbing rounded border border-gray-700 bg-[#1f2937] hover:border-red-500 hover:bg-red-900/30 transition-colors flex items-center justify-center overflow-hidden"
+        title="자석 제거기 — 유닛 위에 드롭하면 아이템 3칸 모두 제거"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={ICON_SRC} alt="자석 제거기" width={size - 4} height={size - 4} draggable={false} />
+      </div>
+    );
+  }
+  ```
+
+- [ ] **Step 2: 사이드바에 "도구" 탭 추가**
+
+  `src/components/actual-data/ChampionItemSidebar.tsx` 상단 타입 라인 수정:
+  ```tsx
+  type Tab = 'champions' | 'items' | 'tools';
+  ```
+
+  import 추가:
+  ```tsx
+  import DraggableItemRemoverTool from './DraggableItemRemoverTool';
+  ```
+
+  탭 버튼 그룹(33-49줄)에 "도구" 버튼 한 개 추가 (아이템 버튼 뒤에):
+  ```tsx
+  <button
+    type="button"
+    className={`px-2 py-1 rounded ${tab === 'tools' ? 'bg-[#8b5cf6] text-white' : 'bg-[#1f2937] text-gray-400 hover:text-gray-200'}`}
+    onClick={() => setTab('tools')}
+  >
+    도구
+  </button>
+  ```
+
+  섹션 렌더 블록(52-56줄)을 다음으로 교체:
+  ```tsx
+  <div className="flex-1 overflow-hidden">
+    {tab === 'champions' && <ChampionSection champions={champions} onChampionClick={onChampionClick} />}
+    {tab === 'items' && <ItemSection items={items} onItemClick={onItemClick} />}
+    {tab === 'tools' && <ToolsSection />}
+  </div>
+  ```
+
+  파일 맨 아래(혹은 `ItemSection` 정의 아래)에 `ToolsSection` 추가:
+  ```tsx
+  function ToolsSection() {
+    return (
+      <div className="flex flex-col h-full p-2 space-y-3">
+        <p className="text-[11px] text-gray-400 leading-relaxed">
+          유닛 위로 드래그해서 사용합니다.
+        </p>
+        <div className="grid grid-cols-5 gap-1.5">
+          <DraggableItemRemoverTool size={44} />
+        </div>
+      </div>
+    );
+  }
+  ```
+
+- [ ] **Step 3: 린트 + 타입체크**
+
+  ```bash
+  pnpm lint && pnpm typecheck
+  ```
+  Expected: 에러 없음. `<img>` 관련 `@next/next/no-img-element` 경고는 이미 전역적으로 존재하는 수준. 신규 파일도 동일한 inline disable 처리(이미 포함).
+
+- [ ] **Step 4: 수동 확인**
+
+  브라우저에서 사이드바 "도구" 탭 클릭 → 자석 제거기 아이콘 보임 → 드래그해서 유닛 위에 드롭 → 3칸 모두 비워지는지.
+
+- [ ] **Step 5: 커밋**
+
+  ```bash
+  git add src/components/actual-data/DraggableItemRemoverTool.tsx src/components/actual-data/ChampionItemSidebar.tsx
+  git commit -m "feat(actual-data): 사이드바 '도구' 탭 + 자석 제거기 드래그 소스"
+  ```
+
+---
+
+## Task 7: 전체 검증 + 최종 커밋
+
+**Files:** 없음 (검증만)
+
+- [ ] **Step 1: 전체 빌드/테스트 스위트 실행**
+
+  ```bash
+  pnpm lint && pnpm typecheck && pnpm build && pnpm test
+  ```
+  Expected: lint 0 errors (사전 존재 warning 유지), typecheck 통과, build 성공, test 전부 PASS.
+
+- [ ] **Step 2: 수동 회귀 체크리스트**
+
+  `pnpm dev` 상태에서 `/actual-data/<gameId>` 열고 모든 인터랙션 1회씩 확인:
+  - [ ] 유닛 슬롯(채워진 것) hover → × 버튼 노출
+  - [ ] × 클릭 → 해당 슬롯만 비워지고 다른 슬롯은 그대로 (재정렬 없음)
+  - [ ] 아이템 사이드바에서 드래그 → 채워진 슬롯 위에 drop → 교체
+  - [ ] 아이템 드래그 → 빈 슬롯 위에 drop → 해당 슬롯 채움
+  - [ ] 아이템 드래그 → 챔프 아이콘(슬롯 바깥) 위에 drop → 첫 빈 슬롯 자동 채움 (기존 UX)
+  - [ ] 아이템 3칸 다 찬 유닛의 챔프 아이콘 위에 drop → 변화 없음
+  - [ ] 자석 제거기 드래그 → 유닛 위 drop → 3칸 전부 undefined
+  - [ ] 자석 제거기 드래그 → 빈 헥스 drop → 변화 없음
+  - [ ] 플레이어팀과 상대팀 모두 동일하게 작동
+  - [ ] 유닛 자체 드래그 이동 / 삭제 등 기존 UX 회귀 없음
+  - [ ] 저장(수동 또는 자동) 후 새로고침 → 슬롯 상태 유지
+
+- [ ] **Step 3: 문제 없으면 체크리스트 통과 커밋 불필요 (이전 단계 커밋으로 완결)**
+
+  체크리스트가 전부 OK 면 최종 PR/머지 단계로. 실패 항목 있으면 해당 Task 로 돌아가 수정 후 재검증.
+
+---
+
+## 참고
+
+- 공식 spec: `docs/superpowers/specs/2026-04-24-item-edit-ux-design.md`
+- 기반 브랜치: `dev` (PR #10 머지로 영상 업로드 기능 포함됨)
+- 새 작업은 새로운 feature 브랜치(예: `feature/item-edit-ux`)에서 시작 권장
+- 테스트 원칙: drop handler 같은 순수 로직은 vitest 단위 테스트, DnD/UI 상호작용은 수동 체크리스트

--- a/docs/superpowers/specs/2026-04-24-item-edit-ux-design.md
+++ b/docs/superpowers/specs/2026-04-24-item-edit-ux-design.md
@@ -1,0 +1,153 @@
+# actual-data 아이템 편집 UX 개선 설계
+
+> **상태**: Design 단계 — 브레인스토밍 완료, 구현 플랜 작성 대기
+> **작성일**: 2026-04-24
+> **선행 문서**: `docs/superpowers/specs/2026-04-23-actual-data-design.md` (actual-data 전체 설계)
+> **대상**: `/actual-data/[gameId]` 편집 페이지 (Sub-project 1 Core가 이미 구현된 상태)
+
+## 1. 배경과 문제
+
+`/actual-data` 편집기에서 보드에 챔피언을 배치하고 아이템을 장착할 수 있지만, **장착된 아이템을 개별적으로 제거하거나 교체하는 수단이 없다**. 현재 흐름은:
+
+1. 잘못 장착된 아이템이 있는 유닛을 **삭제**(보드 밖으로 드래그)
+2. 해당 챔피언을 사이드바에서 다시 드래그
+3. 별 레벨/위치 재설정
+4. 나머지 올바른 아이템 2개 재장착
+5. 새 아이템 장착
+
+이 흐름은 1개 아이템 수정에 5단계가 필요해 ground truth 수집 속도를 크게 떨어뜨린다.
+
+## 2. 목표
+
+- **개별 슬롯 제거**: 1슬롯만 비우기 — O(1) 조작
+- **아이템 교체**: A → B 로 바꾸기 — O(1) 조작
+- **전체 초기화**: 한 유닛의 3슬롯을 한 번에 비우기 — O(1) 조작
+- 기존 "빈 헥스에 아이템 드롭 시 첫 빈 슬롯 자동 채움" UX는 **유지**
+
+## 3. 비목표 (Non-goals)
+
+- 모바일 터치 최적화: 일단 데스크톱 우선. 필요 시 후속 작업.
+- 아이템 이동(A유닛 → B유닛): 본 설계 대상 아님. 현재처럼 제거 후 재장착.
+- 아이템 재조합기(Reforger) 같은 무작위화: 에디터 맥락에 맞지 않아 제외.
+- Undo/Redo: 본 설계 대상 아님.
+
+## 4. UX 설계
+
+### 4.1 개별 슬롯 X 버튼 (정밀 제거)
+
+- 보드 위 유닛 토큰 하단의 아이템 슬롯 3칸 중 **채워진 슬롯**에 hover 시 우상단에 `×` 버튼 노출
+- `×` 클릭 → 해당 슬롯만 `undefined`로 설정 (다른 슬롯 위치·내용 유지, **재정렬 없음**)
+- 비어있는 슬롯에는 `×` 미노출
+- 접근성: `aria-label="{아이템 이름} 제거"`, 키보드 포커스 가능
+
+### 4.2 드래그 교체 (A → B)
+
+- 현재 동작:
+  - `type: 'item'` 드래그 → 점유된 헥스에 drop → 첫 빈 슬롯 자동 채움 → 빈 슬롯 없으면 drop 무시
+- 변경:
+  - 기존 헥스 레벨 droppable은 그대로 두고, 유닛 토큰 하단의 **아이템 슬롯 UI 3칸 각각을 중첩 droppable**로 추가 등록
+  - DnD 라이브러리(@dnd-kit) 특성상 마우스 커서가 슬롯 위에 있으면 슬롯 droppable이 우선 매칭되고, 슬롯 바깥(챔프 아이콘/헥스 여백)에 있으면 헥스 droppable이 매칭됨
+  - 드롭 지점별 동작:
+    | 드롭 위치 | 기존 슬롯 상태 | 동작 |
+    |---|---|---|
+    | 특정 슬롯 UI 영역(`slotIdx`) | 채워짐 | **교체** (해당 slotIdx 덮어씀) |
+    | 특정 슬롯 UI 영역(`slotIdx`) | 비어있음 | 해당 slotIdx 채움 |
+    | 슬롯 바깥 (챔프 아이콘/헥스 여백) | — | 기존 동작: 첫 빈 슬롯 자동 채움. 3칸 다 차있으면 drop 무시 |
+- 슬롯 바깥 드롭 시 자동 채움을 유지하는 이유: 빠른 장착 흐름(아이템 드래그 → 유닛 위 대략 드롭) 보존
+- 유닛이 없는 빈 헥스: 슬롯 자체가 없으므로 자동으로 기존 "챔프 없으면 drop 무시" 규칙 적용
+
+### 4.3 자석 제거기 툴 (전체 초기화)
+
+- `ChampionItemSidebar`의 탭 하단에 고정 노출되는 **Tools** 섹션 신설
+- 현재 툴 1개: **자석 제거기** (`TFT_Consumable_ItemRemover`)
+  - 아이콘: `public/data/images/items/tft_consumable_itemremover.tft_set13.png` (이미 리포 포함)
+  - 이름 툴팁: "자석 제거기 — 유닛 위에 드롭하면 아이템 3칸 모두 제거"
+- 드래그 타입: `type: 'tool', toolKind: 'remove-all'`
+- 점유된 헥스에 drop → `items = [undefined, undefined, undefined]`로 초기화
+- 빈 헥스 또는 보드 밖 drop → 무시 (사라지지 않음)
+
+### 4.4 요약 Matrix
+
+| 작업 | 조작 | 결과 |
+|---|---|---|
+| 슬롯 1개 비우기 | 슬롯 hover → `×` 클릭 | 해당 슬롯만 `undefined` |
+| A→B 교체 | 새 아이템을 해당 슬롯 위에 드롭 | 해당 슬롯 덮어씀 |
+| 3칸 초기화 | 자석 제거기를 유닛 위에 드롭 | 3칸 모두 `undefined` |
+| 빠른 장착 | 아이템을 헥스 본체(슬롯 외)에 드롭 | 첫 빈 슬롯 자동 채움 (기존) |
+
+## 5. 구현 변경 지점
+
+### 5.1 DragData 타입 확장
+파일: `src/components/actual-data/actualDndHandlers.ts` (또는 타입 정의 위치)
+
+```ts
+type DragData =
+  | { type: 'champion'; champion: RawChampion }
+  | { type: 'placed-unit'; team: 'player' | 'opponent'; position: HexCoord }
+  | { type: 'item'; item: RawItem }
+  | { type: 'tool'; toolKind: 'remove-all' };  // NEW
+```
+
+Drop target ID도 확장:
+- 기존: `cell-{row}-{col}`
+- 신규 추가: `item-slot-{team}-{q}-{r}-{slotIdx}` — 유닛의 개별 아이템 슬롯
+
+`parseCellId`와 유사한 `parseSlotId(id) → { team, hex, slotIdx } | null` 추가.
+
+### 5.2 보드 유닛 토큰 렌더
+파일: `src/components/actual-data/ActualBoard.tsx` (또는 토큰 렌더 컴포넌트)
+
+- 각 아이템 슬롯을 `useDroppable({ id: 'item-slot-...' })` 지정
+- 채워진 슬롯에 hover hover 상태 → `×` 버튼 렌더
+  - 위치: 슬롯 우상단, 작은 원형 버튼
+  - 클릭 시 `onRemoveSlot(slotIdx)` 호출
+- `onRemoveSlot` 로직: `units[unitIdx].items[slotIdx] = undefined` 패치 후 `updatePlayerTeam/updateOpponent` 호출
+
+### 5.3 actualDndHandlers.ts drop 로직 분기
+- drop target ID를 `parseCellId` / `parseSlotId` 순으로 시도
+- `item-slot-*`에 drop 시: 해당 유닛·슬롯 특정 → 교체/채움
+- `cell-*`에 drop 시: 기존 동작 유지 (헥스 본체 자동 채움, 챔프/유닛 이동 등)
+- `tool: remove-all` drop:
+  - target이 `item-slot-*` 또는 `cell-*` 중 점유된 헥스 → 해당 유닛 3칸 초기화
+  - 빈 헥스 / 보드 밖 → no-op
+
+### 5.4 사이드바 Tools 섹션
+파일: `src/components/actual-data/ChampionItemSidebar.tsx`
+
+- 탭 헤더 하단(모든 탭에서 공통 노출) 혹은 별도 `tools` 탭 — 후자가 깔끔
+- 현재 탭 state를 `'champions' | 'items' | 'tools'`로 확장
+- Tools 섹션: 자석 제거기 1개 렌더, `useDraggable({ id: 'tool-remove-all', data: { type: 'tool', toolKind: 'remove-all' } })`
+- 아이콘 경로: `/data/images/items/tft_consumable_itemremover.tft_set13.png`
+
+### 5.5 변경 파일 목록
+
+| 파일 | 변경 요지 |
+|---|---|
+| `src/components/actual-data/actualDndHandlers.ts` | DragData union 확장, parseSlotId 추가, item/tool drop 분기 |
+| `src/components/actual-data/ActualBoard.tsx` | 아이템 슬롯 개별 droppable + hover `×` 버튼 |
+| `src/components/actual-data/ChampionItemSidebar.tsx` | Tools 탭/섹션 추가 (자석 제거기) |
+| `src/components/actual-data/OpponentPanel.tsx` | (상대팀도 동일 처리 필요하면 연동) |
+
+## 6. 데이터 모델 영향
+
+없음. `PlacedUnit.items: [slot0, slot1, slot2]` 구조 그대로 사용. `undefined` 슬롯은 이미 JSON 직렬화 시 `null`로 저장되는 기존 규약 유지.
+
+## 7. 검증
+
+- 기존 테스트 스위트(196 pass) 유지되는지 확인
+- 수동 확인 항목:
+  1. 1/2/3번 슬롯 각각 X 클릭 시 해당 슬롯만 제거되는가 (재정렬 없이)
+  2. 점유된 슬롯에 새 아이템 드롭 시 교체되는가
+  3. 빈 슬롯에 드롭 시 해당 슬롯 채움
+  4. 헥스 본체(슬롯 외)에 드롭 시 기존처럼 첫 빈 슬롯 자동 채움
+  5. 자석 제거기를 유닛 위에 드롭 시 3칸 모두 초기화
+  6. 자석 제거기를 빈 헥스 드롭 시 아무 일도 일어나지 않음
+  7. 플레이어팀/상대팀 양쪽 모두 동일하게 동작
+  8. 저장/재로드 후 슬롯 상태 유지
+
+## 8. 오픈 이슈 / 후속 작업
+
+- 모바일/태블릿 터치 UX: `×` 버튼을 항상 노출 또는 long-press 확인 팝업
+- 키보드 단축키 (1/2/3으로 선택 유닛 슬롯 비우기): 파워 유저용, 필요 시
+- 아이템 이동(유닛 간 drag): 현재 범위 제외
+- 재조합기(Reforger) 툴: 에디터에 적합한 사용처가 떠오르면 Tools 섹션에 추가

--- a/src/components/actual-data/ActualBoard.tsx
+++ b/src/components/actual-data/ActualBoard.tsx
@@ -9,6 +9,7 @@ import DroppableHexCell from '@/components/battle/DroppableHexCell';
 import { useActualDataStore } from '@/store/actualDataSlice';
 import { toPlacedChampion } from '@/lib/actualData/unitAdapter';
 import type { PlacedUnit, TeamSnapshot, OpponentSnapshot } from '@/lib/actualData/types';
+import ActualItemSlotsOverlay from './ActualItemSlotsOverlay';
 
 interface ActualBoardProps {
   roundIndex: number;
@@ -64,6 +65,19 @@ export default function ActualBoard({ roundIndex, champions, items, cellSize = 4
       const nextUnits = round.opponent.units.filter((_, i) => i !== index);
       updateOpponent(roundIndex, { units: nextUnits });
     }
+  };
+
+  /** Clear a single item slot on a unit at the given hex. */
+  const handleRemoveItemSlot = (team: 'player' | 'enemy', hexKey: string, slotIdx: 0 | 1 | 2) => {
+    const units = team === 'player' ? round.playerTeam.units : round.opponent.units;
+    const unitIdx = units.findIndex(u => `${u.hex.q},${u.hex.r}` === hexKey);
+    if (unitIdx < 0) return;
+    const target = units[unitIdx];
+    const nextItems = [...target.items] as PlacedUnit['items'];
+    nextItems[slotIdx] = undefined;
+    const nextUnits = units.map((u, i) => (i === unitIdx ? { ...u, items: nextItems } : u));
+    if (team === 'player') updatePlayerTeam(roundIndex, { units: nextUnits });
+    else updateOpponent(roundIndex, { units: nextUnits });
   };
 
   /** 1★ → 2★ → 3★ → 1★ cycle on unit click (matches /simulator). */
@@ -127,6 +141,16 @@ export default function ActualBoard({ roundIndex, champions, items, cellSize = 4
             );
           })
         )}
+      </div>
+
+      {/* Item slot overlay — placed on top so slot droppables win pointer events over the hex cell. */}
+      <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+        <ActualItemSlotsOverlay
+          playerUnits={round.playerTeam.units}
+          opponentUnits={round.opponent.units}
+          cellSize={cellSize}
+          onRemoveItem={handleRemoveItemSlot}
+        />
       </div>
     </div>
   );

--- a/src/components/actual-data/ActualItemSlotsOverlay.tsx
+++ b/src/components/actual-data/ActualItemSlotsOverlay.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useDroppable } from '@dnd-kit/core';
+import { axialToOffset } from '@/types';
+import { createHexLayout } from '@/components/battle/HexBoard';
+import { BOARD_COLS } from '@/lib/simulator/models/constants';
+import type { PlacedUnit } from '@/lib/actualData/types';
+
+interface Props {
+  playerUnits: PlacedUnit[];
+  opponentUnits: PlacedUnit[];
+  cellSize: number;
+  onRemoveItem: (team: 'player' | 'enemy', hexKey: string, slotIdx: 0 | 1 | 2) => void;
+}
+
+const SLOT_SIZE = 18; // SetupBoardCore itemSize(16) + 2px padding
+const SLOT_GAP = 2;
+
+/**
+ * Overlays a droppable + click X button on each of the three item slots of every
+ * placed unit. Positioned to match SetupBoardCore's SVG item row exactly so the
+ * visual icon and the interactive zone overlap.
+ */
+export default function ActualItemSlotsOverlay({ playerUnits, opponentUnits, cellSize, onRemoveItem }: Props) {
+  const { HEX_R, hexCenter } = createHexLayout(cellSize);
+  const entries: Array<{ team: 'player' | 'enemy'; u: PlacedUnit }> = [
+    ...opponentUnits.map(u => ({ team: 'enemy' as const, u })),
+    ...playerUnits.map(u => ({ team: 'player' as const, u })),
+  ];
+
+  return (
+    <>
+      {entries.map(({ team, u }) => {
+        const off = axialToOffset(u.hex);
+        const displayRow = team === 'player' ? off.row + 4 : off.row;
+        if (displayRow < 0 || displayRow > 7 || off.col < 0 || off.col >= BOARD_COLS) return null;
+        const { cx, cy } = hexCenter(displayRow, off.col);
+        const totalWidth = 3 * SLOT_SIZE + 2 * SLOT_GAP;
+        const startX = cx - totalWidth / 2;
+        const yCenter = cy + HEX_R - 12;
+
+        return [0, 1, 2].map((slotIdx) => {
+          const slotItemApi = u.items[slotIdx]; // string | null | undefined
+          const filled = !!slotItemApi;
+          const hexKey = `${u.hex.q},${u.hex.r}`;
+          const slotCenterX = startX + slotIdx * (SLOT_SIZE + SLOT_GAP) + SLOT_SIZE / 2;
+          return (
+            <SlotCell
+              key={`${team}-${hexKey}-${slotIdx}`}
+              team={team}
+              q={u.hex.q}
+              r={u.hex.r}
+              slotIdx={slotIdx as 0 | 1 | 2}
+              cx={slotCenterX}
+              cy={yCenter}
+              filled={filled}
+              onRemove={() => onRemoveItem(team, hexKey, slotIdx as 0 | 1 | 2)}
+            />
+          );
+        });
+      })}
+    </>
+  );
+}
+
+function SlotCell({ team, q, r, slotIdx, cx, cy, filled, onRemove }: {
+  team: 'player' | 'enemy';
+  q: number; r: number; slotIdx: 0 | 1 | 2;
+  cx: number; cy: number;
+  filled: boolean;
+  onRemove: () => void;
+}) {
+  const id = `item-slot-${team}-${q}-${r}-${slotIdx}`;
+  const { isOver, setNodeRef } = useDroppable({ id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-slot-id={id}
+      style={{
+        position: 'absolute',
+        left: cx - SLOT_SIZE / 2,
+        top: cy - SLOT_SIZE / 2,
+        width: SLOT_SIZE,
+        height: SLOT_SIZE,
+        pointerEvents: 'all',
+        // transparent outline that appears when a droppable hover occurs
+        outline: isOver ? '1.5px solid #fbbf24' : filled ? 'none' : '1px dashed rgba(156,163,175,0.35)',
+        borderRadius: 2,
+        boxSizing: 'border-box',
+        background: 'transparent',
+      }}
+      className="group"
+    >
+      {filled && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onRemove(); }}
+          aria-label={`슬롯 ${slotIdx + 1} 제거`}
+          className="absolute -top-1.5 -right-1.5 w-3.5 h-3.5 rounded-full bg-red-600 text-white text-[9px] leading-none flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/actual-data/ChampionItemSidebar.tsx
+++ b/src/components/actual-data/ChampionItemSidebar.tsx
@@ -6,8 +6,9 @@ import { getItemCategory, isDisabledItem } from '@/lib/simulator/systems/item';
 import DraggableChampionCard from '@/components/builder/DraggableChampionCard';
 import DraggableItemIcon from '@/components/builder/DraggableItemIcon';
 import SearchBar from '@/components/ui/SearchBar';
+import DraggableItemRemoverTool from './DraggableItemRemoverTool';
 
-type Tab = 'champions' | 'items';
+type Tab = 'champions' | 'items' | 'tools';
 type CostFilter = null | 1 | 2 | 3 | 4 | 5;
 type ItemTab = 'combined' | 'artifact' | 'radiant' | 'emblem' | 'all';
 
@@ -46,13 +47,20 @@ export default function ChampionItemSidebar({ champions, items, onChampionClick,
           >
             아이템
           </button>
+          <button
+            type="button"
+            className={`px-2 py-1 rounded ${tab === 'tools' ? 'bg-[#8b5cf6] text-white' : 'bg-[#1f2937] text-gray-400 hover:text-gray-200'}`}
+            onClick={() => setTab('tools')}
+          >
+            도구
+          </button>
         </div>
       </div>
 
       <div className="flex-1 overflow-hidden">
-        {tab === 'champions'
-          ? <ChampionSection champions={champions} onChampionClick={onChampionClick} />
-          : <ItemSection items={items} onItemClick={onItemClick} />}
+        {tab === 'champions' && <ChampionSection champions={champions} onChampionClick={onChampionClick} />}
+        {tab === 'items' && <ItemSection items={items} onItemClick={onItemClick} />}
+        {tab === 'tools' && <ToolsSection />}
       </div>
     </aside>
   );
@@ -155,6 +163,19 @@ function ItemSection({ items, onItemClick }: { items: RawItem[]; onItemClick?: (
         {filtered.length === 0 && (
           <div className="col-span-5 text-center text-gray-500 py-4 text-xs">검색 결과가 없습니다.</div>
         )}
+      </div>
+    </div>
+  );
+}
+
+function ToolsSection() {
+  return (
+    <div className="flex flex-col h-full p-2 space-y-3">
+      <p className="text-[11px] text-gray-400 leading-relaxed">
+        유닛 위로 드래그해서 사용합니다.
+      </p>
+      <div className="grid grid-cols-5 gap-1.5">
+        <DraggableItemRemoverTool size={44} />
       </div>
     </div>
   );

--- a/src/components/actual-data/DraggableItemRemoverTool.tsx
+++ b/src/components/actual-data/DraggableItemRemoverTool.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useDraggable } from '@dnd-kit/core';
+import type { DragData } from '@/types';
+
+const ICON_SRC = '/data/images/items/tft_consumable_itemremover.tft_set13.png';
+
+/**
+ * Drag source for the "자석 제거기" tool. Drop onto a placed unit (hex or slot)
+ * clears all three item slots via the `{ type: 'tool', toolKind: 'remove-all' }`
+ * branch in createActualDragEndHandler.
+ */
+export default function DraggableItemRemoverTool({ size = 44 }: { size?: number }) {
+  const data: DragData = { type: 'tool', toolKind: 'remove-all' };
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: 'tool-remove-all',
+    data,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      style={{ width: size, height: size, opacity: isDragging ? 0.4 : 1, touchAction: 'none' }}
+      className="relative cursor-grab active:cursor-grabbing rounded border border-gray-700 bg-[#1f2937] hover:border-red-500 hover:bg-red-900/30 transition-colors flex items-center justify-center overflow-hidden"
+      title="자석 제거기 — 유닛 위에 드롭하면 아이템 3칸 모두 제거"
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={ICON_SRC} alt="자석 제거기" width={size - 4} height={size - 4} draggable={false} />
+    </div>
+  );
+}

--- a/src/components/actual-data/PvPRoundEditor.tsx
+++ b/src/components/actual-data/PvPRoundEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useCallback, useMemo, useState } from 'react';
-import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors, pointerWithin, rectIntersection, type CollisionDetection } from '@dnd-kit/core';
 import type { PvPRound, PlacedUnit } from '@/lib/actualData/types';
 import { useActualDataStore } from '@/store/actualDataSlice';
 import { useGameData } from '@/hooks/useGameData';
@@ -27,6 +27,14 @@ export default function PvPRoundEditor({ index, round }: { index: number; round:
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
   );
+
+  // pointerWithin 으로 작은 슬롯 drop 을 우선 매칭하고, 포인터가 헥스 밖으로 살짝 벗어나면
+  // rectIntersection 으로 fallback 해 기존 헥스 본체 drop 을 잃지 않는다.
+  const collisionDetection: CollisionDetection = (args) => {
+    const pointerHits = pointerWithin(args);
+    if (pointerHits.length > 0) return pointerHits;
+    return rectIntersection(args);
+  };
 
   const [activeDrag, setActiveDrag] = useState<DragData | null>(null);
 
@@ -78,6 +86,7 @@ export default function PvPRoundEditor({ index, round }: { index: number; round:
   return (
     <DndContext
       sensors={sensors}
+      collisionDetection={collisionDetection}
       onDragStart={(e) => {
         const data = e.active.data.current as DragData | undefined;
         if (data) setActiveDrag(data);

--- a/src/components/actual-data/actualDndHandlers.ts
+++ b/src/components/actual-data/actualDndHandlers.ts
@@ -127,9 +127,8 @@ export function createActualDragEndHandler(ctx: () => ActualDndContext | null) {
       return;
     }
 
-    // Champion drop (sidebar → empty hex only). Slot drops are ignored for champion type.
+    // Champion drop (sidebar → empty hex only). Slot id resolves to its parent hex via destHex.
     if (dragData.type === 'champion') {
-      if (slotInfo) return;
       if (existingDestIdx >= 0) return;
       const newUnit: PlacedUnit = {
         championId: dragData.champion.apiName,
@@ -141,9 +140,9 @@ export function createActualDragEndHandler(ctx: () => ActualDndContext | null) {
       return;
     }
 
-    // Placed unit drag — movement only on hex cells, not item slots.
+    // Placed unit drag — slot id resolves to its parent hex via destHex (supports drops onto
+    // the lower item-row region of another occupied hex under pointerWithin collision detection).
     if (dragData.type === 'placed-unit') {
-      if (slotInfo) return;
       const srcTeam = dragData.team;
       const srcUnits = srcTeam === 'player' ? round.playerTeam.units : round.opponent.units;
       const srcIdx = findUnitIndexAt(srcUnits, dragData.position);

--- a/src/components/actual-data/actualDndHandlers.ts
+++ b/src/components/actual-data/actualDndHandlers.ts
@@ -105,10 +105,13 @@ export function createActualDragEndHandler(ctx: () => ActualDndContext | null) {
       return;
     }
 
-    const cellInfo = parseCellId(over.id as string);
-    if (!cellInfo) return;
-    const destTeam = getTeamFromRow(cellInfo.row);
-    const destHex = cellToHex(cellInfo.row, cellInfo.col);
+    // Resolve target: item slot first, then hex cell.
+    const slotInfo = parseSlotId(over.id as string);
+    const cellInfo = slotInfo ? null : parseCellId(over.id as string);
+    if (!slotInfo && !cellInfo) return;
+
+    const destTeam: 'player' | 'enemy' = slotInfo ? slotInfo.team : getTeamFromRow(cellInfo!.row);
+    const destHex: HexCoord = slotInfo ? slotInfo.hex : cellToHex(cellInfo!.row, cellInfo!.col);
     const destUnits = destTeam === 'player' ? round.playerTeam.units : round.opponent.units;
     const setDest = (nextUnits: PlacedUnit[]) => {
       if (destTeam === 'player') updatePlayerTeam(roundIndex, { units: nextUnits });
@@ -116,7 +119,17 @@ export function createActualDragEndHandler(ctx: () => ActualDndContext | null) {
     };
     const existingDestIdx = findUnitIndexAt(destUnits, destHex);
 
+    // Tool: remove-all — clears all items on the target unit.
+    if (dragData.type === 'tool' && dragData.toolKind === 'remove-all') {
+      if (existingDestIdx < 0) return;
+      const cleared = clearUnitItems(destUnits[existingDestIdx]);
+      setDest(destUnits.map((u, i) => (i === existingDestIdx ? cleared : u)));
+      return;
+    }
+
+    // Champion drop (sidebar → empty hex only). Slot drops are ignored for champion type.
     if (dragData.type === 'champion') {
+      if (slotInfo) return;
       if (existingDestIdx >= 0) return;
       const newUnit: PlacedUnit = {
         championId: dragData.champion.apiName,
@@ -128,7 +141,9 @@ export function createActualDragEndHandler(ctx: () => ActualDndContext | null) {
       return;
     }
 
+    // Placed unit drag — movement only on hex cells, not item slots.
     if (dragData.type === 'placed-unit') {
+      if (slotInfo) return;
       const srcTeam = dragData.team;
       const srcUnits = srcTeam === 'player' ? round.playerTeam.units : round.opponent.units;
       const srcIdx = findUnitIndexAt(srcUnits, dragData.position);
@@ -158,18 +173,26 @@ export function createActualDragEndHandler(ctx: () => ActualDndContext | null) {
         });
         setDest(nextUnits);
       } else if (existingDestIdx < 0) {
-        const nextUnits = destUnits.map((u, i) => i === srcIdx ? { ...u, hex: destHex } : u);
+        const nextUnits = destUnits.map((u, i) => (i === srcIdx ? { ...u, hex: destHex } : u));
         setDest(nextUnits);
       }
       return;
     }
 
+    // Item drop
     if (dragData.type === 'item') {
       if (existingDestIdx < 0) return;
       const target = destUnits[existingDestIdx];
-      const updated = setItemInSlot(target, dragData.item);
-      if (!updated) return;
-      setDest(destUnits.map((u, i) => i === existingDestIdx ? updated : u));
+      if (slotInfo) {
+        // Explicit slot → replace or fill that exact slot.
+        const updated = setItemAtSlot(target, dragData.item.apiName, slotInfo.slotIdx);
+        setDest(destUnits.map((u, i) => (i === existingDestIdx ? updated : u)));
+      } else {
+        // Hex body → first empty slot (legacy fast-attach).
+        const updated = setItemInSlot(target, dragData.item);
+        if (!updated) return;
+        setDest(destUnits.map((u, i) => (i === existingDestIdx ? updated : u)));
+      }
     }
   };
 }

--- a/src/components/actual-data/actualDndHandlers.ts
+++ b/src/components/actual-data/actualDndHandlers.ts
@@ -40,6 +40,31 @@ function setItemInSlot(u: PlacedUnit, item: RawItem): PlacedUnit | null {
   return null; // max 3 items
 }
 
+/** Parse an item-slot droppable id `item-slot-{team}-{q}-{r}-{slotIdx}`. */
+export function parseSlotId(id: string): { team: 'player' | 'enemy'; hex: HexCoord; slotIdx: 0 | 1 | 2 } | null {
+  const match = id.match(/^item-slot-(player|enemy)-(-?\d+)-(-?\d+)-(\d+)$/);
+  if (!match) return null;
+  const slotIdx = Number(match[4]);
+  if (slotIdx !== 0 && slotIdx !== 1 && slotIdx !== 2) return null;
+  return {
+    team: match[1] as 'player' | 'enemy',
+    hex: { q: Number(match[2]), r: Number(match[3]) },
+    slotIdx,
+  };
+}
+
+/** Replace or fill a specific slot (0..2) with the given item apiName. Returns a new unit. */
+export function setItemAtSlot(u: PlacedUnit, itemApiName: string, slotIdx: 0 | 1 | 2): PlacedUnit {
+  const next = [...u.items] as PlacedUnit['items'];
+  next[slotIdx] = itemApiName;
+  return { ...u, items: next };
+}
+
+/** Clear all three item slots of a unit. Returns a new unit. */
+export function clearUnitItems(u: PlacedUnit): PlacedUnit {
+  return { ...u, items: [undefined, undefined, undefined] as PlacedUnit['items'] };
+}
+
 export interface ActualDndContext {
   round: PvPRound;
   roundIndex: number;

--- a/src/components/battle/SetupBoardCore.tsx
+++ b/src/components/battle/SetupBoardCore.tsx
@@ -305,7 +305,46 @@ export default function SetupBoardCore({
                   );
                 })()
               )}
-              {result && result.placed.items.length > 0 && (
+              {result && result.placed.itemSlots && (
+                <g>
+                  {(() => {
+                    const slots = result.placed.itemSlots;
+                    const itemSize = 16;
+                    // 고정 3-슬롯 레이아웃 — ActualItemSlotsOverlay 의 droppable 위치와 정확히 일치.
+                    const totalWidth = 3 * itemSize + 2 * 2;
+                    const startX = cx - totalWidth / 2 + itemSize / 2;
+                    const iy = cy + HEX_R - 12;
+                    const nodes = [];
+                    for (let i = 0; i < 3; i++) {
+                      const item = slots[i];
+                      if (!item) continue;
+                      const ix = startX + i * (itemSize + 2);
+                      const patId = `item-${row}-${col}-${i}`;
+                      nodes.push(
+                        <g key={i}>
+                          <defs>
+                            <pattern id={patId} width="1" height="1" patternContentUnits="objectBoundingBox">
+                              <image href={getItemImage(item.apiName)} width="1" height="1" preserveAspectRatio="xMidYMid slice" />
+                            </pattern>
+                          </defs>
+                          <rect
+                            x={ix - itemSize / 2}
+                            y={iy - itemSize / 2}
+                            width={itemSize}
+                            height={itemSize}
+                            rx={2}
+                            fill={`url(#${patId})`}
+                            stroke="#111"
+                            strokeWidth={0.5}
+                          />
+                        </g>
+                      );
+                    }
+                    return nodes;
+                  })()}
+                </g>
+              )}
+              {result && !result.placed.itemSlots && result.placed.items.length > 0 && (
                 <g>
                   {result.placed.items.slice(0, 3).map((item, i) => {
                     const itemSize = 16;

--- a/src/lib/actualData/unitAdapter.ts
+++ b/src/lib/actualData/unitAdapter.ts
@@ -28,8 +28,10 @@ export function resolveChampion(
  * Convert actual-data PlacedUnit -> simulator PlacedChampion for rendering on SetupBoardCore.
  * Requires champion/item catalog lookups. Returns null if champion is not found in the catalog.
  *
- * PlacedUnit.items is a 3-tuple of optional item apiName strings; any missing / unresolved slot
- * is dropped (PlacedChampion.items is a plain RawItem[] with no slot semantics).
+ * PlacedUnit.items is a 3-tuple of optional item apiName strings.
+ *  - `items`: compacted RawItem[] (legacy 호환 — 빈/미해결 슬롯 제거)
+ *  - `itemSlots`: 3-tuple (RawItem | null) — 슬롯 좌표 보존. SetupBoardCore 가 고정 3-슬롯
+ *    레이아웃으로 렌더링할 때 ActualItemSlotsOverlay 의 droppable/X 버튼 위치와 정확히 겹치게 한다.
  */
 export function toPlacedChampion(
   u: PlacedUnit,
@@ -38,17 +40,22 @@ export function toPlacedChampion(
 ): PlacedChampion | null {
   const champion = championCatalog.get(u.championId) ?? SPECIAL_CHAMPIONS[u.championId];
   if (!champion) return null;
+  const itemSlots: Array<RawItem | null> = [null, null, null];
   const items: RawItem[] = [];
-  for (const id of u.items) {
+  for (let i = 0; i < 3; i++) {
+    const id = u.items[i];
     if (!id) continue;
     const item = itemCatalog.get(id);
-    if (item) items.push(item);
+    if (!item) continue;
+    itemSlots[i] = item;
+    items.push(item);
   }
   return {
     champion,
     position: u.hex,
     starLevel: u.starLevel,
     items,
+    itemSlots,
     voidItem: null,
     mfMode: null,
     permanentStacks: null,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -327,6 +327,12 @@ export interface PlacedChampion {
   position: HexCoord;
   starLevel: number; // 1, 2, 3
   items: RawItem[];
+  /**
+   * actual-data 경로에서 슬롯 좌표를 보존하기 위한 선택적 3-tuple.
+   * 길이 3(빈 슬롯은 null). 존재하면 SetupBoardCore 의 고정 3-슬롯 레이아웃 렌더링에 사용된다.
+   * /simulator 등 legacy 경로에서는 undefined → 기존 compacted items 기반 렌더링 유지.
+   */
+  itemSlots?: Array<RawItem | null>;
   voidItem?: RawItem | null;
   mfMode?: MfMode | null;
   permanentStacks?: PermanentStack | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -557,7 +557,8 @@ export const COST_COLORS: Record<number, string> = {
 export type DragData =
   | { type: 'champion'; champion: RawChampion }
   | { type: 'placed-unit'; team: 'player' | 'enemy'; position: HexCoord }
-  | { type: 'item'; item: RawItem };
+  | { type: 'item'; item: RawItem }
+  | { type: 'tool'; toolKind: 'remove-all' };
 
 export const STAR_SCALING: Record<number, number> = {
   1: 1,

--- a/tests/unit/actualData/actualDndHandlers.test.ts
+++ b/tests/unit/actualData/actualDndHandlers.test.ts
@@ -4,7 +4,9 @@ import {
   setItemAtSlot,
   clearUnitItems,
 } from '@/components/actual-data/actualDndHandlers';
-import type { PlacedUnit } from '@/lib/actualData/types';
+import { createActualDragEndHandler, type ActualDndContext } from '@/components/actual-data/actualDndHandlers';
+import type { PlacedUnit, PvPRound, TeamSnapshot, OpponentSnapshot } from '@/lib/actualData/types';
+import type { DragEndEvent } from '@dnd-kit/core';
 
 describe('parseSlotId', () => {
   it('player 팀 슬롯 id 를 파싱한다', () => {
@@ -64,5 +66,142 @@ describe('clearUnitItems', () => {
     const u = unit(['A', 'B', 'C']);
     clearUnitItems(u);
     expect(u.items).toEqual(['A', 'B', 'C']);
+  });
+});
+
+const baseTeam = (units: PlacedUnit[]): TeamSnapshot => ({
+  units,
+  augments: [undefined, undefined, undefined, undefined],
+  level: 6,
+  hp: 100,
+  hexModifiers: [],
+});
+const baseOpponent = (units: PlacedUnit[]): OpponentSnapshot => ({ ...baseTeam(units) });
+
+const makeRound = (playerUnits: PlacedUnit[], opponentUnits: PlacedUnit[] = []): PvPRound => ({
+  type: 'pvp',
+  roundName: '2-1',
+  videoStartTime: 0,
+  playerTeam: baseTeam(playerUnits),
+  opponent: baseOpponent(opponentUnits),
+  winner: 'player',
+});
+
+/** Minimal DragEndEvent stub with just what the handler reads. */
+const makeEvent = (dragData: unknown, overId: string | null): DragEndEvent =>
+  ({
+    active: { data: { current: dragData }, id: 'active' },
+    over: overId ? { id: overId } : null,
+  } as unknown as DragEndEvent);
+
+describe('createActualDragEndHandler - item slot routing', () => {
+  it('item drop 이 정확한 슬롯을 교체한다', () => {
+    const unitA: PlacedUnit = {
+      championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: ['TFT_Item_BFSword', 'TFT_Item_RecurveBow', undefined],
+    };
+    let player: PlacedUnit[] = [unitA];
+    const ctx: ActualDndContext = {
+      round: makeRound(player),
+      roundIndex: 0,
+      updatePlayerTeam: (_i, patch) => { player = patch.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    handler(makeEvent(
+      { type: 'item', item: { apiName: 'TFT_Item_Rabadon' } },
+      'item-slot-player-0-3-0',
+    ));
+    expect(player[0].items).toEqual(['TFT_Item_Rabadon', 'TFT_Item_RecurveBow', undefined]);
+  });
+
+  it('item drop 이 지정된 빈 슬롯을 채운다', () => {
+    const unitA: PlacedUnit = {
+      championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: ['TFT_Item_BFSword', undefined, undefined],
+    };
+    let player: PlacedUnit[] = [unitA];
+    const ctx: ActualDndContext = {
+      round: makeRound(player),
+      roundIndex: 0,
+      updatePlayerTeam: (_i, patch) => { player = patch.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    handler(makeEvent(
+      { type: 'item', item: { apiName: 'TFT_Item_Rabadon' } },
+      'item-slot-player-0-3-2',
+    ));
+    expect(player[0].items).toEqual(['TFT_Item_BFSword', undefined, 'TFT_Item_Rabadon']);
+  });
+
+  it('item drop 이 헥스 본체 (cell-*) 에서는 기존 자동 채움 동작 유지', () => {
+    const unitA: PlacedUnit = {
+      championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: [undefined, undefined, undefined],
+    };
+    let player: PlacedUnit[] = [unitA];
+    const ctx: ActualDndContext = {
+      round: makeRound(player),
+      roundIndex: 0,
+      updatePlayerTeam: (_i, patch) => { player = patch.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    // cell id: player 팀은 row 4-7, q=0,r=3 → dataRow=3, col=q+floor(r/2)=0+1=1, display row=4+3=7
+    handler(makeEvent(
+      { type: 'item', item: { apiName: 'TFT_Item_Rabadon' } },
+      'cell-7-1',
+    ));
+    expect(player[0].items).toEqual(['TFT_Item_Rabadon', undefined, undefined]);
+  });
+});
+
+describe('createActualDragEndHandler - remove-all tool', () => {
+  it('점유된 헥스(cell) 위에 drop 하면 3칸 모두 비운다', () => {
+    const unitA: PlacedUnit = {
+      championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: ['TFT_Item_BFSword', 'TFT_Item_RecurveBow', 'TFT_Item_Rabadon'],
+    };
+    let player: PlacedUnit[] = [unitA];
+    const ctx: ActualDndContext = {
+      round: makeRound(player),
+      roundIndex: 0,
+      updatePlayerTeam: (_i, patch) => { player = patch.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    handler(makeEvent({ type: 'tool', toolKind: 'remove-all' }, 'cell-7-1'));
+    expect(player[0].items).toEqual([undefined, undefined, undefined]);
+  });
+
+  it('점유된 유닛의 슬롯 위에 drop 해도 3칸 모두 비운다', () => {
+    const unitA: PlacedUnit = {
+      championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: ['TFT_Item_BFSword', 'TFT_Item_RecurveBow', undefined],
+    };
+    let player: PlacedUnit[] = [unitA];
+    const ctx: ActualDndContext = {
+      round: makeRound(player),
+      roundIndex: 0,
+      updatePlayerTeam: (_i, patch) => { player = patch.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    handler(makeEvent({ type: 'tool', toolKind: 'remove-all' }, 'item-slot-player-0-3-1'));
+    expect(player[0].items).toEqual([undefined, undefined, undefined]);
+  });
+
+  it('빈 헥스에 drop 하면 아무 변화 없음', () => {
+    let player: PlacedUnit[] = [];
+    const ctx: ActualDndContext = {
+      round: makeRound(player),
+      roundIndex: 0,
+      updatePlayerTeam: (_i, patch) => { player = patch.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    handler(makeEvent({ type: 'tool', toolKind: 'remove-all' }, 'cell-7-1'));
+    expect(player).toEqual([]);
   });
 });

--- a/tests/unit/actualData/actualDndHandlers.test.ts
+++ b/tests/unit/actualData/actualDndHandlers.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseSlotId,
+  setItemAtSlot,
+  clearUnitItems,
+} from '@/components/actual-data/actualDndHandlers';
+import type { PlacedUnit } from '@/lib/actualData/types';
+
+const sampleItem = { apiName: 'TFT_Item_BFSword' } as const;
+
+describe('parseSlotId', () => {
+  it('player 팀 슬롯 id 를 파싱한다', () => {
+    expect(parseSlotId('item-slot-player-1-2-0')).toEqual({
+      team: 'player', hex: { q: 1, r: 2 }, slotIdx: 0,
+    });
+  });
+
+  it('enemy 팀 음수 좌표도 파싱한다', () => {
+    expect(parseSlotId('item-slot-enemy--1-3-2')).toEqual({
+      team: 'enemy', hex: { q: -1, r: 3 }, slotIdx: 2,
+    });
+  });
+
+  it('잘못된 포맷은 null 을 반환한다', () => {
+    expect(parseSlotId('cell-4-3')).toBeNull();
+    expect(parseSlotId('item-slot-foo-1-2-0')).toBeNull();
+    expect(parseSlotId('item-slot-player-1-2-9')).toBeNull();
+  });
+});
+
+const unit = (items: (string | undefined)[]): PlacedUnit => ({
+  championId: 'TFT17_Ahri',
+  hex: { q: 0, r: 0 },
+  starLevel: 2,
+  items: [items[0], items[1], items[2]] as PlacedUnit['items'],
+});
+
+describe('setItemAtSlot', () => {
+  it('빈 슬롯을 지정된 인덱스에 채운다', () => {
+    const u = unit([undefined, undefined, undefined]);
+    const next = setItemAtSlot(u, 'TFT_Item_BFSword', 1);
+    expect(next.items).toEqual([undefined, 'TFT_Item_BFSword', undefined]);
+  });
+
+  it('채워진 슬롯을 덮어쓴다 (교체)', () => {
+    const u = unit(['TFT_Item_BFSword', 'TFT_Item_RecurveBow', undefined]);
+    const next = setItemAtSlot(u, 'TFT_Item_Rabadon', 0);
+    expect(next.items).toEqual(['TFT_Item_Rabadon', 'TFT_Item_RecurveBow', undefined]);
+  });
+
+  it('원본 객체를 mutate 하지 않는다', () => {
+    const u = unit(['A', undefined, undefined]);
+    setItemAtSlot(u, 'B', 0);
+    expect(u.items).toEqual(['A', undefined, undefined]);
+  });
+});
+
+describe('clearUnitItems', () => {
+  it('3칸 모두 undefined 로 만든다', () => {
+    const u = unit(['A', 'B', 'C']);
+    const next = clearUnitItems(u);
+    expect(next.items).toEqual([undefined, undefined, undefined]);
+  });
+
+  it('원본 객체를 mutate 하지 않는다', () => {
+    const u = unit(['A', 'B', 'C']);
+    clearUnitItems(u);
+    expect(u.items).toEqual(['A', 'B', 'C']);
+  });
+});

--- a/tests/unit/actualData/actualDndHandlers.test.ts
+++ b/tests/unit/actualData/actualDndHandlers.test.ts
@@ -6,8 +6,6 @@ import {
 } from '@/components/actual-data/actualDndHandlers';
 import type { PlacedUnit } from '@/lib/actualData/types';
 
-const sampleItem = { apiName: 'TFT_Item_BFSword' } as const;
-
 describe('parseSlotId', () => {
   it('player 팀 슬롯 id 를 파싱한다', () => {
     expect(parseSlotId('item-slot-player-1-2-0')).toEqual({

--- a/tests/unit/actualData/actualDndHandlers.test.ts
+++ b/tests/unit/actualData/actualDndHandlers.test.ts
@@ -205,3 +205,62 @@ describe('createActualDragEndHandler - remove-all tool', () => {
     expect(player).toEqual([]);
   });
 });
+
+describe('createActualDragEndHandler - placed-unit drop onto item-slot id', () => {
+  it('같은 팀 빈 슬롯 id에 drop 하면 해당 hex 로 이동한다 (regression for PR #11 codex P2)', () => {
+    // player 팀에 유닛 2개: A at (0,3), B at (1,3)
+    // A 를 드래그해서 B 의 슬롯 위에 드롭 → A 가 B 의 hex 로 이동하고 B 와 swap
+    const unitA: PlacedUnit = {
+      championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: [undefined, undefined, undefined],
+    };
+    const unitB: PlacedUnit = {
+      championId: 'TFT17_Yasuo', hex: { q: 1, r: 3 }, starLevel: 2,
+      items: ['TFT_Item_BFSword', undefined, undefined],
+    };
+    let player: PlacedUnit[] = [unitA, unitB];
+    const ctx: ActualDndContext = {
+      round: makeRound(player),
+      roundIndex: 0,
+      updatePlayerTeam: (_i, patch) => { player = patch.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+
+    // A (at q=0,r=3) 를 B의 슬롯 1 위로 드롭
+    handler(makeEvent(
+      { type: 'placed-unit', team: 'player', position: { q: 0, r: 3 } },
+      'item-slot-player-1-3-1',
+    ));
+
+    // 스왑 결과: A 는 (1,3), B 는 (0,3)
+    const ahri = player.find(u => u.championId === 'TFT17_Ahri');
+    const yasuo = player.find(u => u.championId === 'TFT17_Yasuo');
+    expect(ahri?.hex).toEqual({ q: 1, r: 3 });
+    expect(yasuo?.hex).toEqual({ q: 0, r: 3 });
+  });
+
+  it('같은 팀 빈 헥스의 슬롯 id 에는 이동하지 않는다 (슬롯 id 는 점유 유닛만 가지므로 해당 상황 자체가 불가능하지만 안전성 검증)', () => {
+    // 이 케이스는 실전에서는 불가능 (overlay 는 점유된 유닛만 렌더) 하지만
+    // 파서가 유효한 id 를 만들어 넣었을 때 handler 가 안전히 처리하는지 검증.
+    // slotInfo.hex = { q: 2, r: 3 } 이고 거기에 유닛이 없으면 같은 팀 move 로 이동.
+    const unitA: PlacedUnit = {
+      championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: [undefined, undefined, undefined],
+    };
+    let player: PlacedUnit[] = [unitA];
+    const ctx: ActualDndContext = {
+      round: makeRound(player),
+      roundIndex: 0,
+      updatePlayerTeam: (_i, patch) => { player = patch.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    handler(makeEvent(
+      { type: 'placed-unit', team: 'player', position: { q: 0, r: 3 } },
+      'item-slot-player-2-3-0',
+    ));
+    // A 가 (2,3) 으로 이동
+    expect(player[0].hex).toEqual({ q: 2, r: 3 });
+  });
+});


### PR DESCRIPTION
## Summary

`/actual-data` 편집기에서 **챔피언을 삭제하지 않고도 아이템을 편집**할 수 있도록 3가지 조작 방식을 추가. 모든 변경은 서브에이전트 주도 TDD + 2단계 리뷰(spec → quality)로 구현.

- **개별 슬롯 X 버튼**: 채워진 슬롯에 hover → 빨간 × 클릭 → 해당 슬롯만 `undefined` (재정렬 없음)
- **드래그 교체**: 사이드바의 새 아이템을 점유된 슬롯 위에 drop → 그 슬롯 덮어쓰기. 슬롯 바깥(챔프 아이콘/여백)에 drop 시 기존 "첫 빈 슬롯 자동 채움" UX 유지
- **자석 제거기 툴**: 사이드바 새 `도구` 탭에 게임 내 `TFT_Consumable_ItemRemover` 아이콘을 드래그 소스로 노출 → 유닛 위 drop 시 3칸 모두 초기화

## 구현 구조

- `DragData` union에 `{ type: 'tool'; toolKind: 'remove-all' }` 추가
- 슬롯 단위 순수 헬퍼: `parseSlotId` / `setItemAtSlot` / `clearUnitItems` (vitest 단위 테스트 8개)
- `createActualDragEndHandler`를 slot-first 라우팅으로 재작성 + 통합 테스트 6개
- `ActualItemSlotsOverlay` 신규 — 유닛 위 HTML 오버레이 (3개 droppable + hover X)
- `PlacedChampion.itemSlots?` 옵션 필드 추가 — `/actual-data`는 3-tuple로 전달, `/simulator`는 기존 compacted 경로 유지 (backward compat)
- DndContext `collisionDetection` → `pointerWithin + rectIntersection` fallback (작은 슬롯 drop 우선)
- `DraggableItemRemoverTool` 컴포넌트 + `ChampionItemSidebar`의 `도구` 탭

## Design / Plan

- Spec: `docs/superpowers/specs/2026-04-24-item-edit-ux-design.md`
- Plan: `docs/superpowers/plans/2026-04-24-item-edit-ux.md` (7 tasks)

## Test Plan

### 자동 검증 (CI 통과 상태)
- [x] `pnpm lint` — 0 errors (5 pre-existing warnings unchanged)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — **210 pass** (+6 new integration cases)
- [x] `pnpm build` — success

### 수동 브라우저 검증 (merge 전 권장)
- [x] 슬롯 hover 시 X 버튼 노출, 클릭 시 해당 슬롯만 제거
- [x] 사이드바 아이템 드래그 → **점유된 슬롯** 위 drop → 교체
- [x] 사이드바 아이템 드래그 → **빈 슬롯** 위 drop → 해당 슬롯 채움
- [x] 사이드바 아이템 드래그 → **슬롯 바깥(챔프 아이콘)** drop → 첫 빈 슬롯 자동 채움 (기존 UX)
- [x] 3칸 다 찬 유닛의 챔프 아이콘 drop → 변화 없음
- [x] 자석 제거기 드래그 → 유닛 drop → 3칸 전체 초기화
- [x] 자석 제거기 드래그 → 빈 헥스 drop → 변화 없음
- [x] 플레이어/상대 팀 모두 동작
- [x] 유닛 자체 드래그 이동/삭제 등 기존 UX 회귀 없음

## 후속 작업 (non-blocking polish)

최종 리뷰에서 제안된 선택적 개선 — 본 PR 범위 외:
- overlay/SVG 외곽 슬롯 2px 드리프트 (실사용 무영향)
- `setItemInSlot` → `appendItemToFirstEmptySlot` 리네임 (naming confusion 해소)
- hex key 포맷 3곳 중복 → `hexKey(h)` export로 통일
- aria-label을 슬롯 번호 → 아이템 이름으로 업그레이드
- UI-level RTL/Playwright 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)