### PR TITLE
feat(simulator): G1 — Stargazer Medallion 회귀 가드 + Shield_NumDeaths 동적화

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -2673,7 +2673,12 @@ export function simulateCombat(
    * 별돌보미들에게 cashout buff (HP × 1+CashoutHP, AS × 1+CashoutAS) 일회 적용.
    * 게임-level 누적 (전 게임의 player 사망) 은 priorShieldDeaths 로 외부 입력.
    */
-  const SHIELD_NUM_DEATHS = 60; // Shield_NumDeaths spec value
+  // Shield_NumDeaths — raw trait variable 에서 동적 읽기 (drift 방지). 미정의 시 60 fallback.
+  // player / enemy 가 다른 별자리 활성 가능성 → 각 팀별 trait active 여부 체크 후 변수 추출.
+  const playerShieldTrait = playerActiveTraits.find(t => t.trait.apiName === 'TFT17_Stargazer_Shield' && t.activeEffect);
+  const enemyShieldTrait = enemyActiveTraits.find(t => t.trait.apiName === 'TFT17_Stargazer_Shield' && t.activeEffect);
+  const playerShieldNumDeaths = (playerShieldTrait?.activeEffect?.variables?.Shield_NumDeaths as number | undefined) ?? 60;
+  const enemyShieldNumDeaths = (enemyShieldTrait?.activeEffect?.variables?.Shield_NumDeaths as number | undefined) ?? 60;
   let playerShieldDeaths = options.priorPlayerShieldDeaths ?? 0;
   let enemyShieldDeaths = options.priorEnemyShieldDeaths ?? 0;
   let playerShieldCashoutDone = false;
@@ -2693,11 +2698,11 @@ export function simulateCombat(
     }
   };
   // priorShieldDeaths 만 으로 이미 threshold 도달했으면 전투 시작 시 즉시 적용.
