### PR TITLE
feat(simulator): 저격수(Sniper/RangedTrait) trait — base damage amp + per-hex 거리

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-28T05:53:32.804Z",
+  "computedAt": "2026-04-28T06:03:21.220Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "29fd06e5181b23caa3e7b5664b42b0bb64b78ec2",
+  "engineSha": "36b8fb7d00f31db511cd102ab45c36cb03e2daee",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -173,6 +173,8 @@ function createCombatUnit(
     bastionDoubleEndTick: 0,
     bastionDoubleArmorBonus: 0,
     bastionDoubleMrBonus: 0,
+    sniperBaseDA: 0,
+    sniperPerHexDA: 0,
   };
 
   // MF 특성 선택 → 실제 트레이트로 치환 + emblem 으로 부여된 trait 합산.
@@ -703,17 +705,14 @@ function applyBastionEffects(activeTraits: ActiveTrait[], units: CombatUnit[]): 
   const durationSec = (v.Duration ?? 0) as number;
   const isHighTier = trait.count >= 6;
   for (const u of units) {
-    // 모든 아군 teamwide
     if (teamwide > 0) {
       u.stats.armor += teamwide;
       u.stats.magicResist += teamwide;
     }
-    // (6) 비-요새 추가
     if (isHighTier && enhancedTeamwide > 0 && !unitHasTrait(u, '요새')) {
       u.stats.armor += enhancedTeamwide;
       u.stats.magicResist += enhancedTeamwide;
     }
-    // 요새 unit 추가 + 첫 Duration 초 doubled
     if (unitHasTrait(u, '요새')) {
       u.stats.armor += bonusArmor;
       u.stats.magicResist += bonusMr;
@@ -739,6 +738,40 @@ function tickBastionDouble(unit: CombatUnit, tick: number): void {
   unit.bastionDoubleEndTick = 0;
   unit.bastionDoubleArmorBonus = 0;
   unit.bastionDoubleMrBonus = 0;
+}
+
+/**
+ * 저격수 (Sniper/RangedTrait) — base damage amp + per-hex 추가 amp.
+ *
+ * Spec (TFT17_RangedTrait):
+ *   (2) PercentDamageIncrease=18%, PerHexIncrease=2%/hex
+ *   (3) 24%, 3%/hex
+ *   (4) 28%, 4%/hex
+ *
+ * 저격수 unit 의 damage hit 시 (hit site 에서 hexDistance(caster, target) 계산):
+ *   추가 damageAmp = sniperBaseDA + sniperPerHexDA * dist
+ */
+function applySniperEffects(activeTraits: ActiveTrait[], units: CombatUnit[]): void {
+  const trait = activeTraits.find(t => t.trait.apiName === 'TFT17_RangedTrait');
+  if (!trait || !trait.activeEffect || trait.style === 0) return;
+  const v = trait.activeEffect.variables;
+  const baseDApct = (v.PercentDamageIncrease ?? 0) as number; // 18 = 18%
+  const perHexPct = (v.PerHexIncrease ?? 0) as number; // 2 = 2% per hex
+  if (baseDApct <= 0) return;
+  const baseDA = baseDApct / 100;
+  const perHexDA = perHexPct / 100;
+  for (const u of units) {
+    if (!unitHasTrait(u, '저격수')) continue;
+    u.sniperBaseDA = baseDA;
+    u.sniperPerHexDA = perHexDA;
+  }
+}
+
+/** 저격수 damage amp 계산 — caster 가 저격수면 base + perHex × distance, 아니면 0. */
+function computeSniperDamageAmp(caster: CombatUnit, target: CombatUnit): number {
+  if (caster.sniperBaseDA <= 0) return 0;
+  const dist = hexDistance(caster.position, target.position);
+  return caster.sniperBaseDA + caster.sniperPerHexDA * dist;
 }
 
 /** 전쟁기계 — BaseDR을 damageReduction에 적용 */
@@ -1130,6 +1163,8 @@ function spawnFreljordTurrets(
             bastionDoubleEndTick: 0,
             bastionDoubleArmorBonus: 0,
             bastionDoubleMrBonus: 0,
+            sniperBaseDA: 0,
+            sniperPerHexDA: 0,
           };
           // Store stun duration for prismatic tier
           if (stunDuration > 0) {
@@ -1264,6 +1299,8 @@ function trySpawnGalio(
     bastionDoubleEndTick: 0,
     bastionDoubleArmorBonus: 0,
     bastionDoubleMrBonus: 0,
+    sniperBaseDA: 0,
+    sniperPerHexDA: 0,
   };
 
   // 착지 충격파 — 영웅 시너지 variables
@@ -1824,6 +1861,8 @@ export function simulateCombat(
   applyFateweaverEffects(enemyActiveTraits, enemies);
   applyBastionEffects(playerActiveTraits, playerUnits);
   applyBastionEffects(enemyActiveTraits, enemies);
+  applySniperEffects(playerActiveTraits, playerUnits);
+  applySniperEffects(enemyActiveTraits, enemies);
 
   // 아이오니아 길 적용
   if (options.playerIoniaPath) {
@@ -2275,6 +2314,8 @@ export function simulateCombat(
           if (unit.inventionTankDamageAmp > 0 && target.role === 'Tank') {
             totalDamageAmp += unit.inventionTankDamageAmp;
           }
+          // 저격수 (Sniper) — 거리 기반 추가 damage amp
+          totalDamageAmp += computeSniperDamageAmp(unit, target);
           const rawDamage = unit.stats.damage * critMult * (1 + totalDamageAmp);
           let finalDamage = applyResistance(rawDamage, target.stats.armor, unit.stats.armorPen);
 
@@ -2533,6 +2574,8 @@ export function simulateCombat(
                 if (unit.inventionTankDamageAmp > 0 && t.role === 'Tank') {
                   abilityDamageAmp += unit.inventionTankDamageAmp;
                 }
+                // 저격수 (Sniper) — 거리 기반 추가 damage amp (per target)
+                abilityDamageAmp += computeSniperDamageAmp(unit, t);
                 // 초가스: % 최대체력 피해 추가
                 let baseDmg = abilityDmg;
                 if (unit.champion.apiName === 'TFT17_Chogath') {
@@ -2803,7 +2846,9 @@ export function simulateCombat(
               if (t.state === 'dead') continue;
               const resistance = dmgType === 'magic' ? t.stats.magicResist : t.stats.armor;
               const pen = dmgType === 'magic' ? unit.stats.magicPen : unit.stats.armorPen;
-              let rawDmg = abilityDmg * (1 + unit.damageAmp);
+              // 저격수 (Sniper) — 거리 기반 추가 damage amp
+              const sniperAmp = computeSniperDamageAmp(unit, t);
+              let rawDmg = abilityDmg * (1 + unit.damageAmp + sniperAmp);
               if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
                 rawDmg *= unit.stats.critMultiplier;
               }

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -2549,7 +2549,9 @@ export function simulateCombat(
                 // DOT도 방어력/피해감소 적용
                 const resistance = dmgType === 'magic' ? t.stats.magicResist : dmgType === 'physical' ? t.stats.armor : 0;
                 const pen = dmgType === 'magic' ? unit.stats.magicPen : dmgType === 'physical' ? unit.stats.armorPen : 0;
-                const mitigated = dmgType === 'true' ? abilityDmg * (1 + unit.damageAmp) : applyResistance(abilityDmg * (1 + unit.damageAmp), resistance, pen);
+                // 저격수 (Sniper) — DOT 도 거리 기반 추가 amp 포함 (codex P2 회귀 가드).
+                const dotDamageAmp = unit.damageAmp + computeSniperDamageAmp(unit, t);
+                const mitigated = dmgType === 'true' ? abilityDmg * (1 + dotDamageAmp) : applyResistance(abilityDmg * (1 + dotDamageAmp), resistance, pen);
                 const perTickDmg = mitigated / config.dot.duration * TICK_DURATION;
                 t.statusEffects.push({
                   type: 'burn', sourceId: unit.id,
@@ -2834,7 +2836,9 @@ export function simulateCombat(
             for (const t of oorAlive) {
               const resistance = dmgType === 'magic' ? t.stats.magicResist : dmgType === 'physical' ? t.stats.armor : 0;
               const pen = dmgType === 'magic' ? unit.stats.magicPen : dmgType === 'physical' ? unit.stats.armorPen : 0;
-              const mitigated = dmgType === 'true' ? abilityDmg * (1 + unit.damageAmp) : applyResistance(abilityDmg * (1 + unit.damageAmp), resistance, pen);
+              // 저격수 (Sniper) — OOR DOT 도 거리 기반 추가 amp 포함 (codex P2 회귀 가드).
+              const oorDotDamageAmp = unit.damageAmp + computeSniperDamageAmp(unit, t);
+              const mitigated = dmgType === 'true' ? abilityDmg * (1 + oorDotDamageAmp) : applyResistance(abilityDmg * (1 + oorDotDamageAmp), resistance, pen);
               const perTickDmg = mitigated / outOfRangeConfig.dot.duration * TICK_DURATION;
               t.statusEffects.push({
                 type: 'burn', sourceId: unit.id,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -522,6 +522,13 @@ export interface CombatUnit {
   stargazerShieldCashoutHpFrac: number;
   /** Shield cashout 발동 시 추가 AS buff (예: 0.18 → AS × 1.18). */
   stargazerShieldCashoutAsFrac: number;
+  /**
+   * 저격수 (Sniper/RangedTrait) — base damage amp + per-hex 추가.
+   * fraction 기준 (예: 0.18 = 18%). 0 = 비-저격수.
+   * damage hit 시: sniperBaseDA + sniperPerHexDA × hexDistance(caster, target).
+   */
+  sniperBaseDA: number;
+  sniperPerHexDA: number;
 }
 
 export interface CombatLog {

--- a/tests/unit/simulator/sniper-trait.test.ts
+++ b/tests/unit/simulator/sniper-trait.test.ts
@@ -1,0 +1,117 @@
+/**
+ * 저격수 (Sniper/RangedTrait) trait 회귀 가드.
+ *
+ * Spec (TFT17_RangedTrait):
+ *   (2) PercentDamageIncrease=18%, PerHexIncrease=2%/hex
+ *   (3) 24%, 3%/hex
+ *   (4) 28%, 4%/hex
+ *
+ * 저격수 unit 의 damage hit 시 (caster, target):
+ *   추가 damageAmp = sniperBaseDA + sniperPerHexDA × hexDistance(caster, target)
+ *
+ * 저격수 챔프 (5명): Gnar, Jhin, Samira, Ezreal, Xayah.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion, RawItem } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+const apJhin = champions.find((c) => c.apiName === 'TFT17_Jhin')!;
+const apEzreal = champions.find((c) => c.apiName === 'TFT17_Ezreal')!;
+const apSamira = champions.find((c) => c.apiName === 'TFT17_Samira')!;
+const apGnar = champions.find((c) => c.apiName === 'TFT17_Gnar')!;
+const apTwistedFate = champions.find((c) => c.apiName === 'TFT17_TwistedFate')!; // 비-저격수
+const dummyEnemy = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
+
+function placed(c: RawChampion, q: number, r: number, items: RawItem[] = []): PlacedChampion {
+  return { champion: c, starLevel: 2, position: { q, r }, items };
+}
+
+describe('Sniper — (2) tier base 18% + per hex 2%', () => {
+  it('저격수 2명 → sniperBaseDA=0.18, sniperPerHexDA=0.02 설정', () => {
+    const team = [placed(apJhin, 0, 0), placed(apEzreal, 1, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const jhin = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Jhin')!;
+    expect(jhin.sniperBaseDA).toBeCloseTo(0.18, 2);
+    expect(jhin.sniperPerHexDA).toBeCloseTo(0.02, 2);
+    // 비-저격수 champ 가 있다면 sniperBaseDA = 0
+  });
+
+  it('저격수 ON 시 player 누적 damageDealt 증가 (멀리서 쏠 수록 더)', () => {
+    // 저격수 2명 vs 멀리 enemy → distance bonus 받음
+    const team = [placed(apJhin, 0, 0), placed(apEzreal, 1, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const withSniper = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    // 비-저격수 비교
+    const team2 = [placed(apTwistedFate, 0, 0), placed(apTwistedFate, 1, 0)];
+    const without = simulateCombat(team2, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    // 본 테스트는 저격수 unit 의 damage 가 비-저격수 보다 큰지 검증.
+    const sniperDmg = withSniper.playerUnits.reduce((s, u) => s + u.totalDamageDealt, 0);
+    const nonSniperDmg = without.playerUnits.reduce((s, u) => s + u.totalDamageDealt, 0);
+    // 저격수 효과로 + base damage 자체도 다르므로 단순 비교는 noise 가능 → loose 비교
+    // 핵심: sniperBaseDA / sniperPerHexDA 가 활성화되어 sniper unit 들이 effect 보유
+    expect(withSniper.playerUnits[0].sniperBaseDA).toBeGreaterThan(0);
+    // 단순히 저격수 ON 일 때 sniper 효과가 작동하는지 (sniperDmg, nonSniperDmg 도 비교 — 다른 챔프라 차이는 큼)
+    expect(sniperDmg).toBeGreaterThan(0);
+    expect(nonSniperDmg).toBeGreaterThan(0);
+  });
+});
+
+describe('Sniper — (3) tier 24% + 3%/hex', () => {
+  it('저격수 3명 → sniperBaseDA=0.24, sniperPerHexDA=0.03', () => {
+    const team = [placed(apJhin, 0, 0), placed(apEzreal, 1, 0), placed(apSamira, 2, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const jhin = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Jhin')!;
+    expect(jhin.sniperBaseDA).toBeCloseTo(0.24, 2);
+    expect(jhin.sniperPerHexDA).toBeCloseTo(0.03, 2);
+  });
+});
+
+describe('Sniper — (4) tier 28% + 4%/hex', () => {
+  it('저격수 4명 → sniperBaseDA=0.28, sniperPerHexDA=0.04', () => {
+    const team = [placed(apJhin, 0, 0), placed(apEzreal, 1, 0), placed(apSamira, 2, 0), placed(apGnar, 3, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const jhin = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Jhin')!;
+    expect(jhin.sniperBaseDA).toBeCloseTo(0.28, 2);
+    expect(jhin.sniperPerHexDA).toBeCloseTo(0.04, 2);
+  });
+});
+
+describe('Sniper — 비-저격수 unit 영향 없음', () => {
+  it('비-저격수 (TwistedFate) sniperBaseDA = 0', () => {
+    const team = [placed(apJhin, 0, 0), placed(apEzreal, 1, 0), placed(apTwistedFate, 2, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const tf = result.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    expect(tf.sniperBaseDA).toBe(0);
+    expect(tf.sniperPerHexDA).toBe(0);
+  });
+});
+
+describe('Sniper — 저격수 1명 (비활성) 영향 없음', () => {
+  it('저격수 1명만 → trait 비활성, sniperBaseDA=0', () => {
+    const team = [placed(apJhin, 0, 0), placed(apTwistedFate, 1, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const jhin = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Jhin')!;
+    expect(jhin.sniperBaseDA).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

영향력 우선순위 3번째 trait. 24일 well 게임에 3명 활성.

## Spec (TFT17_RangedTrait)

| Tier | base | per hex |
|------|---|---|
| (2) | 18% | 2%/hex |
| (3) | 24% | 3%/hex |
| (4) | 28% | 4%/hex |

저격수 unit 의 damage hit 시 caster ↔ target hex 거리 따라 추가 damage amp.

저격수 챔프 (5명): Gnar, Jhin, Samira, Ezreal, Xayah.

## 구현

- `CombatUnit` 에 `sniperBaseDA`, `sniperPerHexDA` 필드 추가 (fraction)
- `applySniperEffects(activeTraits, units)`: 저격수 unit 들에 base/perHex 설정
- `computeSniperDamageAmp(caster, target)`: `caster.sniperBaseDA + caster.sniperPerHexDA × hexDistance(caster, target)`
- damage hit site 3 곳 hook:
  - basic attack: `totalDamageAmp += computeSniperDamageAmp`
  - in-range ability: 동일 패턴
  - OOR ability: 동일 패턴

## 4-게이트

lint 0 / typecheck 0 / **test 343/343** (Sniper 6 신규) / build ✅

## 회귀 가드

`tests/unit/simulator/sniper-trait.test.ts` (6 케이스):
- (2)/(3)/(4) tier 별 sniperBaseDA / sniperPerHexDA 값 검증
- 비-저격수 unit sniperBaseDA = 0
- 저격수 1명 (비활성) sniperBaseDA = 0
- 저격수 ON 시 활성 확인

## Calibration 영향

| | 23일 (mountain, 0명) | 24일 (well, 3명) |
|---|---|---|
| winnerMatchRate | 40.9% (불변) | **76.2%** (불변) |
| avgPlayerDamageErrorPct | -43.7% (불변) | -16.3% → -17.6% |
| avgSurvivorHpErrorPts | 7.62 (불변) | 2.47 → **1.95** ⬇ |

24일 survivor HP 큰 개선. 23일은 저격수 0명이라 무영향.

## 후속

- 다음 trait: 정령족 (Astronaut), N.O.V.A. (DRX), 시간균열자, 암흑의 별

## Test plan

- [x] `tests/unit/simulator/sniper-trait.test.ts` (6 케이스)
- [x] 4-게이트 (lint / typecheck / test 343 / build)
- [x] 양 게임 calibration

🤖 Generated with [Claude Code](https://claude.com/claude-code)