### PR TITLE
feat(simulator): 별돌보미 강화 칸 hover tooltip + SynergyPanel 별자리별 desc

### DIFF
--- a/src/app/simulator/layout/SimulatorLayoutDesktop.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutDesktop.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import { MouseEvent, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { axialToOffset, offsetToAxial } from '@/types';
 import type { ItemFilterTab, SimulatorLayoutProps } from './types';
-import { TICKS_PER_SECOND, BOARD_COLS } from '@/lib/simulator/models/constants';
+import { TICKS_PER_SECOND } from '@/lib/simulator/models/constants';
 import { getItemCategory, isDisabledItem } from '@/lib/simulator/systems/item';
 import { isBilgewaterStatItem } from '@/data/traitModules';
 import { resolveBilgewaterStatEffects } from '@/lib/simulator/systems/stat';
 import { resolveDescription } from '@/lib/utils/text';
 import SetupBoard from '@/components/battle/SetupBoard';
-import DroppableHexCell from '@/components/battle/DroppableHexCell';
+import DroppableOverlay from './shared/DroppableOverlay';
 import ReplayBoard from '@/components/battle/ReplayBoard';
 import BattleControls from '@/components/battle/BattleControls';
 import DamageSidebar from '@/components/battle/DamageSidebar';
@@ -35,11 +34,11 @@ export default function SimulatorLayoutDesktop(props: SimulatorLayoutProps) {
     runSimulation, runMultiple, teamNames, poolFilters, logFilter, setLogFilter,
     showTeamCode, setShowTeamCode, hoverUnit, setHoverUnit,
     mappedPlayerForReplay, playerStargazerTiles, enemyStargazerTiles,
+    playerStargazerInfo, enemyStargazerInfo,
   } = props;
   const { champions, items, traits, teamPlannerMapping } = data;
   const {
     player: playerHexBuffs, enemy: enemyHexBuffs,
-    setOverrides: setHexBuffOverrides,
     moving: movingHexBuff, setMoving: setMovingHexBuff,
   } = hexBuffs;
   const {
@@ -215,67 +214,27 @@ export default function SimulatorLayoutDesktop(props: SimulatorLayoutProps) {
                     movingHexBuffApiName={movingHexBuff?.apiName}
                     playerStargazerTiles={playerStargazerTiles}
                     enemyStargazerTiles={enemyStargazerTiles}
+                    playerStargazerConstellation={tm.playerStargazerConstellation}
+                    enemyStargazerConstellation={tm.enemyStargazerConstellation}
+                    playerStargazerEffectVariables={playerStargazerInfo.effectVariables}
+                    enemyStargazerEffectVariables={enemyStargazerInfo.effectVariables}
+                    playerStargazerCount={playerStargazerInfo.count}
+                    enemyStargazerCount={enemyStargazerInfo.count}
                   />
-                  {/* Droppable overlay */}
+                  {/* Droppable overlay (DnD + 강화 칸 hover tooltip) */}
+                  <DroppableOverlay
+                    tm={tm}
+                    hexBuffs={hexBuffs}
+                    setHoverUnit={setHoverUnit}
+                    onUnitClick={tm.handleUnitClick}
+                    playerStargazerTiles={playerStargazerTiles}
+                    enemyStargazerTiles={enemyStargazerTiles}
+                    playerStargazerConstellation={tm.playerStargazerConstellation}
+                    enemyStargazerConstellation={tm.enemyStargazerConstellation}
+                    playerStargazerInfo={playerStargazerInfo}
+                    enemyStargazerInfo={enemyStargazerInfo}
+                  />
                   <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
-                    {Array.from({ length: 8 }, (_, row) =>
-                      Array.from({ length: BOARD_COLS }, (_, col) => {
-                        const team = row < 4 ? 'enemy' : 'player';
-                        const teamArr = team === 'player' ? tm.playerTeam : tm.enemyTeam;
-                        const dataRow = team === 'player' ? row - 4 : row;
-                        const placedIdx = teamArr.findIndex(p => {
-                          const off = axialToOffset(p.position);
-                          return off.row === dataRow && off.col === col;
-                        });
-                        const placed = placedIdx >= 0 ? teamArr[placedIdx] : null;
-
-                        const cellClick = () => {
-                          if (movingHexBuff) {
-                            const pos = offsetToAxial({ row: dataRow, col });
-                            setHexBuffOverrides(prev => ({
-                              ...prev,
-                              [movingHexBuff.team]: { ...prev[movingHexBuff.team], [movingHexBuff.apiName]: pos },
-                            }));
-                            setMovingHexBuff(null);
-                            return;
-                          }
-                          const hexBuffsForTeam = team === 'player' ? playerHexBuffs : enemyHexBuffs;
-                          const movableBuff = hexBuffsForTeam.find(b => b.movable && b.positions.some(
-                            p => { const off = axialToOffset(p); return off.row === dataRow && off.col === col; }
-                          ));
-                          if (movableBuff && !placed) {
-                            setMovingHexBuff({ team, apiName: movableBuff.augmentApiName });
-                            return;
-                          }
-                          if (placed && placedIdx >= 0) {
-                            tm.handleUnitClick(team, placedIdx);
-                          } else {
-                            const pos = offsetToAxial({ row: dataRow, col });
-                            tm.handleCellClick(pos, team);
-                          }
-                        };
-                        const cellContextMenu = (e: MouseEvent) => {
-                          e.preventDefault();
-                          if (placed && placedIdx >= 0) {
-                            tm.handleRemoveUnit(team, placedIdx);
-                          }
-                        };
-
-                        return (
-                          <DroppableHexCell
-                            key={`cell-${row}-${col}`}
-                            id={`cell-${row}-${col}`}
-                            row={row}
-                            col={col}
-                            placedUnit={placed ? { team, position: placed.position } : null}
-                            onClick={cellClick}
-                            onContextMenu={cellContextMenu}
-                            onMouseEnter={placed ? (rect) => setHoverUnit({ placed, rect }) : undefined}
-                            onMouseLeave={() => setHoverUnit(null)}
-                          />
-                        );
-                      })
-                    )}
                     {movingHexBuff && (
                       <div className="absolute inset-0 z-40 flex items-start justify-center pt-2 pointer-events-none">
                         <div className="bg-yellow-600/90 text-black text-xs font-bold px-4 py-2 rounded-lg shadow-lg pointer-events-auto">
@@ -611,6 +570,12 @@ export default function SimulatorLayoutDesktop(props: SimulatorLayoutProps) {
                   onUnitClick={replay.setSelectedUnitId}
                   playerStargazerTiles={playerStargazerTiles}
                   enemyStargazerTiles={enemyStargazerTiles}
+                  playerStargazerConstellation={tm.playerStargazerConstellation}
+                  enemyStargazerConstellation={tm.enemyStargazerConstellation}
+                  playerStargazerEffectVariables={playerStargazerInfo.effectVariables}
+                  enemyStargazerEffectVariables={enemyStargazerInfo.effectVariables}
+                  playerStargazerCount={playerStargazerInfo.count}
+                  enemyStargazerCount={enemyStargazerInfo.count}
                 />
               </div>
             </div>

--- a/src/app/simulator/layout/SimulatorLayoutMobile.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutMobile.tsx
@@ -203,6 +203,12 @@ export default function SimulatorLayoutMobile(props: SimulatorLayoutProps) {
                 movingHexBuffApiName={hexBuffs.moving?.apiName}
                 playerStargazerTiles={props.playerStargazerTiles}
                 enemyStargazerTiles={props.enemyStargazerTiles}
+                playerStargazerConstellation={tm.playerStargazerConstellation}
+                enemyStargazerConstellation={tm.enemyStargazerConstellation}
+                playerStargazerEffectVariables={props.playerStargazerInfo.effectVariables}
+                enemyStargazerEffectVariables={props.enemyStargazerInfo.effectVariables}
+                playerStargazerCount={props.playerStargazerInfo.count}
+                enemyStargazerCount={props.enemyStargazerInfo.count}
                 cellSize={cellSize}
               />
               <DroppableOverlay
@@ -212,6 +218,12 @@ export default function SimulatorLayoutMobile(props: SimulatorLayoutProps) {
                 cellSize={cellSize}
                 onUnitClick={onUnitClickWithSheet}
                 onMovableActivate={() => setSheetState('peek')}
+                playerStargazerTiles={props.playerStargazerTiles}
+                enemyStargazerTiles={props.enemyStargazerTiles}
+                playerStargazerConstellation={tm.playerStargazerConstellation}
+                enemyStargazerConstellation={tm.enemyStargazerConstellation}
+                playerStargazerInfo={props.playerStargazerInfo}
+                enemyStargazerInfo={props.enemyStargazerInfo}
               />
             </>
           )}
@@ -229,6 +241,12 @@ export default function SimulatorLayoutMobile(props: SimulatorLayoutProps) {
               }}
               playerStargazerTiles={props.playerStargazerTiles}
               enemyStargazerTiles={props.enemyStargazerTiles}
+              playerStargazerConstellation={tm.playerStargazerConstellation}
+              enemyStargazerConstellation={tm.enemyStargazerConstellation}
+              playerStargazerEffectVariables={props.playerStargazerInfo.effectVariables}
+              enemyStargazerEffectVariables={props.enemyStargazerInfo.effectVariables}
+              playerStargazerCount={props.playerStargazerInfo.count}
+              enemyStargazerCount={props.enemyStargazerInfo.count}
               cellSize={cellSize}
             />
           )}

--- a/src/app/simulator/layout/SimulatorLayoutTablet.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutTablet.tsx
@@ -37,6 +37,7 @@ export default function SimulatorLayoutTablet(props: SimulatorLayoutProps) {
     tm, replay, hexBuffs, setHoverUnit, setShowTeamCode, showTeamCode,
     runSimulation, runMultiple, stageNumber, setStageNumber, isRunning,
     teamNames, data, playerStargazerTiles, enemyStargazerTiles,
+    playerStargazerInfo, enemyStargazerInfo,
   } = props;
 
   const windowWidth = useWindowWidth();
@@ -177,6 +178,12 @@ export default function SimulatorLayoutTablet(props: SimulatorLayoutProps) {
                     movingHexBuffApiName={hexBuffs.moving?.apiName}
                     playerStargazerTiles={playerStargazerTiles}
                     enemyStargazerTiles={enemyStargazerTiles}
+                    playerStargazerConstellation={tm.playerStargazerConstellation}
+                    enemyStargazerConstellation={tm.enemyStargazerConstellation}
+                    playerStargazerEffectVariables={playerStargazerInfo.effectVariables}
+                    enemyStargazerEffectVariables={enemyStargazerInfo.effectVariables}
+                    playerStargazerCount={playerStargazerInfo.count}
+                    enemyStargazerCount={enemyStargazerInfo.count}
                     cellSize={cellSize}
                   />
                   <DroppableOverlay
@@ -185,6 +192,12 @@ export default function SimulatorLayoutTablet(props: SimulatorLayoutProps) {
                     setHoverUnit={setHoverUnit}
                     cellSize={cellSize}
                     onUnitClick={onUnitClickWithTab}
+                    playerStargazerTiles={playerStargazerTiles}
+                    enemyStargazerTiles={enemyStargazerTiles}
+                    playerStargazerConstellation={tm.playerStargazerConstellation}
+                    enemyStargazerConstellation={tm.enemyStargazerConstellation}
+                    playerStargazerInfo={playerStargazerInfo}
+                    enemyStargazerInfo={enemyStargazerInfo}
                   />
                 </>
               ) : (
@@ -199,6 +212,12 @@ export default function SimulatorLayoutTablet(props: SimulatorLayoutProps) {
                     }}
                     playerStargazerTiles={playerStargazerTiles}
                     enemyStargazerTiles={enemyStargazerTiles}
+                    playerStargazerConstellation={tm.playerStargazerConstellation}
+                    enemyStargazerConstellation={tm.enemyStargazerConstellation}
+                    playerStargazerEffectVariables={playerStargazerInfo.effectVariables}
+                    enemyStargazerEffectVariables={enemyStargazerInfo.effectVariables}
+                    playerStargazerCount={playerStargazerInfo.count}
+                    enemyStargazerCount={enemyStargazerInfo.count}
                     cellSize={cellSize}
                   />
                 )

--- a/src/app/simulator/layout/shared/DroppableOverlay.tsx
+++ b/src/app/simulator/layout/shared/DroppableOverlay.tsx
@@ -1,19 +1,31 @@
 'use client';
 
-import { MouseEvent } from 'react';
+import { MouseEvent, useState } from 'react';
 import { BOARD_COLS } from '@/lib/simulator/models/constants';
-import { axialToOffset, offsetToAxial } from '@/types';
+import { axialToOffset, offsetToAxial, HexCoord } from '@/types';
 import DroppableHexCell from '@/components/battle/DroppableHexCell';
+import { createHexLayout, DEFAULT_HEX_R } from '@/components/battle/HexBoard';
+import { formatStargazerEffectSummary } from '@/lib/actualData/stargazerMapping';
+import type { StargazerConstellationId } from '@/lib/actualData/types';
 import type { SimulatorLayoutProps } from '../types';
 
 interface DroppableOverlayProps {
   tm: SimulatorLayoutProps['tm'];
   hexBuffs: SimulatorLayoutProps['hexBuffs'];
   setHoverUnit: SimulatorLayoutProps['setHoverUnit'];
-  cellSize: number;
+  /** undefined 시 DEFAULT_HEX_R 사용 (Desktop 기본값). */
+  cellSize?: number;
   onUnitClick: (team: 'player' | 'enemy', index: number) => void;
   /** movable hexBuff 이동 모드 활성화 시 호출 (모바일에서 sheet peek 용) */
   onMovableActivate?: () => void;
+  /** A 팀 강화 칸 (data row 0-3 axial). 표시는 보드 r=7-data_r mirror. */
+  playerStargazerTiles?: ReadonlyArray<HexCoord>;
+  /** B 팀 강화 칸 (그대로 표시). */
+  enemyStargazerTiles?: ReadonlyArray<HexCoord>;
+  playerStargazerConstellation?: StargazerConstellationId | null;
+  enemyStargazerConstellation?: StargazerConstellationId | null;
+  playerStargazerInfo?: { effectVariables: Record<string, number | null | undefined> | null; count: number };
+  enemyStargazerInfo?: { effectVariables: Record<string, number | null | undefined> | null; count: number };
 }
 
 /**
@@ -21,10 +33,29 @@ interface DroppableOverlayProps {
  * 모바일/태블릿/데스크톱 레이아웃에서 재사용.
  */
 export default function DroppableOverlay({
-  tm, hexBuffs, setHoverUnit, cellSize, onUnitClick, onMovableActivate,
+  tm, hexBuffs, setHoverUnit, cellSize = DEFAULT_HEX_R, onUnitClick, onMovableActivate,
+  playerStargazerTiles = [], enemyStargazerTiles = [],
+  playerStargazerConstellation, enemyStargazerConstellation,
+  playerStargazerInfo, enemyStargazerInfo,
 }: DroppableOverlayProps) {
   const { playerTeam, enemyTeam } = tm;
   const { player: playerHexBuffs, enemy: enemyHexBuffs, moving, setMoving, setOverrides } = hexBuffs;
+
+  // 강화 칸 zoneKey 별 팀 매핑 (player tiles 는 보드 r=7-data_r mirror).
+  const playerStargazerTileSet = new Set<string>();
+  const enemyStargazerTileSet = new Set<string>();
+  for (const t of playerStargazerTiles) {
+    const off = axialToOffset(t);
+    playerStargazerTileSet.add(`${7 - off.row}-${off.col}`);
+  }
+  for (const t of enemyStargazerTiles) {
+    const off = axialToOffset(t);
+    enemyStargazerTileSet.add(`${off.row}-${off.col}`);
+  }
+
+  // hover 강화 칸 — tooltip 표시용. cell pixel center (cx, cy) + team 보관.
+  const [hoverStargazer, setHoverStargazer] = useState<{ zoneKey: string; team: 'player' | 'enemy'; cx: number; cy: number } | null>(null);
+  const { hexCenter, HEX_R } = createHexLayout(cellSize);
 
   return (
     <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
@@ -38,6 +69,10 @@ export default function DroppableOverlay({
             return off.row === dataRow && off.col === col;
           });
           const placed = placedIdx >= 0 ? teamArr[placedIdx] : null;
+          const zoneKey = `${row}-${col}`;
+          const isPlayerStargazer = playerStargazerTileSet.has(zoneKey);
+          const isEnemyStargazer = enemyStargazerTileSet.has(zoneKey);
+          const isStargazerTile = isPlayerStargazer || isEnemyStargazer;
 
           const cellClick = () => {
             if (moving) {
@@ -68,6 +103,26 @@ export default function DroppableOverlay({
             if (placed && placedIdx >= 0) tm.handleRemoveUnit(team, placedIdx);
           };
 
+          // hover 핸들러 우선순위: placed unit > stargazer tile > 없음.
+          // 두 개 동시 활성 시 placed unit detail 우선 (기존 동작 유지).
+          const onMouseEnterHandler =
+            placed
+              ? (rect: DOMRect) => setHoverUnit({ placed, rect })
+              : isStargazerTile
+                ? () => {
+                    const { cx, cy } = hexCenter(row, col);
+                    setHoverStargazer({
+                      zoneKey,
+                      team: isPlayerStargazer ? 'player' : 'enemy',
+                      cx, cy,
+                    });
+                  }
+                : undefined;
+          const onMouseLeaveHandler = () => {
+            if (placed) setHoverUnit(null);
+            else setHoverStargazer((prev) => (prev?.zoneKey === zoneKey ? null : prev));
+          };
+
           return (
             <DroppableHexCell
               key={`cell-${row}-${col}`}
@@ -77,13 +132,54 @@ export default function DroppableOverlay({
               placedUnit={placed ? { team, position: placed.position } : null}
               onClick={cellClick}
               onContextMenu={cellContextMenu}
-              onMouseEnter={placed ? (rect) => setHoverUnit({ placed, rect }) : undefined}
-              onMouseLeave={() => setHoverUnit(null)}
+              onMouseEnter={onMouseEnterHandler}
+              onMouseLeave={onMouseLeaveHandler}
               cellSize={cellSize}
             />
           );
         })
       )}
+      {/* 강화 칸 hover tooltip — DnD overlay 가 SVG 위에 있어 SVG hover 가 안 닿으므로 여기서 처리 */}
+      {hoverStargazer && (() => {
+        const constellation = hoverStargazer.team === 'player'
+          ? playerStargazerConstellation
+          : enemyStargazerConstellation;
+        if (!constellation) return null;
+        const info = hoverStargazer.team === 'player' ? playerStargazerInfo : enemyStargazerInfo;
+        const summary = formatStargazerEffectSummary(
+          constellation,
+          info?.effectVariables ?? null,
+          info?.count ?? 0,
+        );
+        const ttWidth = 240;
+        let ttLeft = hoverStargazer.cx - ttWidth / 2;
+        let ttTop = hoverStargazer.cy - HEX_R - 140;
+        if (ttLeft < 4) ttLeft = 4;
+        if (ttTop < 4) ttTop = hoverStargazer.cy + HEX_R + 6;
+        return (
+          <div
+            style={{
+              position: 'absolute',
+              left: ttLeft,
+              top: ttTop,
+              width: ttWidth,
+              background: 'rgba(15,23,42,0.96)',
+              border: '1px solid #A855F7',
+              borderRadius: 6,
+              padding: '6px 8px',
+              color: '#e5e7eb',
+              fontSize: 11,
+              lineHeight: 1.4,
+              whiteSpace: 'pre-line',
+              fontFamily: 'system-ui, sans-serif',
+              pointerEvents: 'none',
+              zIndex: 50,
+            }}
+          >
+            {summary}
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/src/app/simulator/layout/shared/DroppableOverlay.tsx
+++ b/src/app/simulator/layout/shared/DroppableOverlay.tsx
@@ -118,9 +118,11 @@ export default function DroppableOverlay({
                     });
                   }
                 : undefined;
+          // mouseLeave 는 항상 두 hover state 모두 정리 — unit 제거/이동 후 cell 이 empty 로
+          // 재렌더되면 placed 가 false 라도 hoverUnit 이 stale 이므로 무조건 clear (codex P2 회귀 가드).
           const onMouseLeaveHandler = () => {
-            if (placed) setHoverUnit(null);
-            else setHoverStargazer((prev) => (prev?.zoneKey === zoneKey ? null : prev));
+            setHoverUnit(null);
+            setHoverStargazer((prev) => (prev?.zoneKey === zoneKey ? null : prev));
           };
 
           return (

--- a/src/app/simulator/layout/types.ts
+++ b/src/app/simulator/layout/types.ts
@@ -46,6 +46,10 @@ export interface SimulatorLayoutProps {
   playerStargazerTiles: ReadonlyArray<HexCoord>;
   /** B 팀(enemy) 별돌보미 강화 칸 좌표. */
   enemyStargazerTiles: ReadonlyArray<HexCoord>;
+  /** A 팀 별돌보미 활성 trait 정보 — hover tooltip 효과 텍스트 표시용. */
+  playerStargazerInfo: { effectVariables: Record<string, number | null | undefined> | null; count: number };
+  /** B 팀 동일. */
+  enemyStargazerInfo: { effectVariables: Record<string, number | null | undefined> | null; count: number };
   stageNumber: number;
   setStageNumber: Dispatch<SetStateAction<number>>;
   isRunning: boolean;

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -179,6 +179,22 @@ function SimulatorContent() {
     return CONSTELLATION_TILE_PATTERN[tm.enemyStargazerConstellation];
   }, [tm.enemyStargazerConstellation, tm.enemyTraits]);
 
+  // 별돌보미 활성 trait 정보 — hover tooltip 효과 텍스트 표시용.
+  const playerStargazerInfo = useMemo(() => {
+    const active = tm.playerTraits.find(t => t.trait.name === '별돌보미' && t.style > 0);
+    return {
+      effectVariables: active?.activeEffect?.variables ?? null,
+      count: active?.count ?? 0,
+    };
+  }, [tm.playerTraits]);
+  const enemyStargazerInfo = useMemo(() => {
+    const active = tm.enemyTraits.find(t => t.trait.name === '별돌보미' && t.style > 0);
+    return {
+      effectVariables: active?.activeEffect?.variables ?? null,
+      count: active?.count ?? 0,
+    };
+  }, [tm.enemyTraits]);
+
   const runSimulation = useCallback(() => {
     if (tm.playerTeam.length === 0 || tm.enemyTeam.length === 0) return;
     setIsRunning(true);
@@ -279,6 +295,7 @@ function SimulatorContent() {
       moving: movingHexBuff, setMoving: setMovingHexBuff,
     },
     playerStargazerTiles, enemyStargazerTiles,
+    playerStargazerInfo, enemyStargazerInfo,
     stageNumber, setStageNumber, isRunning, runSimulation, runMultiple,
     teamNames,
     poolFilters: {

--- a/src/components/battle/ReplayBoard.tsx
+++ b/src/components/battle/ReplayBoard.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { useState } from 'react';
 import { TickSnapshot, HexCoord, axialToOffset, COST_COLORS } from '@/types';
 import type { StatusEffectType } from '@/types';
 import { getChampionImage } from '@/data/imageMap';
 import { BOARD_COLS } from '@/lib/simulator/models/constants';
 import { STATUS_EFFECT_CONFIG, CATEGORY_BORDER } from '@/lib/statusEffectConfig';
 import { createHexLayout } from './HexBoard';
+import { formatStargazerEffectSummary } from '@/lib/actualData/stargazerMapping';
+import type { StargazerConstellationId } from '@/lib/actualData/types';
 
 interface ReplayBoardProps {
   snapshot: TickSnapshot | null;
@@ -26,6 +29,13 @@ interface ReplayBoardProps {
   playerStargazerTiles?: ReadonlyArray<HexCoord>;
   /** B 팀(enemy) 강화 칸 데이터-row 좌표 (0-3 기준). 그대로 표시. */
   enemyStargazerTiles?: ReadonlyArray<HexCoord>;
+  /** 별돌보미 hover tooltip 용 (SetupBoardCore 와 동일). */
+  playerStargazerConstellation?: StargazerConstellationId | null;
+  enemyStargazerConstellation?: StargazerConstellationId | null;
+  playerStargazerEffectVariables?: Record<string, number | null | undefined> | null;
+  enemyStargazerEffectVariables?: Record<string, number | null | undefined> | null;
+  playerStargazerCount?: number;
+  enemyStargazerCount?: number;
   cellSize?: number;
 }
 
@@ -39,10 +49,18 @@ export default function ReplayBoard({
   onUnitClick,
   playerStargazerTiles = [],
   enemyStargazerTiles = [],
+  playerStargazerConstellation,
+  enemyStargazerConstellation,
+  playerStargazerEffectVariables,
+  enemyStargazerEffectVariables,
+  playerStargazerCount = 0,
+  enemyStargazerCount = 0,
   cellSize = REPLAY_DEFAULT_HEX_R,
 }: ReplayBoardProps) {
   const { HEX_R, HEX_W, HEX_H, PAD, teamGap, hexCenter, hexPoints } = createHexLayout(cellSize);
   const cols = BOARD_COLS;
+  // hover 강화 칸 — tooltip 표시용 (SetupBoardCore 와 동일 패턴).
+  const [hoverTile, setHoverTile] = useState<{ zoneKey: string; team: 'player' | 'enemy'; cx: number; cy: number } | null>(null);
   const width = cols * (HEX_W + PAD) + HEX_W / 2 + 40;
   const height = ROWS * (HEX_H * 0.75 + PAD) + HEX_R + 40 + teamGap;
   const splitY = 4 * (HEX_H * 0.75 + PAD) + 10;
@@ -79,15 +97,18 @@ export default function ReplayBoard({
   // combat 의 applyStargazerEffects 는 r>=4 unit 을 mirrorPosition 으로 r=0..3 변환 후
   // 패턴 체크 (mirrorPosition: r → 7-r, offset col 보존).
   // 따라서 player tiles 는 보드 r=7-data_r 위치에 표시해야 실제 효과 적용 위치와 일치.
-  const stargazerTileSet = new Set<string>();
+  // hover tooltip 위해 player/enemy 별 분리 — 클릭/hover 시 어느 별자리 효과인지 식별.
+  const playerStargazerTileSet = new Set<string>();
+  const enemyStargazerTileSet = new Set<string>();
   for (const t of playerStargazerTiles) {
     const off = axialToOffset(t);
-    stargazerTileSet.add(`${7 - off.row}-${off.col}`);
+    playerStargazerTileSet.add(`${7 - off.row}-${off.col}`);
   }
   for (const t of enemyStargazerTiles) {
     const off = axialToOffset(t);
-    stargazerTileSet.add(`${off.row}-${off.col}`);
+    enemyStargazerTileSet.add(`${off.row}-${off.col}`);
   }
+  const stargazerTileSet = new Set([...playerStargazerTileSet, ...enemyStargazerTileSet]);
 
   // Helper: get pixel center for a unit by id
   function getUnitCenter(unitId: string): { cx: number; cy: number } | null {
@@ -147,6 +168,21 @@ export default function ReplayBoard({
           const unitSnap = unitId && snapshot ? snapshot.units[unitId] : null;
           const isSelected = unitId === selectedUnitId;
 
+          // 강화 칸 hover 핸들러 — SetupBoardCore 와 동일 패턴.
+          const onStargazerEnter = () => {
+            const isPlayerTile = playerStargazerTileSet.has(zoneKey);
+            const isEnemyTile = enemyStargazerTileSet.has(zoneKey);
+            if (!isPlayerTile && !isEnemyTile) return;
+            setHoverTile({
+              zoneKey,
+              team: isPlayerTile ? 'player' : 'enemy',
+              cx, cy,
+            });
+          };
+          const onStargazerLeave = () => {
+            setHoverTile((prev) => (prev?.zoneKey === zoneKey ? null : prev));
+          };
+
           if (!unitId || !meta || !unitSnap) {
             // Empty cell
             return (
@@ -156,6 +192,8 @@ export default function ReplayBoard({
                 fill="#0d1117"
                 stroke={isStargazerTile ? '#A855F7' : '#1e2535'}
                 strokeWidth={isStargazerTile ? 2.5 : 0.5}
+                onMouseEnter={isStargazerTile ? onStargazerEnter : undefined}
+                onMouseLeave={isStargazerTile ? onStargazerLeave : undefined}
               />
             );
           }
@@ -189,6 +227,8 @@ export default function ReplayBoard({
                 fill={`url(#replay-${unitId})`}
                 stroke={isSelected ? '#f59e0b' : isStargazerTile ? '#A855F7' : costColor}
                 strokeWidth={isSelected ? 3 : isStargazerTile ? 2.5 : 2}
+                onMouseEnter={isStargazerTile ? onStargazerEnter : undefined}
+                onMouseLeave={isStargazerTile ? onStargazerLeave : undefined}
               />
 
               {/* Star level */}
@@ -363,6 +403,44 @@ export default function ReplayBoard({
           </text>
         );
       })}
+      {/* 강화 칸 hover tooltip — SetupBoardCore 와 동일 패턴 */}
+      {hoverTile && (() => {
+        const constellation = hoverTile.team === 'player'
+          ? playerStargazerConstellation
+          : enemyStargazerConstellation;
+        if (!constellation) return null;
+        const variables = hoverTile.team === 'player'
+          ? playerStargazerEffectVariables
+          : enemyStargazerEffectVariables;
+        const count = hoverTile.team === 'player' ? playerStargazerCount : enemyStargazerCount;
+        const summary = formatStargazerEffectSummary(constellation, variables ?? null, count);
+        const ttWidth = 220;
+        const ttHeight = 130;
+        let ttX = hoverTile.cx - ttWidth / 2;
+        let ttY = hoverTile.cy - HEX_R - ttHeight - 6;
+        if (ttX < 4) ttX = 4;
+        if (ttX + ttWidth > width - 4) ttX = width - 4 - ttWidth;
+        if (ttY < 4) ttY = hoverTile.cy + HEX_R + 6;
+        return (
+          <foreignObject x={ttX} y={ttY} width={ttWidth} height={ttHeight} style={{ pointerEvents: 'none' }}>
+            <div
+              style={{
+                background: 'rgba(15,23,42,0.96)',
+                border: '1px solid #A855F7',
+                borderRadius: 6,
+                padding: '6px 8px',
+                color: '#e5e7eb',
+                fontSize: 10,
+                lineHeight: 1.35,
+                whiteSpace: 'pre-line',
+                fontFamily: 'system-ui, sans-serif',
+              }}
+            >
+              {summary}
+            </div>
+          </foreignObject>
+        );
+      })()}
     </svg>
   );
 }

--- a/src/components/battle/SetupBoardCore.tsx
+++ b/src/components/battle/SetupBoardCore.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { useState } from 'react';
 import { PlacedChampion, HexCoord, HexBuff, axialToOffset, offsetToAxial, COST_COLORS, MF_MODE_CONFIG } from '@/types';
 import { getChampionImage, getItemImage } from '@/data/imageMap';
 import { BOARD_COLS } from '@/lib/simulator/models/constants';
 import { createHexLayout, DEFAULT_HEX_R } from './HexBoard';
+import { formatStargazerEffectSummary } from '@/lib/actualData/stargazerMapping';
+import type { StargazerConstellationId } from '@/lib/actualData/types';
 
 export interface SetupBoardCoreProps {
   playerChampions: PlacedChampion[];
@@ -21,6 +24,18 @@ export interface SetupBoardCoreProps {
   playerStargazerTiles?: ReadonlyArray<HexCoord>;
   /** B 팀(enemy) 강화 칸 데이터-row 좌표 (0-3 기준). 그대로 표시. */
   enemyStargazerTiles?: ReadonlyArray<HexCoord>;
+  /** A 팀 별자리 id — 강화 칸 hover tooltip 효과 텍스트 생성용. */
+  playerStargazerConstellation?: StargazerConstellationId | null;
+  /** B 팀 별자리 id — 동일. */
+  enemyStargazerConstellation?: StargazerConstellationId | null;
+  /** A 팀 별돌보미 활성 effect variables — tooltip tier 별 변수 표시용. */
+  playerStargazerEffectVariables?: Record<string, number | null | undefined> | null;
+  /** B 팀 동일. */
+  enemyStargazerEffectVariables?: Record<string, number | null | undefined> | null;
+  /** A 팀 별돌보미 active count (= 활성 trait.count). tooltip 헤더 표시용. */
+  playerStargazerCount?: number;
+  /** B 팀 동일. */
+  enemyStargazerCount?: number;
   cellSize?: number;
 }
 
@@ -128,12 +143,21 @@ export default function SetupBoardCore({
   movingHexBuffApiName,
   playerStargazerTiles = [],
   enemyStargazerTiles = [],
+  playerStargazerConstellation,
+  enemyStargazerConstellation,
+  playerStargazerEffectVariables,
+  enemyStargazerEffectVariables,
+  playerStargazerCount = 0,
+  enemyStargazerCount = 0,
   cellSize = DEFAULT_HEX_R,
 }: SetupBoardCoreProps) {
   const { HEX_R, HEX_W, HEX_H, PAD, teamGap, hexCenter, hexPoints } = createHexLayout(cellSize);
   const cols = BOARD_COLS;
   const width = cols * (HEX_W + PAD) + HEX_W / 2 + 40;
   const height = ROWS * (HEX_H * 0.75 + PAD) + HEX_R + 40 + teamGap;
+
+  // hover 강화 칸 — tooltip 표시용. zoneKey + screen 좌표 (svg 안 cx/cy).
+  const [hoverTile, setHoverTile] = useState<{ zoneKey: string; team: 'player' | 'enemy'; cx: number; cy: number } | null>(null);
 
   // 프렐요드 포탑 효과 범위
   const turretZones = getTurretEffectZones(playerChampions, enemyChampions);
@@ -163,15 +187,18 @@ export default function SetupBoardCore({
   // 따라서 player tiles 는 보드 r=7-data_r 위치에 표시해야 실제 효과 적용 위치와 일치.
   // (예: 패턴 data r=0 → 보드 r=7 표시 → unit 이 r=7 에 있으면 mirror back r=0 → 패턴 r=0 매칭).
   // enemy 는 mirror 안 거치므로 data row 그대로 표시.
-  const stargazerTileSet = new Set<string>();
+  // hover tooltip 위해 player/enemy 별 분리 — 클릭/hover 시 어느 별자리 효과인지 식별.
+  const playerStargazerTileSet = new Set<string>();
+  const enemyStargazerTileSet = new Set<string>();
   for (const t of playerStargazerTiles) {
     const off = axialToOffset(t);
-    stargazerTileSet.add(`${7 - off.row}-${off.col}`);
+    playerStargazerTileSet.add(`${7 - off.row}-${off.col}`);
   }
   for (const t of enemyStargazerTiles) {
     const off = axialToOffset(t);
-    stargazerTileSet.add(`${off.row}-${off.col}`);
+    enemyStargazerTileSet.add(`${off.row}-${off.col}`);
   }
+  const stargazerTileSet = new Set([...playerStargazerTileSet, ...enemyStargazerTileSet]);
 
   const selectedOffset = selectedCell ? axialToOffset(selectedCell) : null;
 
@@ -281,6 +308,21 @@ export default function SetupBoardCore({
             }
           };
 
+          // 강화 칸 hover 핸들러 — 어느 팀의 별자리인지 식별 후 tooltip state 설정.
+          const onStargazerEnter = () => {
+            const isPlayerTile = playerStargazerTileSet.has(zoneKey);
+            const isEnemyTile = enemyStargazerTileSet.has(zoneKey);
+            if (!isPlayerTile && !isEnemyTile) return;
+            setHoverTile({
+              zoneKey,
+              team: isPlayerTile ? 'player' : 'enemy',
+              cx, cy,
+            });
+          };
+          const onStargazerLeave = () => {
+            setHoverTile((prev) => (prev?.zoneKey === zoneKey ? null : prev));
+          };
+
           return (
             <g key={`${row}-${col}`} onClick={handleClick} onDoubleClick={handleDoubleClick} onContextMenu={handleContextMenu} className="cursor-pointer">
               <polygon
@@ -298,6 +340,8 @@ export default function SetupBoardCore({
                 }
                 strokeWidth={unitSel ? 2.5 : sel ? 2.5 : hexBuffInfo ? 2 : stargazerTileSet.has(zoneKey) ? 2.5 : result ? 2 : (isFrontZone || isBackZone) ? 1.5 : 1}
                 strokeDasharray={hexBuffInfo?.movable ? '4 2' : undefined}
+                onMouseEnter={stargazerTileSet.has(zoneKey) ? onStargazerEnter : undefined}
+                onMouseLeave={stargazerTileSet.has(zoneKey) ? onStargazerLeave : undefined}
               />
               {hexBuffInfo && !result && (
                 <>
@@ -416,6 +460,45 @@ export default function SetupBoardCore({
           );
         })
       )}
+      {/* 강화 칸 hover tooltip — SVG 안에 foreignObject 로 HTML 렌더 */}
+      {hoverTile && (() => {
+        const constellation = hoverTile.team === 'player'
+          ? playerStargazerConstellation
+          : enemyStargazerConstellation;
+        if (!constellation) return null;
+        const variables = hoverTile.team === 'player'
+          ? playerStargazerEffectVariables
+          : enemyStargazerEffectVariables;
+        const count = hoverTile.team === 'player' ? playerStargazerCount : enemyStargazerCount;
+        const summary = formatStargazerEffectSummary(constellation, variables ?? null, count);
+        // tooltip 위치: hex 위쪽에 표시. 보드 밖으로 나갈 수 있으므로 클램프.
+        const ttWidth = 220;
+        const ttHeight = 130;
+        let ttX = hoverTile.cx - ttWidth / 2;
+        let ttY = hoverTile.cy - HEX_R - ttHeight - 6;
+        if (ttX < 4) ttX = 4;
+        if (ttX + ttWidth > width - 4) ttX = width - 4 - ttWidth;
+        if (ttY < 4) ttY = hoverTile.cy + HEX_R + 6;
+        return (
+          <foreignObject x={ttX} y={ttY} width={ttWidth} height={ttHeight} style={{ pointerEvents: 'none' }}>
+            <div
+              style={{
+                background: 'rgba(15,23,42,0.96)',
+                border: '1px solid #A855F7',
+                borderRadius: 6,
+                padding: '6px 8px',
+                color: '#e5e7eb',
+                fontSize: 10,
+                lineHeight: 1.35,
+                whiteSpace: 'pre-line',
+                fontFamily: 'system-ui, sans-serif',
+              }}
+            >
+              {summary}
+            </div>
+          </foreignObject>
+        );
+      })()}
     </svg>
   );
 }

--- a/src/hooks/useTeamManagement.ts
+++ b/src/hooks/useTeamManagement.ts
@@ -307,9 +307,17 @@ export function useTeamManagement({ traits }: UseTeamManagementArgs) {
   // MF mode selection popup state
   const [pendingMfPlacement, setPendingMfPlacement] = useState<{ team: 'player' | 'enemy'; index: number } | null>(null);
 
-  // Synergy calculation (pass mfMode for trait substitution)
-  const playerTraits = useMemo(() => resolveTraits(playerTeam, traits), [playerTeam, traits]);
-  const enemyTraits = useMemo(() => resolveTraits(enemyTeam, traits), [enemyTeam, traits]);
+  // Synergy calculation (pass mfMode for trait substitution + 별돌보미 별자리 전달).
+  // 별자리 선택 시 base TFT17_Stargazer 대신 variant trait (TFT17_Stargazer_Mountain 등)
+  // 활성 → SynergyPanel 의 trait tooltip 도 자동으로 variant desc / variables 표시.
+  const playerTraits = useMemo(
+    () => resolveTraits(playerTeam, traits, { stargazerConstellation: playerStargazerConstellation ?? undefined }),
+    [playerTeam, traits, playerStargazerConstellation],
+  );
+  const enemyTraits = useMemo(
+    () => resolveTraits(enemyTeam, traits, { stargazerConstellation: enemyStargazerConstellation ?? undefined }),
+    [enemyTeam, traits, enemyStargazerConstellation],
+  );
 
   // Selected placed unit
   const selectedPlaced = useMemo(() => {

--- a/src/lib/actualData/stargazerMapping.ts
+++ b/src/lib/actualData/stargazerMapping.ts
@@ -140,3 +140,96 @@ export function isOnEmpoweredTile(
   const tiles = CONSTELLATION_TILE_PATTERN[constellation];
   return tiles.some((t) => t.q === position.q && t.r === position.r);
 }
+
+/**
+ * 별자리별 효과 요약 텍스트 생성. UI tooltip 표시용.
+ * activeEffectVariables 가 null/undefined 이면 별자리 한글명만 반환.
+ */
+export function formatStargazerEffectSummary(
+  constellation: StargazerConstellationId,
+  activeEffectVariables: Record<string, number | null | undefined> | null | undefined,
+  count: number,
+): string {
+  const name = CONSTELLATION_KOREAN_NAME[constellation];
+  if (!activeEffectVariables) return `별돌보미 ${name}`;
+  const v = activeEffectVariables;
+  const lines: string[] = [`별돌보미 ${name} (${count})`];
+  const pct = (n: number | null | undefined): string => {
+    if (n == null) return '0';
+    // 1 미만 fraction → percent. 1 이상은 그대로 (이미 percentage points).
+    return n < 1 ? `${Math.round(n * 100)}%` : `${Math.round(n)}%`;
+  };
+  switch (constellation) {
+    case 'mountain': {
+      // Mountain: 강화 칸 별돌보미 stat 누적 + StatIncrease 증폭
+      const hp = v.Mountain_Health, ad = v.Mountain_ADAP, as = v.Mountain_AS;
+      const dr = v.Mountain_DR, res = v.Mountain_Resists, inc = v.Mountain_StatIncrease;
+      lines.push('강화 칸 별돌보미:');
+      if (hp) lines.push(`  체력 +${pct(hp)}`);
+      if (ad) lines.push(`  공격력/주문력 +${pct(ad)}`);
+      if (as) lines.push(`  공격속도 +${pct(as)}`);
+      if (dr) lines.push(`  내구력 +${pct(dr)}`);
+      if (res) lines.push(`  방어/마저 +${res}`);
+      if (inc) lines.push(`  추가 효과 +${pct(inc)} 증폭`);
+      break;
+    }
+    case 'boar': {
+      // Wolf: teamwide HP/AD/AP + 별돌보미 추가 HP/ADAP
+      const tw = v.Wolf_Health_Teamwide, hp = v.Wolf_Health, ad = v.Wolf_ADAP;
+      if (tw) lines.push(`강화 칸 모든 아군: 체력/공/주 +${pct(tw)}`);
+      lines.push('+ 별돌보미 추가:');
+      if (hp) lines.push(`  체력 +${pct(hp)}`);
+      if (ad) lines.push(`  공격력/주문력 +${ad}%`);
+      break;
+    }
+    case 'medal': {
+      // Medallion: teamwide damageAmp + 3성당 증가
+      const da = v.Medallion_DA, inc3 = v.Medallion_IncreasePer3Star;
+      if (da) lines.push(`강화 칸 모든 아군 피해증폭 +${pct(da)}`);
+      if (inc3) lines.push(`3성 1명당 추가 +${inc3}%`);
+      break;
+    }
+    case 'huntress': {
+      // Huntress: teamwide AS + 별돌보미 추가 AS + mark + heal
+      const tw = v.Huntress_AS_Teamwide, own = v.Huntress_AS, heal = v.Huntress_Heal;
+      const marks = v.NumMarks;
+      if (tw) lines.push(`강화 칸 모든 아군 공속 +${pct(tw)}`);
+      if (own) lines.push(`별돌보미 공속 추가 +${pct(own)}`);
+      if (marks) lines.push(`전투 시작: 적 maxHp 상위 ${marks}명 표식`);
+      if (heal) lines.push(`표식 적 사망 시 별돌보미 maxHp ${pct(heal)} 회복`);
+      break;
+    }
+    case 'snake': {
+      // Serpent: teamwide DR + 별돌보미 추가 DR + poison
+      const tw = v.Serpent_DR_Teamwide, own = v.Serpent_DR;
+      const poison = v.Serpent_Poison, dur = v.Serpent_Duration;
+      if (tw) lines.push(`강화 칸 모든 아군 내구력 +${pct(tw)}`);
+      if (own) lines.push(`별돌보미 내구력 추가 +${pct(own)}`);
+      if (poison && dur) lines.push(`별돌보미 명중 적: 입힌 피해 ${pct(poison)} 를 ${dur}초 마법 DOT`);
+      break;
+    }
+    case 'altar': {
+      // Shield: teamwide HP/AS + 60회 사망 cashout
+      const hp = v.Shield_Health_Teamwide, as = v.Shield_AS_Teamwide;
+      const cHp = v.Shield_CashoutHP, cAs = v.Shield_CashoutAS, n = v.Shield_NumDeaths;
+      if (hp) lines.push(`강화 칸 모든 아군 체력 +${hp}%`);
+      if (as) lines.push(`강화 칸 모든 아군 공속 +${as}%`);
+      if (n && (cHp || cAs)) {
+        lines.push(`사망 ${n}회 누적 시 별돌보미 추가:`);
+        if (cHp) lines.push(`  체력 +${cHp}%`);
+        if (cAs) lines.push(`  공속 +${cAs}%`);
+      }
+      break;
+    }
+    case 'well': {
+      // Fountain: teamwide ManaRegen + 별돌보미 추가 + 스킬 시전 시 lowest HP heal
+      const tw = v.Fountain_ManaRegen_Teamwide, own = v.Fountain_ManaRegen;
+      const heal = v.Fountain_HealPercent;
+      if (tw) lines.push(`강화 칸 모든 아군 마나재생 +${tw}/초`);
+      if (own) lines.push(`별돌보미 마나재생 추가 +${own}/초`);
+      if (heal) lines.push(`별돌보미 스킬 시전 시 즉발 피해의 ${pct(heal)} 만큼 가장 낮은 아군 회복`);
+      break;
+    }
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

handoff 후속 작업 후보 두 건 동시 처리:
1. 강화 칸 hover tooltip — 보드 보라 테두리 칸에 마우스 올리면 별자리 효과 텍스트 표시
2. SynergyPanel 별자리별 desc — 선택된 별자리에 따라 별돌보미 trait tooltip 효과 설명 자동 swap

## 1. 강화 칸 hover tooltip

**구현**:
- `formatStargazerEffectSummary(constellation, variables, count)` helper (`lib/actualData/stargazerMapping.ts`) — 7 변종별 한글 설명 매핑 (Mountain HP%, Wolf teamwide, Huntress 표식, Serpent 중독, Shield cashout, Fountain 마나재생, Medallion damageAmp)
- `DroppableOverlay` 에 stargazer hover state + 좌표 기반 tooltip 렌더
  - DnD overlay 가 SVG 위에 있어 SVG hover 가 안 닿는 구조라 DnD layer 에서 통합 처리
  - 우선순위: placed unit 상세 > stargazer tile 효과 > 없음
- 3 layout (Desktop/Tablet/Mobile) 모두 `DroppableOverlay` 사용으로 통일:
  - Desktop 의 인라인 droppable overlay 코드 (60+ 줄) 를 `DroppableOverlay` 컴포넌트 호출로 교체
  - Movable banner 만 별도 div 로 유지
- `SetupBoardCore` + `ReplayBoard` 에도 동일 hover 코드 추가 (ReplayBoard 는 DnD overlay 없으므로 자체 SVG hover 동작)

## 2. SynergyPanel 별자리별 desc

**구현**:
- `useTeamManagement.ts:311` 의 `resolveTraits` 호출에 `stargazerConstellation` options 전달
- 별자리 선택 시 base `TFT17_Stargazer` 대신 variant trait (`TFT17_Stargazer_Mountain` 등) 활성
- `SynergyPanel` 의 trait tooltip 이 자동으로 variant desc + variables 표시 (별도 코드 변경 없음)

## 4-게이트

lint 0 / typecheck 0 / **test 337/337** (UI 만 변경, simulator 로직 무영향) / build ✅

## Test plan

- [x] dev 서버에서 강화 칸 hover tooltip 확인 — 별자리 한글명 + 활성 효과 텍스트 표시
- [x] dev 서버에서 별자리 변경 시 SynergyPanel 별돌보미 trait tooltip desc 자동 변경 확인
- [x] 4-게이트 (lint / typecheck / test 337 / build)

## 후속

- handoff 후속 후보 잔여: tile reveal (level별 점진 공개) — 사용자 의도로 미구현 유지
- 23일 baseline -43.7% damage err 잔여 원인 (emblem/level 외 메커니즘) 재조사

🤖 Generated with [Claude Code](https://claude.com/claude-code)