-  if (playerShieldDeaths >= SHIELD_NUM_DEATHS) {
+  if (playerShieldDeaths >= playerShieldNumDeaths) {
     applyShieldCashout(playerUnits);
     playerShieldCashoutDone = true;
   }
-  if (enemyShieldDeaths >= SHIELD_NUM_DEATHS) {
+  if (enemyShieldDeaths >= enemyShieldNumDeaths) {
     applyShieldCashout(enemies);
     enemyShieldCashoutDone = true;
   }
@@ -2708,14 +2713,14 @@ export function simulateCombat(
     const deadEnemyUnit = enemies.find((u) => u.id === sourceId);
     if (deadPlayerUnit && !isAutoUnit(deadPlayerUnit.champion.apiName)) {
       playerShieldDeaths++;
-      if (!playerShieldCashoutDone && playerShieldDeaths >= SHIELD_NUM_DEATHS) {
+      if (!playerShieldCashoutDone && playerShieldDeaths >= playerShieldNumDeaths) {
         applyShieldCashout(playerUnits);
         playerShieldCashoutDone = true;
       }
     }
     if (deadEnemyUnit && !isAutoUnit(deadEnemyUnit.champion.apiName)) {
       enemyShieldDeaths++;
-      if (!enemyShieldCashoutDone && enemyShieldDeaths >= SHIELD_NUM_DEATHS) {
+      if (!enemyShieldCashoutDone && enemyShieldDeaths >= enemyShieldNumDeaths) {
         applyShieldCashout(enemies);
         enemyShieldCashoutDone = true;
       }

--- a/tests/unit/simulator/stargazer-medallion.test.ts
+++ b/tests/unit/simulator/stargazer-medallion.test.ts
@@ -1,0 +1,116 @@
+/**
+ * 별돌보미 메달(Medallion) 변종 17.2 회귀 가드.
+ *
+ * 17.2 trait desc:
+ *   "(3) Medallion_DA(12)% 피해 증폭, 아군 3성 unit 하나당 +Medallion_IncreasePer3Star(5)%"
+ *
+ * raw effects (TFT17_Stargazer_Medallion):
+ *   (3) tier: Medallion_DA=12 (% pt), Medallion_IncreasePer3Star=5 (% pt per 3성)
+ *
+ * 17.2 변경: Medallion_IncreasePer3Star 6.5 → 5 (PR #37 fetch 자동 반영).
+ *
+ * 시뮬 (combatLoop.ts applyStargazerEffects Medallion 분기):
+ *   - 강화 칸 (medal pattern) 안 unit 모두에게 damageAmp += (baseDA + per3Star × 3성수) / 100
+ *   - 3성 카운트는 player team 전체 (강화 칸 외부 포함, desc "아군 3성 unit").
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import { CONSTELLATION_TILE_PATTERN } from '@/lib/actualData/stargazerMapping';
+import type { PlacedChampion, RawChampion, RawItem } from '@/types';
+
+const { champions, traits, items } = loadServerCatalogs();
+const STARGAZER_EMBLEM = items.find((i) => i.apiName === 'TFT17_Item_StargazerEmblemItem')!;
+const apTwistedFate = champions.find((c) => c.apiName === 'TFT17_TwistedFate')!;
+const apTalon = champions.find((c) => c.apiName === 'TFT17_Talon')!;
+const apJax = champions.find((c) => c.apiName === 'TFT17_Jax')!;
+const apAatrox = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
+const dummyEnemy = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
+
+function placed(c: RawChampion, q: number, r: number, starLevel: number = 2, eqItems: RawItem[] = []): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: eqItems };
+}
+
+function buildMedalTeamWithStars(stars: number[]): PlacedChampion[] {
+  const tiles = CONSTELLATION_TILE_PATTERN.medal;
+  const champs = [apTwistedFate, apTalon, apJax, apAatrox];
+  // 강화 칸 4 위치 + 별돌보미 4명. emblem 으로 Aatrox 도 별돌보미 trait.
+  return [
+    placed(champs[0], tiles[0].q, tiles[0].r, stars[0] ?? 2),
+    placed(champs[1], tiles[1].q, tiles[1].r, stars[1] ?? 2),
+    placed(champs[2], tiles[2].q, tiles[2].r, stars[2] ?? 2),
+    placed(champs[3], tiles[3].q, tiles[3].r, stars[3] ?? 2, [STARGAZER_EMBLEM]),
+  ];
+}
+
+describe('Medallion 17.2 — base damageAmp + 3성당 추가', () => {
+  it('(3) 별돌보미 4명 (3성 0명) + medallion → damageAmp += 0.12 (base 12%)', () => {
+    const team = buildMedalTeamWithStars([2, 2, 2, 2]);
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'medal',
+    });
+    const tf = result.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    expect(tf.damageAmp).toBeCloseTo(0.12, 2);
+  });
+
+  it('3성 unit 1명 추가 → damageAmp += 0.12 + 0.05 = 0.17', () => {
+    const team = buildMedalTeamWithStars([3, 2, 2, 2]); // 3성 1명
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'medal',
+    });
+    const talon = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Talon')!;
+    // base 12% + 3성 1명당 5% → 17%
+    expect(talon.damageAmp).toBeCloseTo(0.17, 2);
+  });
+
+  it('3성 unit 3명 → damageAmp += 0.12 + 3 × 0.05 = 0.27 (17.2 IncreasePer3Star=5)', () => {
+    const team = buildMedalTeamWithStars([3, 3, 3, 2]); // 3성 3명
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'medal',
+    });
+    const aatrox = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Aatrox')!;
+    // base 12% + 3 × 5% = 27%
+    expect(aatrox.damageAmp).toBeCloseTo(0.27, 2);
+  });
+
+  it('medallion 외 별자리 (mountain) → Medallion damageAmp 미적용', () => {
+    const team = buildMedalTeamWithStars([3, 3, 2, 2]);
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'mountain',
+    });
+    const tf = result.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    // mountain 별자리는 강화 칸 별돌보미만 buff (Medallion 미적용)
+    expect(tf.damageAmp).toBe(0);
+  });
+
+  it('강화 칸 외 unit (medallion 별자리 활성이라도) → damageAmp 미적용', () => {
+    const tiles = CONSTELLATION_TILE_PATTERN.medal;
+    // 별돌보미 4명, 한 명만 강화 칸 안. 다른 3명은 medal pattern 외부 좌표.
+    // medal pattern 외부 axial: (5,3) → (3,6), (4,2) → (2,5), (3,2) → (2,4) 등
+    const team = [
+      placed(apTwistedFate, tiles[0].q, tiles[0].r, 2), // on tile
+      placed(apTalon, 5, 3, 2), // off tile
+      placed(apJax, 4, 2, 2),
+      placed(apAatrox, 3, 2, 2, [STARGAZER_EMBLEM]),
+    ];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerStargazerConstellation: 'medal',
+    });
+    const talon = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Talon')!;
+    // 강화 칸 외 → Medallion damageAmp 미적용 (0)
+    expect(talon.damageAmp).toBe(0);
+    // TF 는 강화 칸 안 → damageAmp 적용
+    const tf = result.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    expect(tf.damageAmp).toBeCloseTo(0.12, 2);
+  });
+});


### PR DESCRIPTION
## Summary

G1 일부 — Stargazer Medallion 변종 정확성 회귀 가드 + Shield_NumDeaths drift 방지.

## Changes

| 작업 | 내용 |
|------|------|
| **Medallion 회귀 가드** | 시뮬 코드는 이미 17.2 정확 구현 (`Medallion_DA=12`, `IncreasePer3Star=5` fetch 자동 반영). 회귀 방지 테스트 5건 신규. |
| **Shield_NumDeaths 동적화** | hardcoded `SHIELD_NUM_DEATHS = 60` → trait variable 동적 읽기 (player / enemy 분리). 데이터 hotfix 시 자동 동기화. |

## Medallion 회귀 가드 (5 cases)

```
(3) tier (3성 0명) → damageAmp 0.12 (base 12%)
3성 1명           → damageAmp 0.17 (12% + 5%)
3성 3명           → damageAmp 0.27 (12% + 3×5% — 17.2 IncreasePer3Star=5 검증)
medal 외 별자리   → damageAmp 0
강화 칸 외 unit   → damageAmp 0 (강화 칸 안 unit 만 0.12)
```

## Shield_NumDeaths 변경 (drift 방지)

**Before**:
```ts
const SHIELD_NUM_DEATHS = 60; // hardcoded
```

**After**:
```ts
const playerShieldTrait = playerActiveTraits.find(t => t.trait.apiName === 'TFT17_Stargazer_Shield' && t.activeEffect);
const enemyShieldTrait = enemyActiveTraits.find(t => t.trait.apiName === 'TFT17_Stargazer_Shield' && t.activeEffect);
const playerShieldNumDeaths = (playerShieldTrait?.activeEffect?.variables?.Shield_NumDeaths ?? 60) as number;
const enemyShieldNumDeaths = (enemyShieldTrait?.activeEffect?.variables?.Shield_NumDeaths ?? 60) as number;
```

## Test plan

- [x] `pnpm vitest run` — **433/441 PASS** (8 skipped — Fountain legacy)
  - `stargazer-medallion.test.ts` — **5/5 PASS** (신규)
  - `stargazer-shield-cashout.test.ts` — 기존 통과 유지
- [x] `pnpm typecheck` — pass

## Future work (G1 잔여)

- **base TFT17_Stargazer (8)/(9)/(10) tier hash 변수** 의미 매핑 (`{3b1fef00}`, `{aa686d69}`, `{56df89e0}`, `{a6419a0b}`, `{b44d11c3}` 등) — 외부 source / 인게임 검증 후 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)