### PR TITLE
feat(simulator): PR-7 옵션 E — 강화 칸 player level 점진 공개 (revealedTiles)

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-28T01:19:44.475Z",
+  "computedAt": "2026-04-28T04:26:15.849Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "a41b76d550f39eb8524e5399f79156a6bca278b4",
+  "engineSha": "e74c41568f00f5049b8c0576ad3c7dfd83fc8055",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [
@@ -1090,13 +1090,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 4123,
-          "simMean": 4483.52220581138,
+          "simMean": 4477.778896828879,
           "simMedian": 4671.025427666889,
           "simRange": [
-            2593.0771683478915,
+            2535.6440785228765,
             4993.456372091268
           ],
-          "diffPct": 0.08744171860571924
+          "diffPct": 0.08604872588621847
         },
         {
           "hex": {
@@ -1105,13 +1105,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 1083,
-          "simMean": 321.45053891477056,
+          "simMean": 328.8199044199147,
           "simMedian": 299.2652172220801,
           "simRange": [
             221.82695722522968,
-            473.58620602252165
+            547.2798610739633
           ],
-          "diffPct": -0.7031850979549672
+          "diffPct": -0.6963805130010021
         },
         {
           "hex": {
@@ -1184,9 +1184,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.9,
-          "simMeanHp": 92.49086802449048,
+          "simMeanHp": 91.59355036703965,
           "aliveMismatch": true,
-          "hpDiffPoints": 92.49086802449048
+          "hpDiffPoints": 91.59355036703965
         },
         {
           "hex": {
@@ -1240,9 +1240,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.1,
-          "simMeanHp": 44.694581382857436,
+          "simMeanHp": 34.733724257837636,
           "aliveMismatch": false,
-          "hpDiffPoints": 44.694581382857436
+          "hpDiffPoints": 34.733724257837636
         },
         {
           "hex": {
@@ -1254,9 +1254,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.1,
-          "simMeanHp": 4.170955397779685,
+          "simMeanHp": 3.875122885464414,
           "aliveMismatch": false,
-          "hpDiffPoints": 4.170955397779685
+          "hpDiffPoints": 3.875122885464414
         },
         {
           "hex": {
@@ -1282,9 +1282,9 @@
           "actualAlive": true,
           "actualHp": 8,
           "simAliveRate": 0.1,
-          "simMeanHp": 19.73702671154846,
+          "simMeanHp": 20.493966456713782,
           "aliveMismatch": true,
-          "hpDiffPoints": 11.73702671154846
+          "hpDiffPoints": 12.493966456713782
         }
       ],
       "warnings": []
@@ -1554,13 +1554,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 4574,
-          "simMean": 4747.768935885834,
-          "simMedian": 4399.7582019098845,
+          "simMean": 4607.444598724317,
+          "simMedian": 4553.032525086661,
           "simRange": [
-            4119.314580659638,
-            5730.219702656463
+            3789.700342949076,
+            5376.773528077656
           ],
-          "diffPct": 0.037990585020951956
+          "diffPct": 0.007311893031114358
         },
         {
           "hex": {
@@ -1569,13 +1569,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 1742,
-          "simMean": 419.3952879598504,
-          "simMedian": 415.91886093843783,
+          "simMean": 413.7298144157711,
+          "simMedian": 402.09330395317465,
           "simRange": [
             362.92089249492903,
-            558.9833275371259
+            474.67747812580626
           ],
-          "diffPct": -0.7592449552469285
+          "diffPct": -0.7624972362710842
         },
         {
           "hex": {
@@ -1584,13 +1584,13 @@
           },
           "championId": "TFT17_Caitlyn",
           "actual": 1311,
-          "simMean": 150.45882306379434,
-          "simMedian": 97.6470588235294,
+          "simMean": 139.39835276806355,
+          "simMedian": 87.40588257856228,
           "simRange": [
-            97.6470588235294,
-            286.70588002485385
+            87.40588257856228,
+            272.3682335260686
           ],
-          "diffPct": -0.8852335445737648
+          "diffPct": -0.8936702114660081
         },
         {
           "hex": {
@@ -1599,13 +1599,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 725,
-          "simMean": 197.71561754644523,
+          "simMean": 198.4032443486169,
           "simMedian": 187.03448090060004,
           "simRange": [
             144.40162271805275,
-            284.6774810709769
+            280.09330284522946
           ],
-          "diffPct": -0.7272888033842135
+          "diffPct": -0.7263403526225973
         },
         {
           "hex": {
@@ -1689,10 +1689,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.6,
-          "simMeanHp": 56.527432941647966,
-          "aliveMismatch": true,
-          "hpDiffPoints": 56.527432941647966
+          "simAliveRate": 0.5,
+          "simMeanHp": 40.01180456203441,
+          "aliveMismatch": false,
+          "hpDiffPoints": 40.01180456203441
         },
         {
           "hex": {
@@ -1704,9 +1704,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 44.669645745945864,
+          "simMeanHp": 57.369132200763566,
           "aliveMismatch": true,
-          "hpDiffPoints": 44.669645745945864
+          "hpDiffPoints": 57.369132200763566
         },
         {
           "hex": {
@@ -1769,13 +1769,13 @@
           },
           "championId": "TFT17_Caitlyn",
           "actual": 1454,
-          "simMean": 593.3229303231483,
-          "simMedian": 583.7733413403014,
+          "simMean": 577.2569570203178,
+          "simMedian": 531.1394973296538,
           "simRange": [
-            402.4592564370897,
-            776.7816588202243
+            458.10190988459703,
+            870.2045478869394
           ],
-          "diffPct": -0.5919374619510672
+          "diffPct": -0.6029869621593412
         },
         {
           "hex": {
@@ -1784,13 +1784,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 479,
-          "simMean": 206.19130387513536,
+          "simMean": 220.06956450835523,
           "simMedian": 198.2608695652174,
           "simRange": [
             198.2608695652174,
-            237.91304111480713
+            337.0434758974159
           ],
-          "diffPct": -0.5695379877345818
+          "diffPct": -0.5405645834898638
         },
         {
           "hex": {
@@ -1799,13 +1799,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 1323,
-          "simMean": 3801.5703444852697,
-          "simMedian": 3795.537367413026,
+          "simMean": 3708.2647743644566,
+          "simMedian": 3751.3053676835807,
           "simRange": [
-            3448.460486392833,
-            4152.0845201154025
+            3413.9412202146445,
+            3871.3909375139087
           ],
-          "diffPct": 1.8734469724000526
+          "diffPct": 1.802921220230126
         },
         {
           "hex": {
@@ -1814,13 +1814,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 945,
-          "simMean": 542.2845064114483,
-          "simMedian": 543.6382973139384,
+          "simMean": 560.0746517713169,
+          "simMedian": 559.6508073156346,
           "simRange": [
-            427.52327149562717,
+            516.4739982949702,
             652.9145698726228
           ],
-          "diffPct": -0.42615396146936685
+          "diffPct": -0.4073284108240033
         },
         {
           "hex": {
@@ -1829,13 +1829,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 676,
-          "simMean": 247.0874664833072,
+          "simMean": 242.74485797960355,
           "simMedian": 224.58098832024012,
           "simRange": [
-            224.58098832024012,
-            324.28294740687335
+            211.42156806537042,
+            359.81337997724273
           ],
-          "diffPct": -0.6344859963264686
+          "diffPct": -0.6409099734029533
         }
       ],
       "survivors": [
@@ -1849,9 +1849,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 59.896416818952126,
+          "simMeanHp": 58.55779261321088,
           "aliveMismatch": true,
-          "hpDiffPoints": 59.896416818952126
+          "hpDiffPoints": 58.55779261321088
         },
         {
           "hex": {
@@ -1956,13 +1956,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 6242,
-          "simMean": 6973.091257251743,
-          "simMedian": 6969.224494792971,
+          "simMean": 7063.437172662181,
+          "simMedian": 7013.756024364923,
           "simRange": [
-            6477.578772424104,
-            7496.607224485276
+            6561.584888943495,
+            7643.3882708663305
           ],
-          "diffPct": 0.11712452054657846
+          "diffPct": 0.13159839356971822
         },
         {
           "hex": {
@@ -1971,13 +1971,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 2130,
-          "simMean": 492.9575297804537,
-          "simMedian": 523.9777753771493,
+          "simMean": 542.7205955300477,
+          "simMedian": 519.1446717368232,
           "simRange": [
-            197.74329261852864,
-            702.1537099360506
+            475.6467432950192,
+            649.2245210727968
           ],
-          "diffPct": -0.7685645400091767
+          "diffPct": -0.7452015983427005
         },
         {
           "hex": {
@@ -1986,13 +1986,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 944,
-          "simMean": 474.73251891094696,
-          "simMedian": 496.2782608695652,
+          "simMean": 532.5913021834,
+          "simMedian": 536.6260845516039,
           "simRange": [
-            342.9565193342126,
-            576.9739082336425
+            496.2782608695652,
+            617.3217319156812
           ],
-          "diffPct": -0.4971053825095901
+          "diffPct": -0.4358142985345339
         },
         {
           "hex": {
@@ -2001,13 +2001,13 @@
           },
           "championId": "TFT17_Caitlyn",
           "actual": 2608,
-          "simMean": 201.73999847306146,
-          "simMedian": 160.11111111111114,
+          "simMean": 177.91172387730404,
+          "simMedian": 143.00000061262398,
           "simRange": [
-            160.11111111111114,
-            384.26666284932037
+            143.00000061262398,
+            320.51724275243305
           ],
-          "diffPct": -0.922645706106955
+          "diffPct": -0.9317823144642239
         },
         {
           "hex": {
@@ -2016,13 +2016,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 846,
-          "simMean": 241.27199764893166,
-          "simMedian": 216.31034249513002,
+          "simMean": 147.43792958354643,
+          "simMedian": 142.75862027345033,
           "simRange": [
-            161.37930987433515,
-            367.299307299881
+            111.62931001937852,
+            199.86206497919972
           ],
-          "diffPct": -0.7148085134173384
+          "diffPct": -0.8257234874898979
         }
       ],
       "survivors": [
@@ -2036,9 +2036,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 69.9563763367182,
+          "simMeanHp": 87.03632231380507,
           "aliveMismatch": true,
-          "hpDiffPoints": 69.9563763367182
+          "hpDiffPoints": 87.03632231380507
         },
         {
           "hex": {
@@ -2050,9 +2050,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 40.54975052058745,
+          "simMeanHp": 29.162219272305855,
           "aliveMismatch": true,
-          "hpDiffPoints": 40.54975052058745
+          "hpDiffPoints": 29.162219272305855
         },
         {
           "hex": {
@@ -2063,10 +2063,10 @@
           "team": "player",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.3,
-          "simMeanHp": 5.7642164854173155,
+          "simAliveRate": 0,
+          "simMeanHp": 0,
           "aliveMismatch": false,
-          "hpDiffPoints": 5.7642164854173155
+          "hpDiffPoints": 0
         },
         {
           "hex": {
@@ -2171,13 +2171,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 5564,
-          "simMean": 7843.825770230028,
-          "simMedian": 7813.884943224819,
+          "simMean": 8041.420237866968,
+          "simMedian": 8008.894185585676,
           "simRange": [
-            7176.301640465518,
+            7341.593940294115,
             8818.84520777595
           ],
-          "diffPct": 0.4097458249874241
+          "diffPct": 0.4452588493650194
         },
         {
           "hex": {
@@ -2186,13 +2186,13 @@
           },
           "championId": "TFT17_Caitlyn",
           "actual": 1482,
-          "simMean": 479.5844046275562,
-          "simMedian": 440.60689416424987,
+          "simMean": 434.4703236505235,
+          "simMedian": 393.4669649928278,
           "simRange": [
-            376.1018620728548,
-            649.6604779875613
+            335.8446220664499,
+            600.8323422325936
           ],
-          "diffPct": -0.676393789050232
+          "diffPct": -0.7068351392371637
         },
         {
           "hex": {
@@ -2201,13 +2201,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 1342,
-          "simMean": 462.22599128731474,
-          "simMedian": 457.5627970977014,
+          "simMean": 467.3149712402259,
+          "simMedian": 508.5972798563221,
           "simRange": [
             201.86972984043575,
-            743.2028130520667
+            655.8457695105994
           ],
-          "diffPct": -0.65556930604522
+          "diffPct": -0.6517772196421566
         },
         {
           "hex": {
@@ -2216,13 +2216,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 1464,
-          "simMean": 378.5151949666137,
-          "simMedian": 395.9999978542328,
+          "simMean": 355.6980223776568,
+          "simMedian": 371.482757658794,
           "simRange": [
-            263.5454511642456,
-            473.1310632162566
+            206.8181818181818,
+            444.7674285432248
           ],
-          "diffPct": -0.7414513695583239
+          "diffPct": -0.7570368699606169
         },
         {
           "hex": {
@@ -2231,13 +2231,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 382,
-          "simMean": 256.61341628808526,
-          "simMedian": 266.15769050364884,
+          "simMean": 215.05345885910947,
+          "simMedian": 184.53599841588735,
           "simRange": [
             167.75999946892262,
-            364.55538153837506
+            365.8458429958339
           ],
-          "diffPct": -0.32823713013590244
+          "diffPct": -0.4370328302117553
         },
         {
           "hex": {
@@ -2246,13 +2246,13 @@
           },
           "championId": "TFT17_Milio",
           "actual": 1069,
-          "simMean": 1037.584408086356,
-          "simMedian": 1042.6833735887526,
+          "simMean": 1024.9782133546819,
+          "simMedian": 1044.7003238802326,
           "simRange": [
-            131.71438738874065,
-            1355.81259821718
+            139.076895077041,
+            1327.3000308369633
           ],
-          "diffPct": -0.029387831537552846
+          "diffPct": -0.0411803429797176
         }
       ],
       "opponentDamage": [
@@ -2263,13 +2263,13 @@
           },
           "championId": "TFT17_IvernMinion",
           "actual": 6057,
-          "simMean": 3718.1584390487747,
-          "simMedian": 3691.6496429547597,
+          "simMean": 3748.034872729605,
+          "simMedian": 3703.09065168273,
           "simRange": [
-            2635.5805207725684,
-            4969.770877884088
+            2722.550431512066,
+            4882.357216085903
           ],
-          "diffPct": -0.38613861002992
+          "diffPct": -0.3812060636074616
         },
         {
           "hex": {
@@ -2278,13 +2278,13 @@
           },
           "championId": "TFT17_Veigar",
           "actual": 2565,
-          "simMean": 172.37748605843322,
-          "simMedian": 167.71764656655927,
+          "simMean": 175.97894660450456,
+          "simMedian": 179.94158115545343,
           "simRange": [
             114.35294146046918,
-            234.00920505541973
+            247.15322131524377
           ],
-          "diffPct": -0.932796301731605
+          "diffPct": -0.9313922235460022
         },
         {
           "hex": {
@@ -2293,13 +2293,13 @@
           },
           "championId": "TFT17_Karma",
           "actual": 1558,
-          "simMean": 105.49289991599312,
-          "simMedian": 110.26369084209264,
+          "simMean": 106.33671336918766,
+          "simMedian": 102.8803242631181,
           "simRange": [
-            79.99999943901511,
-            117.32251455527532
+            89.41176358391257,
+            122.35293949351592
           ],
-          "diffPct": -0.9322895379229826
+          "diffPct": -0.9317479375037306
         },
         {
           "hex": {
@@ -2323,13 +2323,13 @@
           },
           "championId": "TFT17_Lissandra",
           "actual": 962,
-          "simMean": 48.827586009584614,
+          "simMean": 52.551723841963145,
           "simMedian": 41.37931034482759,
           "simRange": [
             41.37931034482759,
-            70.34482709292708
+            78.62068866861277
           ],
-          "diffPct": -0.9492436735867104
+          "diffPct": -0.9453724284387077
         }
       ],
       "survivors": [
@@ -2343,9 +2343,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 65.5851481088282,
+          "simMeanHp": 63.68796643241245,
           "aliveMismatch": true,
-          "hpDiffPoints": 65.5851481088282
+          "hpDiffPoints": 63.68796643241245
         },
         {
           "hex": {
@@ -2357,9 +2357,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 65.58853543670732,
+          "simMeanHp": 61.754559982738684,
           "aliveMismatch": true,
-          "hpDiffPoints": 65.58853543670732
+          "hpDiffPoints": 61.754559982738684
         },
         {
           "hex": {
@@ -2399,9 +2399,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 82.51934959667733,
+          "simMeanHp": 80.95430039880304,
           "aliveMismatch": true,
-          "hpDiffPoints": 82.51934959667733
+          "hpDiffPoints": 80.95430039880304
         },
         {
           "hex": {
@@ -2506,13 +2506,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 10147,
-          "simMean": 8860.05082616381,
-          "simMedian": 8946.50602065745,
+          "simMean": 8926.329322405812,
+          "simMedian": 9000.028936399889,
           "simRange": [
             8445.335133722212,
-            9081.316371576611
+            9090.540518605076
           ],
-          "diffPct": -0.12683050890274863
+          "diffPct": -0.12029867720451241
         },
         {
           "hex": {
@@ -2521,13 +2521,13 @@
           },
           "championId": "TFT17_Caitlyn",
           "actual": 2657,
-          "simMean": 1043.4398745167205,
-          "simMedian": 1047.783802657292,
+          "simMean": 944.1135724848218,
+          "simMedian": 945.9203102916829,
           "simRange": [
-            686.0965469130156,
-            1316.4707489292484
+            612.611998087511,
+            1196.1891353202723
           ],
-          "diffPct": -0.6072864604754533
+          "diffPct": -0.6446693366635974
         },
         {
           "hex": {
@@ -2536,13 +2536,13 @@
           },
           "championId": "TFT17_Milio",
           "actual": 2555,
-          "simMean": 1026.722877624152,
+          "simMean": 1021.7552016386071,
           "simMedian": 1070.6273155535732,
           "simRange": [
             861.3098031624486,
-            1127.946652271474
+            1105.783175407219
           ],
-          "diffPct": -0.5981515156069855
+          "diffPct": -0.6000958114917389
         },
         {
           "hex": {
@@ -2581,13 +2581,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 2440,
-          "simMean": 640.4257824790378,
-          "simMedian": 647.0336204679141,
+          "simMean": 635.2083914856707,
+          "simMedian": 643.4868226497631,
           "simRange": [
             553.4804026558149,
             692.1139347652828
           ],
-          "diffPct": -0.7375304170167878
+          "diffPct": -0.7396686920140694
         }
       ],
       "survivors": [
@@ -2629,9 +2629,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.4,
-          "simMeanHp": 53.50747587632061,
+          "simMeanHp": 47.91464825111047,
           "aliveMismatch": false,
-          "hpDiffPoints": 53.50747587632061
+          "hpDiffPoints": 47.91464825111047
         },
         {
           "hex": {
@@ -2792,13 +2792,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 6971,
-          "simMean": 8420.483299095275,
-          "simMedian": 8411.57042821314,
+          "simMean": 8478.441869291388,
+          "simMedian": 8508.493891890808,
           "simRange": [
-            8007.368348292502,
+            8062.7826108882,
             9134.212749825312
           ],
-          "diffPct": 0.20793046895643014
+          "diffPct": 0.21624470940917914
         },
         {
           "hex": {
@@ -2807,13 +2807,13 @@
           },
           "championId": "TFT17_Caitlyn",
           "actual": 2055,
-          "simMean": 1160.9019096052139,
-          "simMedian": 1094.6009118199058,
+          "simMean": 1022.136485776086,
+          "simMedian": 959.4299032313097,
           "simRange": [
-            908.3027027027027,
-            1829.0572413793104
+            810.9143543500845,
+            1728.564013439165
           ],
-          "diffPct": -0.4350842289025723
+          "diffPct": -0.5026099825907124
         },
         {
           "hex": {
@@ -2837,13 +2837,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 1497,
-          "simMean": 482.9783216908084,
-          "simMedian": 481.2285028479565,
+          "simMean": 478.11432198072544,
+          "simMedian": 478.9884017209008,
           "simRange": [
             261.7856432584992,
             644.7595348314306
           ],
-          "diffPct": -0.6773691905873024
+          "diffPct": -0.680618355390297
         },
         {
           "hex": {
@@ -2887,9 +2887,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 77.81715832127239,
+          "simMeanHp": 76.74016678244797,
           "aliveMismatch": true,
-          "hpDiffPoints": 77.81715832127239
+          "hpDiffPoints": 76.74016678244797
         },
         {
           "hex": {
@@ -2915,9 +2915,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 64.89454210983219,
+          "simMeanHp": 56.58026197773254,
           "aliveMismatch": true,
-          "hpDiffPoints": 64.89454210983219
+          "hpDiffPoints": 56.58026197773254
         },
         {
           "hex": {
@@ -5685,7 +5685,7 @@
     "pvpRoundCount": 22,
     "winnerMatchRate": 0.4090909090909091,
     "weakSignalRoundCount": 0,
-    "avgPlayerDamageErrorPct": -0.4370761939314006,
-    "avgSurvivorHpErrorPts": 7.621002536417259
+    "avgPlayerDamageErrorPct": -0.43997561555281356,
+    "avgSurvivorHpErrorPts": 7.6979815955433635
   }
 }

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-04-28T01:19:45.593Z",
+  "computedAt": "2026-04-28T04:26:17.012Z",
   "sourceGameMtime": 1777278310429,
-  "engineSha": "a41b76d550f39eb8524e5399f79156a6bca278b4",
+  "engineSha": "e74c41568f00f5049b8c0576ad3c7dfd83fc8055",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -116,6 +116,14 @@ export interface SimulateOptions {
   priorPlayerShieldDeaths?: number;
   /** B 팀(enemy) 누적 사망 카운트. 의미는 player 와 동일. */
   priorEnemyShieldDeaths?: number;
+  /**
+   * 별돌보미 강화 칸 점진 공개 — 플레이어 레벨에 따라 14칸 풀 패턴 중
+   * 일부만 공개됨. 미지정 시 full reveal (PR-3 기존 동작 유지, backward compat).
+   * 추정 매핑 (정확한 spec 자료 없음): min(14, max(0, (level-1) * 2)).
+   */
+  playerLevel?: number;
+  /** B 팀(enemy) 플레이어 레벨. 의미는 player 와 동일. */
+  enemyLevel?: number;
 }
 
 function createCombatUnit(
@@ -667,11 +675,24 @@ function applyJuggernautDR(activeTraits: ActiveTrait[], units: CombatUnit[]): vo
  *   - 비-Teamwide 변수 (예: Wolf_Health, Wolf_ADAP) → **강화 칸의 별돌보미만**
  *     추가 stat
  */
+/**
+ * 강화 칸 점진 공개 — 플레이어 레벨에 따라 14칸 패턴 중 일부만 활성.
+ * 추정 매핑 (정확한 spec 자료 없음): min(14, max(0, (level-1) * 2)).
+ *   lvl 1 → 0, 2 → 2, 3 → 4, ..., 8 → 14, 9 → 14 (capped).
+ * undefined 입력 시 full 14 (backward compat — PR-3 기본 동작).
+ */
+function revealedTileCount(level: number | undefined): number {
+  if (level == null) return 14;
+  const computed = Math.max(0, (level - 1) * 2);
+  return Math.min(14, computed);
+}
+
 function applyStargazerEffects(
   traits: ActiveTrait[],
   units: CombatUnit[],
   opposingUnits: CombatUnit[],
   constellation: StargazerConstellationId | undefined,
+  playerLevel: number | undefined,
 ): void {
   const stargazer = traits.find((t) => t.trait.name === '별돌보미');
   if (!stargazer || !stargazer.activeEffect || stargazer.style === 0) return;
@@ -681,7 +702,11 @@ function applyStargazerEffects(
   if (!constellation) return;
 
   const eff = stargazer.activeEffect.variables;
-  const empoweredTiles = CONSTELLATION_TILE_PATTERN[constellation];
+  // 점진 공개 — 플레이어 레벨에 따라 14칸 중 첫 N칸만 활성. 미지정 시 full.
+  const empoweredTiles = CONSTELLATION_TILE_PATTERN[constellation].slice(
+    0,
+    revealedTileCount(playerLevel),
+  );
   const isStargazerUnit = (u: CombatUnit): boolean => unitHasTrait(u, '별돌보미');
   // CONSTELLATION_TILE_PATTERN 은 player half (r=0..3) 만 정의. enemy 팀이
   // mirror 된 보드 (r=4..7) 에 있을 때 (skipMirror=false 또는 simulator 직접 호출)
@@ -1709,8 +1734,8 @@ export function simulateCombat(
   applyShenBastionAura(enemyActiveTraits, enemies);
   applyJhinAnnihilator(playerActiveTraits, enemies);  // 적 대상
   applyJhinAnnihilator(enemyActiveTraits, playerUnits);
-  applyStargazerEffects(playerActiveTraits, playerUnits, enemies, options.playerStargazerConstellation);
-  applyStargazerEffects(enemyActiveTraits, enemies, playerUnits, options.enemyStargazerConstellation);
+  applyStargazerEffects(playerActiveTraits, playerUnits, enemies, options.playerStargazerConstellation, options.playerLevel);
+  applyStargazerEffects(enemyActiveTraits, enemies, playerUnits, options.enemyStargazerConstellation, options.enemyLevel);
   applyMorganaDarklight(playerActiveTraits, playerUnits);
   applyMorganaDarklight(enemyActiveTraits, enemies);
 

--- a/src/lib/validation/schemaAdapter.ts
+++ b/src/lib/validation/schemaAdapter.ts
@@ -195,6 +195,9 @@ export function toNRunInput(
         // game-level 단일 별자리 → 양 팀에 동일 전달 (실제 게임은 양 팀 동일 별자리).
         playerStargazerConstellation: options.stargazerConstellation,
         enemyStargazerConstellation: options.stargazerConstellation,
+        // 별돌보미 강화 칸 점진 공개 — round metadata 의 player level 전달.
+        playerLevel: round.playerTeam.level,
+        enemyLevel: round.opponent.level,
         skipMirror: true,
         stageNumber,
       },

--- a/tests/unit/simulator/stargazer-tile-reveal.test.ts
+++ b/tests/unit/simulator/stargazer-tile-reveal.test.ts
@@ -1,0 +1,144 @@
+/**
+ * 별돌보미 강화 칸 점진 공개 (revealedTiles) 회귀 가드 (PR-7 옵션 E).
+ *
+ * Spec 텍스트: "플레이어 레벨이 오를 때마다 더 많은 칸이 드러납니다."
+ * 정확한 reveal 매핑은 spec 자료 부족이라 추정 적용 (보수적):
+ *   tiles = min(14, max(0, (level - 1) * 2))
+ *   lvl 1 → 0, 2 → 2, 3 → 4, 4 → 6, ..., 8 → 14, 9 → 14 (capped).
+ *
+ * playerLevel 미지정 시 full 14 (PR-3 backward compat).
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import { CONSTELLATION_TILE_PATTERN } from '@/lib/actualData/stargazerMapping';
+import type { PlacedChampion, RawChampion, RawItem } from '@/types';
+
+const { champions, traits, items } = loadServerCatalogs();
+const STARGAZER_EMBLEM = items.find((i) => i.apiName === 'TFT17_Item_StargazerEmblemItem')!;
+const apTwistedFate = champions.find((c) => c.apiName === 'TFT17_TwistedFate')!;
+const apTalon = champions.find((c) => c.apiName === 'TFT17_Talon')!;
+const apJax = champions.find((c) => c.apiName === 'TFT17_Jax')!;
+const apAatrox = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
+const apMilio = champions.find((c) => c.apiName === 'TFT17_Milio')!;
+const apCorki = champions.find((c) => c.apiName === 'TFT17_Corki')!;
+const dummyEnemy = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
+
+function placed(c: RawChampion, q: number, r: number, extraItems: RawItem[] = []): PlacedChampion {
+  return { champion: c, starLevel: 2, position: { q, r }, items: extraItems };
+}
+
+/** mountain 첫 6 tile 에 별돌보미 6명 배치 (3 base + 3 emblem). */
+function buildMountainTeam(): PlacedChampion[] {
+  const tiles = CONSTELLATION_TILE_PATTERN.mountain;
+  return [
+    placed(apTwistedFate, tiles[0].q, tiles[0].r),
+    placed(apTalon, tiles[1].q, tiles[1].r),
+    placed(apJax, tiles[2].q, tiles[2].r),
+    placed(apAatrox, tiles[3].q, tiles[3].r, [STARGAZER_EMBLEM]),
+    placed(apMilio, tiles[4].q, tiles[4].r, [STARGAZER_EMBLEM]),
+    placed(apCorki, tiles[5].q, tiles[5].r, [STARGAZER_EMBLEM]),
+  ];
+}
+
+describe('Tile reveal — playerLevel 미지정 시 full 14 (backward compat)', () => {
+  it('playerLevel undefined 일 때 모든 6 unit (첫 6 tile) effect 받음', () => {
+    const team = buildMountainTeam();
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const noLevel = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'mountain',
+      // playerLevel 미지정
+    });
+    const noConst = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const tf1 = noLevel.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    const tf2 = noConst.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    // mountain 효과로 maxHp 증가 (level 미지정이라 full 14 reveal — 첫 6 tile 모두 강화 칸)
+    expect(tf1.maxHp).toBeGreaterThan(tf2.maxHp);
+  });
+});
+
+describe('Tile reveal — playerLevel 9 (full reveal)', () => {
+  it('lvl 9 → revealed 14 (모든 unit effect)', () => {
+    const team = buildMountainTeam();
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const lvl9 = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'mountain',
+      playerLevel: 9,
+    });
+    const noLevel = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'mountain',
+    });
+    // lvl 9 = 14 reveal = full = no level (default 14)
+    const tfLvl9 = lvl9.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    const tfNoLevel = noLevel.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    expect(tfLvl9.maxHp).toBe(tfNoLevel.maxHp);
+  });
+});
+
+describe('Tile reveal — playerLevel 1 (no tiles)', () => {
+  it('lvl 1 → revealed 0 → 강화 칸 효과 미적용 (별자리 효과 없음)', () => {
+    const team = buildMountainTeam();
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const lvl1 = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'mountain',
+      playerLevel: 1,
+    });
+    const noConst = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    // lvl 1 = 0 reveal = 별자리 미선택과 동일
+    const tf1 = lvl1.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    const tf2 = noConst.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    expect(tf1.maxHp).toBe(tf2.maxHp);
+  });
+});
+
+describe('Tile reveal — playerLevel 4 → 6 tiles (첫 6 unit 만 effect)', () => {
+  it('lvl 4 reveal=6 → 6 unit 모두 강화 칸 안 (mountain 6 tile 위에 정확히)', () => {
+    // 패턴 첫 6 tile = lvl 4 의 reveal 6 tile 과 일치 → 모두 effect.
+    const team = buildMountainTeam();
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const lvl4 = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'mountain',
+      playerLevel: 4,
+    });
+    const lvl9 = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'mountain',
+      playerLevel: 9,
+    });
+    // 첫 6 unit 이 첫 6 tile 위 — lvl 4 (6 reveal) 와 lvl 9 (14 reveal) 동일 결과.
+    const tf4 = lvl4.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    const tf9 = lvl9.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    expect(tf4.maxHp).toBe(tf9.maxHp);
+  });
+
+  it('lvl 3 reveal=4 → 첫 4 unit 만 강화 칸, 5/6 번째 unit 미적용', () => {
+    // mountain 첫 4 tile 안의 unit (TF/Talon/Jax/Aatrox) 만 effect, 5,6 (Milio/Corki) 미적용.
+    const team = buildMountainTeam();
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const lvl3 = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'mountain',
+      playerLevel: 3,
+    });
+    const noConst = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    // 5 번째 unit (Milio) — 강화 칸 외 → maxHp 동일 (효과 미적용)
+    const milio3 = lvl3.playerUnits.find(u => u.champion.apiName === 'TFT17_Milio')!;
+    const milioNo = noConst.playerUnits.find(u => u.champion.apiName === 'TFT17_Milio')!;
+    expect(milio3.maxHp).toBe(milioNo.maxHp);
+    // 1 번째 unit (TF) — 강화 칸 안 → maxHp 큼
+    const tf3 = lvl3.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    const tfNo = noConst.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    expect(tf3.maxHp).toBeGreaterThan(tfNo.maxHp);
+  });
+});


### PR DESCRIPTION
## Summary

handoff PR-4 옵션 E: 별돌보미 강화 칸의 플레이어 레벨별 점진 공개 메커니즘 구현. handoff 5 옵션 (A~E) 중 마지막.

> 노트: 옵션 D (Mountain emblem 누적) 는 PR-6 사전 점검 결과 actual-data 가 이미 정확해서 스킵.

## Spec

> "플레이어 레벨이 오를 때마다 더 많은 칸이 드러납니다."

정확한 reveal 매핑은 spec 자료 부족 → 추정 적용 (보수적):
```
tiles = min(14, max(0, (level - 1) * 2))
lvl 1 → 0, 2 → 2, 3 → 4, 4 → 6, ..., 8 → 14, 9 → 14 (capped)
```

## 구현

- `SimulateOptions` 에 `playerLevel` / `enemyLevel` 추가 (optional)
- `revealedTileCount(level)` helper — 위 매핑 함수
- `applyStargazerEffects` 시그니처에 `playerLevel` 추가 (caller 양 팀별 갱신)
- `empoweredTiles = CONSTELLATION_TILE_PATTERN[id].slice(0, revealedTileCount(level))`
- `schemaAdapter`: `round.playerTeam.level` / `round.opponent.level` 자동 전달

**Backward compat**: playerLevel 미지정 시 full 14 (PR-3 기존 동작 유지)

**UI 표시**: simulator/page.tsx 는 풀 reveal 유지 — 사용자가 강화 칸 최대 영역 시각화. level 점진 공개는 engine 내부 효과 적용에만 영향.

## 4-게이트

lint 0 / typecheck 0 / **test 342/342** (PR-6 baseline 337 + tile reveal 5) / build ✅

## 회귀 가드

`tests/unit/simulator/stargazer-tile-reveal.test.ts` (5 케이스):
- playerLevel undefined → full 14 (backward compat)
- lvl 9 → full 14 (= no level 동일)
- lvl 1 → 0 reveal (별자리 미선택과 동일)
- lvl 4 reveal 6 → 첫 6 unit 모두 effect (lvl 9 와 동일)
- lvl 3 reveal 4 → 5/6 번째 unit 효과 미적용

## Calibration 영향

| | 23일 (mountain) | 24일 (well) |
|---|---|---|
| winnerMatchRate | **40.9%** (불변) | **76.2%** (불변) |
| avgPlayerDamageErrorPct | -43.7% → **-44.0%** (-0.3%) | -16.3% (불변) |
| avgSurvivorHpErrorPts | 7.62 → 7.70 | 2.47 (불변) |

**23일 변화 분석**: 초반 PvP 라운드 (lvl 3-5) 에서 별돌보미 효과가 점진 공개로 줄어들어 player 데미지 under-predict 가 더 커짐. spec 의 "level 따라 점진 공개" 와 일치하는 동작.

**24일 변화 없음**: 24일 후반 PvP 의 player level 9 (full reveal) 라 영향 X.

핵심 지표 winnerMatchRate 양 게임 모두 보존.

## 후속 후보

- 정확한 lvl→reveal 매핑 검증 (Riot/community 자료 발견 시 fine-tune)
- 23일 baseline -44% 잔여 원인 재조사 (emblem/level 외 — 아이템 / augment / ability 효과)
- handoff stargazer 작업 일단락 — 다른 메커니즘/시스템 으로 이동 결정

## Test plan

- [x] `tests/unit/simulator/stargazer-tile-reveal.test.ts` (5 케이스)
- [x] 4-게이트 (lint / typecheck / test 342 / build)
- [x] 양 게임 calibration — winnerMatchRate 보존, damage err 변화 분석

🤖 Generated with [Claude Code](https://claude.com/claude-code)