### PR TITLE
feat(simulator): F3 — PsyOps SympatheticImplant TrueDamage raw 정밀화

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -3163,6 +3163,10 @@ export function simulateCombat(
 
             // 다중 타겟 피해 루프
             let totalAbilityDmg = 0;
+            // raw total — per-target modifier (damageAmp/sniper/crit/secondary/Chogath %hp 등) 적용 후,
+            // resistance/shield/DR/invulnerable 적용 전. on_cast.rawValue 로 emit 되어
+            // SympatheticImplant TrueDamageConversion 등 raw 기반 follow-up effect 가 사용.
+            let totalRawAbilityDmg = 0;
             const aliveTargets = abilityTargets.filter(t => t.state !== 'dead');
             const abilityDmg = isSplitDamage && aliveTargets.length > 0
               ? hitCountTotal / aliveTargets.length
@@ -3237,6 +3241,8 @@ export function simulateCombat(
                 if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
                   dmg *= unit.stats.critMultiplier;
                 }
+                // raw (mitigation 전) 누적 — on_cast.rawValue 용.
+                totalRawAbilityDmg += dmg;
 
                 const resistance = dmgType === 'magic' ? t.stats.magicResist
                   : dmgType === 'physical' ? t.stats.armor : 0;
@@ -3374,9 +3380,11 @@ export function simulateCombat(
               totalAbilityDmg += droneDmg;
             }
 
-            // rawValue = hitCountTotal (resistance 적용 전 raw 총 ability damage).
+            // rawValue = totalRawAbilityDmg (per-target modifier 적용 후, resistance 미적용 누적).
             // value = totalAbilityDmg (실제 적용 mitigated total).
-            eventBus.emit('on_cast', { sourceId: unit.id, targetId: target.id, value: totalAbilityDmg, rawValue: hitCountTotal, tick });
+            // dot path 면 totalRawAbilityDmg 누적 안 됨 → hitCountTotal 폴백 (DOT total raw).
+            const rawForCast = totalRawAbilityDmg > 0 ? totalRawAbilityDmg : hitCountTotal;
+            eventBus.emit('on_cast', { sourceId: unit.id, targetId: target.id, value: totalAbilityDmg, rawValue: rawForCast, tick });
           }
 
           // Execute threshold: kill if below HP %
