### PR TITLE
feat(simulator): Set 17 emblem 19종 trait 카운트 매핑 추가 (PR-A)

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-27T07:54:50.514Z",
+  "computedAt": "2026-04-27T08:03:38.117Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "3100c598e212c76cf729f76287fb098e17ba016f",
+  "engineSha": "c0d5fd50f184902a9afa65ab898cd615c9a70cea",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-27T07:37:29.749Z",
+  "computedAt": "2026-04-27T07:54:50.514Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "9d4aacafc38b8a806a09fda214f6730a13d711c3",
+  "engineSha": "3100c598e212c76cf729f76287fb098e17ba016f",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-04-27T07:54:51.594Z",
+  "computedAt": "2026-04-27T08:03:39.205Z",
   "sourceGameMtime": 1777264427399,
-  "engineSha": "3100c598e212c76cf729f76287fb098e17ba016f",
+  "engineSha": "c0d5fd50f184902a9afa65ab898cd615c9a70cea",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-04-27T07:37:30.806Z",
+  "computedAt": "2026-04-27T07:54:51.594Z",
   "sourceGameMtime": 1777264427399,
-  "engineSha": "9d4aacafc38b8a806a09fda214f6730a13d711c3",
+  "engineSha": "3100c598e212c76cf729f76287fb098e17ba016f",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -21,7 +21,26 @@ import { EventBus } from '@/lib/simulator/events/eventBus';
 import { ItemEffectRuntime } from '@/lib/simulator/systems/items';
 import type { ActionDeps, DamageType } from '@/lib/simulator/systems/items';
 import { ROLE_OMNIVAMP, getFighterASBonus } from '@/lib/simulator/models/unit';
-import { resolveTraits } from '@/lib/simulator/systems/trait';
+import { resolveTraits, getEmblemTraitNames } from '@/lib/simulator/systems/trait';
+
+/**
+ * unit 의 trait 멤버십 검사 헬퍼. champion.traits 직접 조회는 emblem 으로 부여된
+ * trait 를 누락 — `resolvedTraits` 가 항상 createCombatUnit 시점에 emblem 까지
+ * 합산해 둔 진짜 멤버십 list. fallback 은 champion.traits (resolvedTraits 미설정
+ * 시 기본 traits 와 동일).
+ */
+function unitHasTrait(u: CombatUnit, traitName: string): boolean {
+  return (u.resolvedTraits ?? u.champion.traits).includes(traitName);
+}
+
+/**
+ * PlacedChampion (createCombatUnit 전 시점) 의 trait 멤버십 — champion.traits +
+ * emblem 합산. unit 생성 후엔 unitHasTrait 사용.
+ */
+function placedHasTrait(p: PlacedChampion, traitName: string): boolean {
+  if (p.champion.traits.includes(traitName)) return true;
+  return getEmblemTraitNames(p.items).includes(traitName);
+}
 import { resolveAugmentEffects, resolveInCombatAugmentEffects, resolvePerUnitMods, applyPerUnitMods, AugmentWithStacks } from '@/lib/simulator/systems/augment';
 import type { IoniaPathType } from '@/data/traitModules';
 import { computeSpellCanCrit } from '@/lib/combat/spellCrit';
@@ -132,10 +151,22 @@ function createCombatUnit(
     spellCanCrit: computeSpellCanCrit(allItems, activeTraits),
   };
 
-  // MF 특성 선택 → 실제 트레이트로 치환
+  // MF 특성 선택 → 실제 트레이트로 치환 + emblem 으로 부여된 trait 합산.
+  // resolvedTraits 가 unit 의 진짜 trait 멤버십 — combat-time 효과 (시너지 per-unit
+  // bonus / arbiter law) 가 emblem 보유 unit 도 일관되게 인식하도록 한다.
+  const emblemTraits = getEmblemTraitNames(allItems);
+  let baseTraits = placed.champion.traits;
   if (placed.champion.apiName === 'TFT17_MissFortune' && placed.mfMode) {
     const modeCfg = MF_MODE_CONFIG[placed.mfMode];
-    unit.resolvedTraits = placed.champion.traits.map(t => t === '특성 선택' ? modeCfg.name : t);
+    baseTraits = baseTraits.map(t => t === '특성 선택' ? modeCfg.name : t);
+  }
+  if (emblemTraits.length > 0 || baseTraits !== placed.champion.traits) {
+    // dedup — 동일 trait 가 champion 에 이미 있으면 emblem 으로 재추가하지 않음
+    const merged = [...baseTraits];
+    for (const t of emblemTraits) {
+      if (!merged.includes(t)) merged.push(t);
+    }
+    unit.resolvedTraits = merged;
   }
 
   // 공허 돌연변이 전투 효과 적용
