### PR TITLE
feat(actual-data): 별돌보미 별자리 입력 UI + apiName 매핑 헬퍼 (PR-1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ scripts/
 # actual-data videos (로컬 전용, 각 기기에서만 보관)
 actual-data/videos/*
 !actual-data/videos/.gitkeep
+.DS_Store

--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-27T04:28:33.350Z",
-  "sourceGameMtime": 1777257269352,
-  "engineSha": "49ebaeaccbc37cde89946701e8fcc11a9fc112fa",
+  "computedAt": "2026-04-27T06:46:44.879Z",
+  "sourceGameMtime": 1777272377555,
+  "engineSha": "373c6cd727c81f6ae9fd971d7f5d0ce2c3487e59",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/game-20260423-001.json
+++ b/actual-data/game-20260423-001.json
@@ -7536,5 +7536,6 @@
         }
       ]
     }
-  ]
+  ],
+  "stargazerConstellation": "mountain"
 }

--- a/src/components/actual-data/GameMetaEditor.tsx
+++ b/src/components/actual-data/GameMetaEditor.tsx
@@ -1,6 +1,14 @@
 'use client';
 import { useActualDataStore } from '@/store/actualDataSlice';
-import type { ShrineName, ActualGameData } from '@/lib/actualData/types';
+import type {
+  ShrineName,
+  ActualGameData,
+  StargazerConstellationId,
+} from '@/lib/actualData/types';
+import {
+  CONSTELLATION_IDS,
+  CONSTELLATION_KOREAN_NAME,
+} from '@/lib/actualData/stargazerMapping';
 
 const SHRINES: ShrineName[] = [
   'ahri',
@@ -99,6 +107,28 @@ export default function GameMetaEditor({ onClose }: { onClose: () => void }) {
             </select>
           </label>
         </div>
+
+        <label className="flex flex-col text-sm">
+          <span className="text-gray-300">별돌보미 별자리</span>
+          <select
+            value={game.stargazerConstellation ?? ''}
+            onChange={(e) =>
+              updateGameMeta({
+                stargazerConstellation: e.target.value === ''
+                  ? undefined
+                  : (e.target.value as StargazerConstellationId),
+              })
+            }
+            className="border border-gray-700 bg-gray-900 text-gray-100 p-1 rounded"
+          >
+            <option value="">(미선택)</option>
+            {CONSTELLATION_IDS.map((id) => (
+              <option key={id} value={id}>
+                {CONSTELLATION_KOREAN_NAME[id]}
+              </option>
+            ))}
+          </select>
+        </label>
 
         <div className="flex justify-end">
           <button onClick={onClose} className="px-3 py-1 border border-gray-700 text-gray-200 hover:bg-gray-700 rounded">

--- a/src/lib/actualData/stargazerMapping.ts
+++ b/src/lib/actualData/stargazerMapping.ts
@@ -1,0 +1,47 @@
+import type { StargazerConstellationId } from './types';
+
+/**
+ * 별돌보미 별자리 (게임 데이터 schema enum) ↔ trait apiName 매핑.
+ *
+ * Riot internal apiName 과 인게임 한글 표기가 일관되지 않아 (`Wolf` apiName 이
+ * 실제로는 "멧돼지" 별자리) 명시적 매핑 필요.
+ *
+ * 7개 변종은 base trait `TFT17_Stargazer` 위에 적용되는 컨스텔레이션. 게임마다
+ * 하나씩 randomized — game-level field `ActualGameData.stargazerConstellation`
+ * 에 사용자가 입력.
+ */
+export const CONSTELLATION_TO_TRAIT_API: Record<StargazerConstellationId, string> = {
+  altar: 'TFT17_Stargazer_Shield',
+  boar: 'TFT17_Stargazer_Wolf',
+  huntress: 'TFT17_Stargazer_Huntress',
+  medal: 'TFT17_Stargazer_Medallion',
+  mountain: 'TFT17_Stargazer_Mountain',
+  snake: 'TFT17_Stargazer_Serpent',
+  well: 'TFT17_Stargazer_Fountain',
+};
+
+/** 인게임 한글 표기. UI dropdown / 디스플레이용. */
+export const CONSTELLATION_KOREAN_NAME: Record<StargazerConstellationId, string> = {
+  altar: '제단',
+  boar: '멧돼지',
+  huntress: '여사냥꾼',
+  medal: '메달',
+  mountain: '산',
+  snake: '뱀',
+  well: '우물',
+};
+
+/** 모든 별자리 id 를 한글 알파벳 순으로 정렬한 배열 — UI dropdown 옵션 순서. */
+export const CONSTELLATION_IDS: StargazerConstellationId[] = (
+  Object.keys(CONSTELLATION_KOREAN_NAME) as StargazerConstellationId[]
+).sort((a, b) =>
+  CONSTELLATION_KOREAN_NAME[a].localeCompare(CONSTELLATION_KOREAN_NAME[b], 'ko'),
+);
+
+/** trait apiName → constellation id 역매핑 (필요 시). */
+export function traitApiToConstellationId(apiName: string): StargazerConstellationId | null {
+  for (const [id, api] of Object.entries(CONSTELLATION_TO_TRAIT_API)) {
+    if (api === apiName) return id as StargazerConstellationId;
+  }
+  return null;
+}

--- a/tests/unit/actualData/stargazerMapping.test.ts
+++ b/tests/unit/actualData/stargazerMapping.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONSTELLATION_TO_TRAIT_API,
+  CONSTELLATION_KOREAN_NAME,
+  CONSTELLATION_IDS,
+  traitApiToConstellationId,
+} from '@/lib/actualData/stargazerMapping';
+import { StargazerConstellationIdSchema } from '@/lib/actualData/schema';
+
+describe('stargazerMapping', () => {
+  it('covers every schema enum value', () => {
+    const enumValues = StargazerConstellationIdSchema.options;
+    for (const v of enumValues) {
+      expect(CONSTELLATION_TO_TRAIT_API[v]).toBeDefined();
+      expect(CONSTELLATION_KOREAN_NAME[v]).toBeDefined();
+    }
+    expect(CONSTELLATION_IDS).toHaveLength(enumValues.length);
+  });
+
+  it('maps boar → Wolf (Riot internal name vs in-game label)', () => {
+    expect(CONSTELLATION_TO_TRAIT_API.boar).toBe('TFT17_Stargazer_Wolf');
+    expect(CONSTELLATION_KOREAN_NAME.boar).toBe('멧돼지');
+  });
+
+  it('maps altar → Shield (제단)', () => {
+    expect(CONSTELLATION_TO_TRAIT_API.altar).toBe('TFT17_Stargazer_Shield');
+    expect(CONSTELLATION_KOREAN_NAME.altar).toBe('제단');
+  });
+
+  it('reverse mapping', () => {
+    expect(traitApiToConstellationId('TFT17_Stargazer_Mountain')).toBe('mountain');
+    expect(traitApiToConstellationId('TFT17_Stargazer_Wolf')).toBe('boar');
+    expect(traitApiToConstellationId('TFT17_Stargazer')).toBeNull(); // base
+    expect(traitApiToConstellationId('TFT17_NonExistent')).toBeNull();
+  });
+
+  it('all 7 trait apiNames are unique', () => {
+    const set = new Set(Object.values(CONSTELLATION_TO_TRAIT_API));
+    expect(set.size).toBe(Object.keys(CONSTELLATION_TO_TRAIT_API).length);
+  });
+});