@@ -3455,6 +3463,9 @@ export function simulateCombat(
 
           // 피해 적용
           let totalAbilityDmg = 0;
+          // raw total — per-target modifier (damageAmp/sniper/crit) 적용 후, mitigation 전.
+          // on_cast.rawValue 로 emit 되어 SympatheticImplant 등 raw 기반 effect 가 사용.
+          let totalRawAbilityDmg = 0;
           const oorAlive = abilityTargets.filter(t => t.state !== 'dead');
           const abilityDmg = oorIsSplit && oorAlive.length > 0
             ? oorHitTotal / oorAlive.length
@@ -3487,6 +3498,8 @@ export function simulateCombat(
               if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
                 rawDmg *= unit.stats.critMultiplier;
               }
+              // raw 누적 — mitigation 전 per-target modifier 적용 후.
+              totalRawAbilityDmg += rawDmg;
               let dmg = dmgType === 'true' ? rawDmg : applyResistance(rawDmg, resistance, pen);
               if (t.damageReduction > 0) dmg *= (1 - t.damageReduction);
               dmg = applyShield(t, dmg, eventBus, tick);
@@ -3547,8 +3560,10 @@ export function simulateCombat(
           // (codex P1 회귀 가드: Talon/Corki 같은 dash user 가 사거리 밖 시전 시 누락 방지).
           triggerFountainHeal(unit, totalAbilityDmg, tick, time, tickLogs);
 
-          // rawValue = oorHitTotal (raw 총 ability damage), value = totalAbilityDmg (mitigated).
-          eventBus.emit('on_cast', { sourceId: unit.id, targetId: target.id, value: totalAbilityDmg, rawValue: oorHitTotal, tick });
+          // rawValue = totalRawAbilityDmg (per-target modifier 적용 후, resistance 미적용 누적).
+          // dot path 면 raw 누적 안 됨 → oorHitTotal 폴백.
+          const oorRawForCast = totalRawAbilityDmg > 0 ? totalRawAbilityDmg : oorHitTotal;
+          eventBus.emit('on_cast', { sourceId: unit.id, targetId: target.id, value: totalAbilityDmg, rawValue: oorRawForCast, tick });
         } else {
           // 일반 이동
           const newPos = findBestMoveToward(unit.position, target.position, occupiedPositions);

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -3125,8 +3125,8 @@ export function simulateCombat(
               logs.push(selfLog);
               tickLogs.push(selfLog);
               // on_cast 이벤트 emit — PsyOps 등 cast event subscriber 호환 (codex P2 회귀 가드).
-              // targetId 는 self (적군 X). value 는 실제 입은 self damage.
-              eventBus.emit('on_cast', { sourceId: unit.id, targetId: unit.id, value: dmgApplied, tick });
+              // targetId 는 self (적군 X). value 는 실제 입은 self damage. rawValue 는 동일 (no resistance for self).
+              eventBus.emit('on_cast', { sourceId: unit.id, targetId: unit.id, value: dmgApplied, rawValue: rawAbilityDmg, tick });
               continue; // 일반 ability 흐름 skip — 적군/아군 데미지 없음
             }
 
@@ -3374,7 +3374,9 @@ export function simulateCombat(
               totalAbilityDmg += droneDmg;
             }
 
-            eventBus.emit('on_cast', { sourceId: unit.id, targetId: target.id, value: totalAbilityDmg, tick });
+            // rawValue = hitCountTotal (resistance 적용 전 raw 총 ability damage).
+            // value = totalAbilityDmg (실제 적용 mitigated total).
+            eventBus.emit('on_cast', { sourceId: unit.id, targetId: target.id, value: totalAbilityDmg, rawValue: hitCountTotal, tick });
           }
 
           // Execute threshold: kill if below HP %
@@ -3545,7 +3547,8 @@ export function simulateCombat(
           // (codex P1 회귀 가드: Talon/Corki 같은 dash user 가 사거리 밖 시전 시 누락 방지).
           triggerFountainHeal(unit, totalAbilityDmg, tick, time, tickLogs);
 
-          eventBus.emit('on_cast', { sourceId: unit.id, targetId: target.id, value: totalAbilityDmg, tick });
+          // rawValue = oorHitTotal (raw 총 ability damage), value = totalAbilityDmg (mitigated).
+          eventBus.emit('on_cast', { sourceId: unit.id, targetId: target.id, value: totalAbilityDmg, rawValue: oorHitTotal, tick });
         } else {
           // 일반 이동
           const newPos = findBestMoveToward(unit.position, target.position, occupiedPositions);

--- a/src/lib/simulator/events/eventBus.ts
+++ b/src/lib/simulator/events/eventBus.ts
@@ -27,7 +27,18 @@ export type CombatEventType =
 export interface CombatEventPayload {
   sourceId: string;
   targetId?: string;
+  /**
+   * 이벤트 결과값 (보통 mitigated damage / total damage dealt 등 적용 후 값).
+   * on_cast: 시전자가 적에게 실제로 입힌 mitigated total damage.
+   * on_hit: 적용된 hit damage.
+   */
   value?: number;
+  /**
+   * Raw value (resistance 적용 전 base ability damage).
+   * on_cast 에서 'pctDealtRaw' 등 raw 기반 follow-up effect 가 사용.
+   * SympatheticImplant TrueDamageConversion 등 raw damage 기반 산식.
+   */
+  rawValue?: number;
   damageType?: 'physical' | 'magic' | 'true';
   tick: number;
 }

--- a/src/lib/simulator/systems/items/definitions/psyops.ts
+++ b/src/lib/simulator/systems/items/definitions/psyops.ts
@@ -191,7 +191,8 @@ function buildSympatheticImplant(
     },
   ];
   // 17.2 Radiant: 초능력 유닛 ability 시전 시 스킬 피해의 N% 를 고정 피해로 추가.
-  // on_cast 시 payload.value (raw ability damage) 의 trueDamageConversion% 만큼 true damage.
+  // on_cast payload.rawValue (resistance 적용 전 raw ability damage) 의 trueDamageConversion%
+  // 만큼 true damage 를 attackTarget 에 적용. raw 기반이라 mitigated 편차 없음.
   if (trueDamageConversion > 0) {
     descriptors.push({
       kind: 'trigger',
@@ -199,7 +200,7 @@ function buildSympatheticImplant(
       condition: isPsyOpsUnit,
       action: {
         kind: 'dealDamage',
-        amount: { mode: 'pctDealt', pct: trueDamageConversion },
+        amount: { mode: 'pctDealtRaw', pct: trueDamageConversion },
         type: 'true',
         target: 'attackTarget',
       },

--- a/src/lib/simulator/systems/items/primitives/action.ts
+++ b/src/lib/simulator/systems/items/primitives/action.ts
@@ -130,6 +130,8 @@ function resolveDamageAmount(amount: DamageAmount, ctx: ActionContext, target: C
       return ctx.unit.stats.ap * amount.pct;
     case 'pctDealt':
       return (ctx.payload?.value ?? 0) * amount.pct;
+    case 'pctDealtRaw':
+      return (ctx.payload?.rawValue ?? ctx.payload?.value ?? 0) * amount.pct;
     case 'pctOfStack':
       return (ctx.state.stacks.get(amount.stack) ?? 0) * amount.pct;
   }

--- a/src/lib/simulator/systems/items/primitives/types.ts
+++ b/src/lib/simulator/systems/items/primitives/types.ts
@@ -23,8 +23,13 @@ export type DamageAmount =
   | { mode: 'pctMaxHp'; pct: number }
   | { mode: 'pctAttackDamage'; pct: number }
   | { mode: 'pctAbilityPower'; pct: number }
-  /** payload.value 의 N% (trigger-chained action 에서 현재 이벤트 피해 기준) */
+  /** payload.value 의 N% (trigger-chained action 에서 현재 이벤트 피해 기준 — mitigated). */
   | { mode: 'pctDealt'; pct: number }
+  /**
+   * payload.rawValue 의 N% — resistance 적용 전 raw damage 기준.
+   * SympatheticImplant TrueDamageConversion 등 raw 기반 산식 ("스킬 피해의 N%").
+   */
+  | { mode: 'pctDealtRaw'; pct: number }
   /** state.stacks[stack] 의 N% — 누적된 값 기반 (e.g. 드론 업링크 3초 window) */
   | { mode: 'pctOfStack'; stack: string; pct: number };
 


### PR DESCRIPTION
## Summary

PR #39 Known limitation 후속 — TrueDamageConversion (공감 임플란트 Radiant) 가 mitigated damage 기반으로 작동해 실게임 대비 ~5% 편차 → raw damage 기반으로 정밀화.

## Changes

| 파일 | 변경 |
|------|------|
| `src/lib/simulator/events/eventBus.ts` | `CombatEventPayload.rawValue?: number` 추가 |
| `src/lib/simulator/systems/items/primitives/types.ts` | DamageAmount `'pctDealtRaw'` 모드 신설 |
| `src/lib/simulator/systems/items/primitives/action.ts` | `pctDealtRaw` resolve (fallback: payload.value) |
| `src/lib/simulator/engine/combatLoop.ts` | 3개 on_cast emit 에 rawValue 추가 (자폭 / in-range / OOR) |
| `src/lib/simulator/systems/items/definitions/psyops.ts` | SympatheticImplantMod_Radiant TrueDamage `pctDealt` → `pctDealtRaw` |

## 시맨틱

- `payload.value` (기존): **mitigated** total damage (resistance 적용 후) — `pctDealt` mode 사용
- `payload.rawValue` (신규): **raw** total ability damage (resistance 적용 전) — `pctDealtRaw` mode 사용

기존 `pctDealt` 사용처 (drone uplink 등) 는 mitigated 기준 그대로 유지 — 시맨틱 변경 없음, 영향 범위 최소.

## Test plan

- [x] `pnpm vitest run` — **405/413 PASS** (8 skipped — Fountain 17.2 마이그)
- [x] `pnpm typecheck` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)