@@ -200,7 +231,7 @@ function applySet17SynergyBuffs(traits: ActiveTrait[], units: CombatUnit[]): voi
     const tierIdx = at.trait.effects.findIndex(e => e === at.activeEffect);
     const ti = Math.max(0, tierIdx);
 
-    const isChampTrait = (u: CombatUnit) => (u.resolvedTraits ?? u.champion.traits).includes(at.trait.name);
+    const isChampTrait = (u: CombatUnit) => unitHasTrait(u, at.trait.name);
 
     // 도전자: 아군 AS + 도전자 추가 AS
     if (sc.teamwideAS) {
@@ -408,7 +439,7 @@ function applyIoniaPath(
   const vars = ionia.activeEffect.variables;
 
   const ioniaUnits = teamUnits.filter(u =>
-    u.state !== 'dead' && u.champion.traits.includes('아이오니아')
+    u.state !== 'dead' && unitHasTrait(u, '아이오니아')
   );
   if (ioniaUnits.length === 0) return;
 
@@ -516,7 +547,7 @@ function applyDefenderBonus(activeTraits: ActiveTrait[], units: CombatUnit[]): v
   const bonus = (defender.activeEffect.variables['BonusArmorMR'] ?? 0) as number;
   if (bonus <= 0) return;
   for (const u of units) {
-    if (u.champion.traits.includes('엄호대')) {
+    if (unitHasTrait(u, '엄호대')) {
       u.stats.armor += bonus;
       u.stats.magicResist += bonus;
     }
@@ -530,7 +561,7 @@ function applySorcererBonus(activeTraits: ActiveTrait[], units: CombatUnit[]): v
   const bonusAP = (sorc.activeEffect.variables['BonusAP'] ?? 0) as number;
   if (bonusAP <= 0) return;
   for (const u of units) {
-    if (u.champion.traits.includes('비전 마법사')) {
+    if (unitHasTrait(u, '비전 마법사')) {
       u.stats.ap += bonusAP;
     }
   }
@@ -595,7 +626,7 @@ function applyJuggernautDR(activeTraits: ActiveTrait[], units: CombatUnit[]): vo
   const baseDR = (jugg.activeEffect.variables['BaseDR'] ?? 0) as number;
   if (baseDR <= 0) return;
   for (const u of units) {
-    if (u.champion.traits.includes('전쟁기계')) {
+    if (unitHasTrait(u, '전쟁기계')) {
       u.damageReduction += baseDR;
     }
   }
@@ -623,11 +654,9 @@ function applyStargazerEffects(traits: ActiveTrait[], units: CombatUnit[]): void
 
   const eff = stargazer.activeEffect.variables;
 
-  const isStargazerUnit = (u: CombatUnit): boolean => {
-    const champTraits = u.resolvedTraits ?? u.champion.traits;
-    if (champTraits.includes('별돌보미')) return true;
-    return u.items.some((it) => it.apiName === 'TFT17_Item_StargazerEmblemItem');
-  };
+  // resolvedTraits 가 createCombatUnit 에서 champion.traits + emblem 합산으로
+  // 설정되므로 unitHasTrait 한 번으로 emblem 보유 unit 도 정확히 인식.
+  const isStargazerUnit = (u: CombatUnit): boolean => unitHasTrait(u, '별돌보미');
 
   // === Mountain 변종 ===
   if (apiName === 'TFT17_Stargazer_Mountain') {
@@ -983,7 +1012,7 @@ function trySpawnGalio(
   const enemyTrueDamage = (dVars['EnemyTrueDamage'] ?? 0) as number;
 
   for (const u of teamUnits) {
-    if (!u.champion.traits.includes('데마시아') || u.state === 'dead') continue;
+    if (!unitHasTrait(u, '데마시아') || u.state === 'dead') continue;
     u.stats.armor += rallyArmorMR;
     u.stats.magicResist += rallyArmorMR;
     if (manaReductionPct > 0) {
@@ -1104,7 +1133,7 @@ function applyPiltoverInvention(
     if (moduleKey === 'VoltageConduit') {
       const reduction = (item.effects['ManaReduction'] ?? 0.30) as number;
       for (const ally of aliveTeam) {
-        if (ally.champion.traits.includes('필트오버')) {
+        if (unitHasTrait(ally, '필트오버')) {
           ally.maxMana = Math.round(ally.maxMana * (1 - reduction));
         }
       }
@@ -1402,7 +1431,7 @@ export function simulateCombat(
     : options.enemyGalio ?? null;
 
   const playerUnits = playerTeamFiltered.map((p, i) => {
-    const isBW = p.champion.traits.includes('빌지워터');
+    const isBW = placedHasTrait(p, '빌지워터');
     const effects = isBW ? mergeEffects(playerAugmentEffects, playerBWEffects) : playerAugmentEffects;
     const unit = createCombatUnit(p, 'player', i, playerActiveTraits, effects);
     const mod = resolvePerUnitMods(playerAugsWithStacks, p.champion);
@@ -1414,7 +1443,7 @@ export function simulateCombat(
   });
   const enemies = enemyTeamFiltered.map((p, i) => {
     const positioned = options.skipMirror ? p : { ...p, position: mirrorPosition(p.position) };
-    const isBW = p.champion.traits.includes('빌지워터');
+    const isBW = placedHasTrait(p, '빌지워터');
     const effects = isBW ? mergeEffects(enemyAugmentEffects, enemyBWEffects) : enemyAugmentEffects;
     const unit = createCombatUnit(positioned, 'enemy', i, enemyActiveTraits, effects);
     const mod = resolvePerUnitMods(enemyAugsWithStacks, p.champion);
@@ -1500,7 +1529,7 @@ export function simulateCombat(
     if (manaPerKill <= 0 && armorMRReduction <= 0) return;
     eventBus.on('on_death', 'harvester', () => {
       for (const u of killerTeam) {
-        if (u.champion.traits.includes('수확자') && u.state !== 'dead') {
+        if (unitHasTrait(u, '수확자') && u.state !== 'dead') {
           u.currentMana = Math.min(u.maxMana, u.currentMana + manaPerKill);
         }
       }
@@ -1542,8 +1571,8 @@ export function simulateCombat(
   const enemyGalioFlag = { spawned: false };
 
   // 중재자 법률 런타임
-  const playerArbiterUnits = playerUnits.filter(u => u.champion.traits.includes('중재자'));
-  const enemyArbiterUnits = enemies.filter(u => u.champion.traits.includes('중재자'));
+  const playerArbiterUnits = playerUnits.filter(u => unitHasTrait(u, '중재자'));
+  const enemyArbiterUnits = enemies.filter(u => unitHasTrait(u, '중재자'));
   const playerLawResolved = options.playerArbiterLaw && playerArbiterUnits.length >= 2
     ? resolveArbiterValue(options.playerArbiterLaw, playerArbiterUnits.length) : null;
   const enemyLawResolved = options.enemyArbiterLaw && enemyArbiterUnits.length >= 2
@@ -1711,12 +1740,12 @@ export function simulateCombat(
     const challengerIds = new Set<string>();
     if (playerChallengerActive) {
       for (const u of playerUnits) {
-        if ((u.resolvedTraits ?? u.champion.traits).includes('도전자')) challengerIds.add(u.id);
+        if (unitHasTrait(u, '도전자')) challengerIds.add(u.id);
       }
     }
     if (enemyChallengerActive) {
       for (const u of enemies) {
-        if ((u.resolvedTraits ?? u.champion.traits).includes('도전자')) challengerIds.add(u.id);
+        if (unitHasTrait(u, '도전자')) challengerIds.add(u.id);
       }
     }
 
@@ -1856,7 +1885,7 @@ export function simulateCombat(
           unit.attackCount++;
 
           // 중재자 법률 카운터 업데이트
-          if (unit.champion.traits.includes('중재자')) {
+          if (unitHasTrait(unit, '중재자')) {
             const arbState = unit.team === 'player' ? playerArbiterState : enemyArbiterState;
             arbState.hitCount++;
             arbState.attackCount++;
@@ -1946,7 +1975,7 @@ export function simulateCombat(
             unit.currentMana = 0;
             unit.state = 'casting';
             unit.castCount++;
-            if (unit.champion.traits.includes('중재자')) {
+            if (unitHasTrait(unit, '중재자')) {
               (unit.team === 'player' ? playerArbiterState : enemyArbiterState).manaSpent += unit.maxMana;
             }
             // 마나 소모 시점 — PsyOps 공감 임플란트 등

--- a/src/lib/simulator/systems/item.ts
+++ b/src/lib/simulator/systems/item.ts
@@ -1,5 +1,6 @@
 import { RawItem, ItemEffect, ItemCategory, EquipValidation, PlacedChampion, ActiveTrait } from '@/types';
 import { ITEM_EFFECT_KEYS } from '@/lib/simulator/models/constants';
+import { getEmblemTraitNames } from '@/lib/simulator/systems/trait';
 
 /** 비활성(disable) 아이템 — UI에서 숨김 처리 */
 const DISABLED_ITEMS = new Set([
@@ -170,7 +171,11 @@ export function canEquipItem(
     if (!voidTrait || !voidTrait.activeEffect) {
       return { canEquip: false, reason: '공허 시너지가 활성화되어야 합니다' };
     }
-    if (!champion.champion.traits.includes('공허')) {
+    // emblem 으로 공허 부여받은 unit 도 장착 가능 (champion.traits + emblem 합산)
+    const hasVoid =
+      champion.champion.traits.includes('공허') ||
+      getEmblemTraitNames(champion.items).includes('공허');
+    if (!hasVoid) {
       return { canEquip: false, reason: '공허 챔피언만 돌연변이를 장착할 수 있습니다' };
     }
     if (champion.voidItem) {

--- a/src/lib/simulator/systems/trait.ts
+++ b/src/lib/simulator/systems/trait.ts
@@ -14,12 +14,31 @@ function resolveMfTraits(champion: RawChampion, mfMode?: PlacedChampion['mfMode'
 const MF_TRAIT_API_TO_NAME: Record<string, string> = {};
 
 /**
- * Emblem 아이템 → 부여 trait 한글명 매핑.
- * 인벤토리 슬롯에 emblem 아이템이 들어가면 해당 unit 의 trait 카운트에 포함.
+ * Emblem 아이템 → 부여 trait 한글명 매핑 (Set 17 전체 19종).
+ * 인벤토리 슬롯에 emblem 아이템이 들어가면 해당 unit 의 trait 카운트에 +1
+ * 되고 unit 자체도 그 trait 보유 unit 으로 처리 (효과 받음).
  * 새 emblem 추가 시 여기에 등록.
  */
 const EMBLEM_ITEM_TO_TRAIT_NAME: Record<string, string> = {
+  TFT17_Item_AnimaSquadEmblemItem: '동물특공대',
+  TFT17_Item_ASTraitEmblemItem: '도전자',
+  TFT17_Item_AssassinTraitEmblemItem: '불한당',
+  TFT17_Item_AstronautEmblemItem: '정령족',
+  TFT17_Item_DarkStarEmblemItem: '암흑의 별',
+  TFT17_Item_DRXEmblemItem: 'N.O.V.A.',
+  TFT17_Item_FavoredEmblemItem: '중재자',
+  TFT17_Item_FlexTraitEmblemItem: '여행자',
+  TFT17_Item_HPTankEmblemItem: '싸움꾼',
+  TFT17_Item_MeleeTraitEmblemItem: '습격자',
+  TFT17_Item_PrimordianEmblemItem: '태고족',
+  TFT17_Item_PsyOpsEmblemItem: '초능력',
+  TFT17_Item_PulsefireEmblemItem: '시간 균열자',
+  TFT17_Item_RangedTraitEmblemItem: '저격수',
+  TFT17_Item_ResistTankEmblemItem: '요새',
+  TFT17_Item_ShieldTankEmblemItem: '선봉대',
+  TFT17_Item_SpaceGrooveEmblemItem: '우주 그루브',
   TFT17_Item_StargazerEmblemItem: '별돌보미',
+  TFT17_Item_SummonTraitEmblemItem: '길잡이',
 };
 
 function emblemTraitFromItems(items: RawItem[] | undefined): string[] {

--- a/src/lib/simulator/systems/trait.ts
+++ b/src/lib/simulator/systems/trait.ts
@@ -51,6 +51,11 @@ function emblemTraitFromItems(items: RawItem[] | undefined): string[] {
   return out;
 }
 
+/** Public helper: emblem 아이템 배열로부터 부여 trait 한글명 목록 추출. */
+export function getEmblemTraitNames(items: RawItem[] | undefined): string[] {
+  return emblemTraitFromItems(items);
+}
+
 export interface ResolveTraitsOptions {
   /** 별돌보미 변종 — game-level state. 지정 시 base 대신 specific 변종 trait 활성. */
   stargazerConstellation?: StargazerConstellationId;

--- a/tests/unit/simulator/emblem-trait-mappings.test.ts
+++ b/tests/unit/simulator/emblem-trait-mappings.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Set 17 emblem 아이템 19종이 각자의 trait 카운트에 +1 부여하고 unit 자체도
+ * 해당 trait 보유 unit 으로 처리되는지 회귀 가드.
+ *
+ * resolveTraits 가 champion.traits + emblem 합산 카운트 산출.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveTraits } from '@/lib/simulator/systems/trait';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { RawChampion, RawItem } from '@/types';
+
+const { champions, traits, items } = loadServerCatalogs();
+
+function findChamp(api: string): RawChampion {
+  const c = champions.find((x) => x.apiName === api);
+  if (!c) throw new Error(`champion ${api} missing`);
+  return c;
+}
+
+function findItem(api: string): RawItem {
+  const it = items.find((x) => x.apiName === api);
+  if (!it) throw new Error(`item ${api} missing`);
+  return it;
+}
+
+/**
+ * Set 17 emblem 19종 + 부여 trait 한글명. resolveTraits 결과의 카운트가 +1
+ * 되어야 한다 (champion 자체에 그 trait 없는 unit 이 emblem 통해 trait 보유).
+ */
+const EMBLEM_CASES: ReadonlyArray<readonly [emblemApi: string, traitName: string]> = [
+  ['TFT17_Item_AnimaSquadEmblemItem', '동물특공대'],
+  ['TFT17_Item_ASTraitEmblemItem', '도전자'],
+  ['TFT17_Item_AssassinTraitEmblemItem', '불한당'],
+  ['TFT17_Item_AstronautEmblemItem', '정령족'],
+  ['TFT17_Item_DarkStarEmblemItem', '암흑의 별'],
+  ['TFT17_Item_DRXEmblemItem', 'N.O.V.A.'],
+  ['TFT17_Item_FavoredEmblemItem', '중재자'],
+  ['TFT17_Item_FlexTraitEmblemItem', '여행자'],
+  ['TFT17_Item_HPTankEmblemItem', '싸움꾼'],
+  ['TFT17_Item_MeleeTraitEmblemItem', '습격자'],
+  ['TFT17_Item_PrimordianEmblemItem', '태고족'],
+  ['TFT17_Item_PsyOpsEmblemItem', '초능력'],
+  ['TFT17_Item_PulsefireEmblemItem', '시간 균열자'],
+  ['TFT17_Item_RangedTraitEmblemItem', '저격수'],
+  ['TFT17_Item_ResistTankEmblemItem', '요새'],
+  ['TFT17_Item_ShieldTankEmblemItem', '선봉대'],
+  ['TFT17_Item_SpaceGrooveEmblemItem', '우주 그루브'],
+  ['TFT17_Item_StargazerEmblemItem', '별돌보미'],
+  ['TFT17_Item_SummonTraitEmblemItem', '길잡이'],
+];
+
+describe('Emblem 19종 → trait 카운트 매핑', () => {
+  // Caitlyn 은 N.O.V.A. + 운명술사 trait 보유. emblem 없는 단일 unit baseline 으로 사용 —
+  // emblem 부여 시 champion 의 기본 trait 외에 추가 trait 카운트가 발생하는지 확인.
+  const baselineChamp = findChamp('TFT17_Caitlyn');
+
+  it.each(EMBLEM_CASES)(
+    '%s → trait "%s" 카운트 +1',
+    (emblemApi, traitName) => {
+      const emblem = findItem(emblemApi);
+      // emblem 보유 unit
+      const teamWithEmblem = [
+        { champion: baselineChamp, items: [emblem] },
+      ];
+      // baseline (champion 자체 trait 만)
+      const teamWithout = [{ champion: baselineChamp }];
+
+      const withEmblem = resolveTraits(teamWithEmblem, traits);
+      const without = resolveTraits(teamWithout, traits);
+
+      const withCount = withEmblem.find((t) => t.trait.name === traitName)?.count ?? 0;
+      const withoutCount = without.find((t) => t.trait.name === traitName)?.count ?? 0;
+
+      // emblem 보유 시 정확히 +1
+      expect(withCount - withoutCount).toBe(1);
+    },
+  );
+
+  it('같은 unit 의 여러 emblem 은 각자 카운트 (Set 17 룰)', () => {
+    const team = [
+      {
+        champion: baselineChamp,
+        items: [
+          findItem('TFT17_Item_StargazerEmblemItem'),
+          findItem('TFT17_Item_AnimaSquadEmblemItem'),
+        ],
+      },
+    ];
+    const active = resolveTraits(team, traits);
+    expect(active.find((t) => t.trait.name === '별돌보미')?.count).toBe(1);
+    expect(active.find((t) => t.trait.name === '동물특공대')?.count).toBe(1);
+  });
+
+  it('emblem 외 일반 아이템은 trait 카운트 무영향', () => {
+    const team = [
+      {
+        champion: baselineChamp,
+        items: [findItem('TFT_Item_BFSword'), findItem('TFT_Item_GargoyleStoneplate')],
+      },
+    ];
+    const active = resolveTraits(team, traits);
+    // Caitlyn 의 기본 trait (N.O.V.A., 운명술사) 만 카운트
+    const traitNames = active.map((t) => t.trait.name).sort();
+    expect(traitNames).toContain('N.O.V.A.');
+    expect(traitNames).toContain('운명술사');
+    // emblem 으로 부여될 만한 다른 trait 들은 카운트 0
+    expect(active.find((t) => t.trait.name === '별돌보미')).toBeUndefined();
+    expect(active.find((t) => t.trait.name === '도전자')).toBeUndefined();
+  });
+});

--- a/tests/unit/simulator/emblem-trait-mappings.test.ts
+++ b/tests/unit/simulator/emblem-trait-mappings.test.ts
@@ -91,6 +91,34 @@ describe('Emblem 19종 → trait 카운트 매핑', () => {
     expect(active.find((t) => t.trait.name === '동물특공대')?.count).toBe(1);
   });
 
+  it('emblem 보유 unit 의 resolvedTraits 에 부여 trait 가 포함되어야 함 (champion 자체 trait 미보유 케이스)', async () => {
+    // codex P1: trait 카운트는 +1 되지만 unit 의 resolvedTraits 에 emblem trait 가
+    // 누락되면 combat-time per-unit 효과 (도전자/불한당/시너지 buff / arbiter law)
+    // 가 그 unit 자체를 제외 — sim 모순. createCombatUnit 시점에 emblem trait 합산
+    // 되어 있어야 unitHasTrait 일관성 유지.
+    const { simulateCombat } = await import('@/lib/simulator/engine/combatLoop');
+    const challengerEmblem = findItem('TFT17_Item_ASTraitEmblemItem');
+    // Caitlyn 은 도전자 trait 미보유. emblem 으로 도전자 받음.
+    const ally = [
+      { champion: baselineChamp, starLevel: 2 as const, position: { q: 0, r: 3 }, items: [challengerEmblem] },
+    ];
+    const enemy = [
+      { champion: findChamp('TFT17_Aatrox'), starLevel: 1 as const, position: { q: 6, r: 3 }, items: [] },
+    ];
+    const result = simulateCombat(ally, enemy, {
+      seed: 0,
+      allTraits: traits,
+      skipMirror: true,
+      stageNumber: 5,
+    });
+    const unit = result.playerUnits.find((u) => u.champion.apiName === 'TFT17_Caitlyn')!;
+    expect(unit.resolvedTraits).toBeDefined();
+    expect(unit.resolvedTraits).toContain('도전자');
+    // champion 의 기본 trait (N.O.V.A., 운명술사) 도 보존
+    expect(unit.resolvedTraits).toContain('N.O.V.A.');
+    expect(unit.resolvedTraits).toContain('운명술사');
+  });
+
   it('emblem 외 일반 아이템은 trait 카운트 무영향', () => {
     const team = [
       {


### PR DESCRIPTION
## Summary

PR #14 (별돌보미 PR-2) 의 \`EMBLEM_ITEM_TO_TRAIT_NAME\` 매핑이 별돌보미 emblem 1종만 처리. 나머지 18 emblem 도 같은 패턴으로 추가 — emblem 보유 unit 의 trait 카운트 +1, 그 unit 자체도 trait 보유 unit 으로 처리 (효과 받음).

## Mapping (Set 17 전체 19종)

| emblem apiName | trait |
|---|---|
| TFT17_Item_FavoredEmblemItem | 중재자 |
| TFT17_Item_RangedTraitEmblemItem | 저격수 |
| TFT17_Item_ShieldTankEmblemItem | 선봉대 |
| TFT17_Item_AnimaSquadEmblemItem | 동물특공대 |
| TFT17_Item_PulsefireEmblemItem | 시간 균열자 |
| TFT17_Item_DRXEmblemItem | N.O.V.A. |
| TFT17_Item_AstronautEmblemItem | 정령족 |
| TFT17_Item_SummonTraitEmblemItem | 길잡이 |
| TFT17_Item_PsyOpsEmblemItem | 초능력 |
| TFT17_Item_HPTankEmblemItem | 싸움꾼 |
| TFT17_Item_AssassinTraitEmblemItem | 불한당 |
| TFT17_Item_ASTraitEmblemItem | 도전자 |
| TFT17_Item_DarkStarEmblemItem | 암흑의 별 |
| TFT17_Item_StargazerEmblemItem | 별돌보미 (PR-2) |
| TFT17_Item_MeleeTraitEmblemItem | 습격자 |
| TFT17_Item_SpaceGrooveEmblemItem | 우주 그루브 |
| TFT17_Item_ResistTankEmblemItem | 요새 |
| TFT17_Item_FlexTraitEmblemItem | 여행자 |
| TFT17_Item_PrimordianEmblemItem | 태고족 |

trait name 은 \`public/data/tft_set17_traits.json\` 의 \`name\` 필드와 정확히 매칭.

## 영향

- **\`/simulator\` 탭** (직접 팀 짜고 시뮬) 과 **actual-data validation** 양쪽 모두 emblem 인식
- 모든 trait 효과 — emblem 보유 unit 도 그 trait 보유 unit 으로 sim 처리 (단 그 trait 의 effect 가 sim 엔진에 구현된 것만)
- **별돌보미 외 trait 의 sim effect 는 아직 미구현 부분 多** — emblem 만으로 metric 큰 변화는 없음. PR-3 (별돌보미 6 변종 effects) + 후속 trait 구현 후 본격 효과.

## Test plan

- [x] 단위 테스트 +21 (273 → 294 pass)
  - 19개 emblem 각자 trait 카운트 +1 (it.each)
  - 같은 unit 의 여러 emblem 각자 독립 카운트
  - emblem 외 일반 아이템 trait 카운트 무영향
- [x] 양 게임 (23일/24일) 캐시 재실행 — **회귀 없음** (23일 player 팀이 별돌보미 emblem 만 활용, 다른 emblem 보유 unit 없음)
- [x] \`pnpm lint\` 0 errors
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm build\` succeeds
- [x] PR review

## Followup

- **PR-3**: 별돌보미 7개 변종 강화 칸 패턴 + 6 변종 effects (Wolf/Medallion/Huntress/Serpent/Shield/Fountain). 위 emblem 매핑 활용해 emblem 보유 unit 도 정확히 효과 받음.
- 다른 trait (운명술사 / N.O.V.A. capstone / 정령족) 의 sim effect 구현은 별 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)