### PR DESCRIPTION
## Summary

별돌보미 trait 시스템 구현의 1단계 — **데이터 인프라만**. 엔진 통합은 PR-2 에서.

별돌보미는 게임마다 **8개 변종 (제단/멧돼지/우물/여사냥꾼/메달/산/뱀)** 중 하나가 randomized 활성. schema 의 game-level field \`stargazerConstellation\` 은 이미 정의돼 있었으나 입력 UI 와 trait apiName 매핑 부재로 sim 엔진에 전달 불가능.

## Changes

### 신규
- \`src/lib/actualData/stargazerMapping.ts\` — 매핑 헬퍼:
  - \`CONSTELLATION_TO_TRAIT_API\`: schema id → trait apiName (예: \`boar\` → \`TFT17_Stargazer_Wolf\`, \`altar\` → \`TFT17_Stargazer_Shield\`)
  - \`CONSTELLATION_KOREAN_NAME\`: 인게임 한글 표기 (UI 용)
  - \`traitApiToConstellationId\`: 역매핑
- \`tests/unit/actualData/stargazerMapping.test.ts\` — 5 tests

### 수정
- \`src/components/actual-data/GameMetaEditor.tsx\` — 별자리 dropdown 추가 (한글명 정렬 + 미선택 옵션)
- \`actual-data/game-20260423-001.json\` — \`stargazerConstellation: "mountain"\` 입력
- \`.gitignore\` — \`.DS_Store\` 추가

## Riot internal apiName vs 인게임 한글 매핑

description 안에서 추출한 매핑:

| schema id | apiName | 인게임 한글 |
|---|---|---|
| \`boar\` | \`TFT17_Stargazer_Wolf\` | **멧돼지** (apiName 과 다름!) |
| \`altar\` | \`TFT17_Stargazer_Shield\` | 제단 |
| \`well\` | \`TFT17_Stargazer_Fountain\` | 우물 |
| \`huntress\` | \`TFT17_Stargazer_Huntress\` | 여사냥꾼 |
| \`medal\` | \`TFT17_Stargazer_Medallion\` | 메달 |
| \`mountain\` | \`TFT17_Stargazer_Mountain\` | 산 |
| \`snake\` | \`TFT17_Stargazer_Serpent\` | 뱀 |

## 엔진 동작

**변화 없음 (회귀 가드)**. 264 tests pass. PR-2 에서 \`resolveTraits\` 가 이 정보를 받아 변종 effects 적용 시 메트릭 변화 시작.

## 24일 게임 별자리

미입력 상태 (사용자가 영상 보고 추후 UI 로 입력 가능). PR-2 에서 측정할 때까지 추가하면 됨.

## Test plan

- [x] \`pnpm lint\` 0 errors
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test --run\` 264 pass (+5 신규)
- [x] \`pnpm build\` succeeds
- [x] \`schema enum\` ↔ \`apiName\` 매핑 단위 테스트 (모든 enum 값 커버)
- [x] PR review

## Followup (PR-2)

- \`resolveTraits\` 가 \`stargazerConstellation\` 받아 base + 변종 trait 활성
- 7 변종 effects 처리 (Wolf_ADAP, Medallion_DA, Mountain_Health 등)
- Stargazer Emblem 아이템 → trait counter 부여
- 양 게임 (23일/24일) 캐시 재생성 → metric 비교 (23일 winnerMatchRate 대폭 상승 기대)

🤖 Generated with [Claude Code](https://claude.com/claude-code)