### PR TITLE
feat(simulator): G2 Phase 1 — 최신상(GravesTrait) Frame 변환 (3종)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -3154,14 +3154,34 @@ export function simulateCombat(
             eventBus.emit('on_heal', { sourceId: unit.id, value: heal, tick });
           }
 
-          // 최신상 (GravesTrait) DoubleTap Frame — 25% 확률 추가 1회 공격 (동일 damage).
-          // 단순화: 같은 finalDamage 를 한 번 더 적용 + on_hit / on_damage 이벤트 emit.
+          // 최신상 (GravesTrait) DoubleTap Frame — 25% 확률 추가 1회 공격.
+          // codex P1 가드: rawDamage 부터 mitigation pipeline 다시 거쳐야 (shielded target
+          // 에 첫 hit post-shield 값 재사용 시 under-damage 발생).
+          // codex P2 가드: 풀 attack 이벤트 emit (on_attack/on_damage/on_hit/on_hit_taken)
+          // — item runtime counter 등 attack-count 기반 시스템 정확 작동.
           if (unit.gravesDoubleAttackChance > 0 && target.state !== 'dead'
               && rng.next() < unit.gravesDoubleAttackChance) {
-            target.currentHp -= finalDamage;
-            target.totalDamageTaken += finalDamage;
-            unit.totalDamageDealt += finalDamage;
-            eventBus.emit('on_hit', { sourceId: unit.id, targetId: target.id, value: finalDamage, damageType: 'physical', tick });
+            // 새 hit — rawDamage 재사용 (동일 source stats 기반) + mitigation 재계산.
+            // 단, crit 은 첫 hit 와 동일하게 취급 (rawDamage 에 critMult 이미 포함).
+            let extraFinal = applyResistance(rawDamage, target.stats.armor, unit.stats.armorPen);
+            if (target.damageReduction > 0) extraFinal *= (1 - target.damageReduction);
+            if ((target.role === 'Fighter' || target.role === 'Assassin') && target.target !== unit.id) {
+              extraFinal *= (1 - NON_TARGET_DAMAGE_REDUCTION);
+            }
+            extraFinal = applyShield(target, extraFinal, eventBus, tick);
+            if (target.statusEffects.some(e => e.type === 'invulnerable')) extraFinal = 0;
+
+            target.currentHp -= extraFinal;
+            target.totalDamageTaken += extraFinal;
+            unit.totalDamageDealt += extraFinal;
+            unit.attackCount++;
+
+            // 풀 attack 이벤트 emit — 일반 평타와 동일 path.
+            eventBus.emit('on_attack', { sourceId: unit.id, targetId: target.id, value: extraFinal, tick });
+            eventBus.emit('on_hit', { sourceId: unit.id, targetId: target.id, value: extraFinal, damageType: 'physical', tick });
+            eventBus.emit('on_damage', { sourceId: target.id, targetId: unit.id, value: extraFinal, damageType: 'physical', tick });
+            eventBus.emit('on_hit_taken', { sourceId: target.id, targetId: unit.id, value: extraFinal, damageType: 'physical', tick });
+
             if (target.currentHp <= 0) {
               target.currentHp = 0;
               target.state = 'dead';
@@ -3172,6 +3192,17 @@ export function simulateCombat(
               logs.push(dlog); tickLogs.push(dlog);
               eventBus.emit('on_kill', { sourceId: unit.id, targetId: target.id, tick });
               eventBus.emit('on_death', { sourceId: target.id, targetId: unit.id, tick });
+            }
+
+            // 별돌보미 뱀(Serpent) — DoubleTap 추가 hit 도 중독 적용.
+            triggerSerpentPoison(unit, target, extraFinal);
+
+            // omnivamp 도 추가 hit 에 적용 (attack 1회 와 동일).
+            if (unit.omnivamp > 0 && extraFinal > 0) {
+              const grievousReduction = target.augmentGrievousWounds > 0 ? (1 - target.augmentGrievousWounds) : 1;
+              const heal = extraFinal * unit.omnivamp * grievousReduction;
+              unit.currentHp = Math.min(unit.maxHp, unit.currentHp + heal);
+              eventBus.emit('on_heal', { sourceId: unit.id, value: heal, tick });
             }
           }
 

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -116,6 +116,16 @@ export interface SimulateOptions {
   priorPlayerShieldDeaths?: number;
   /** B 팀(enemy) 누적 사망 카운트. 의미는 player 와 동일. */
   priorEnemyShieldDeaths?: number;
+  /**
+   * 최신상 (TFT17_GravesTrait) Frame 선택 — A 팀(player) 의 가장 강한 그레이브즈 1명에 적용.
+   * 'CloseQuarters' (맹공): 사거리 -2, 공격력 전사 변환, +HP 250, +AD 25%, +흡혈 10%
+   * 'SharpshooterModule' (위력): 정밀 (spellCanCrit) + 스킬 피해 5% 증가
+   * 'DoubleTap' (사수): 25% 확률 2회 공격
+   * 미지정 시 Frame 미적용. 하위 업그레이드 (Buckshot 등) 는 후속 PR.
+   */
+  playerGravesFrame?: 'CloseQuarters' | 'SharpshooterModule' | 'DoubleTap';
+  /** B 팀(enemy) 그레이브즈 Frame. 의미는 player 와 동일. */
+  enemyGravesFrame?: 'CloseQuarters' | 'SharpshooterModule' | 'DoubleTap';
 }
 
 function createCombatUnit(
@@ -163,6 +173,9 @@ function createCombatUnit(
     healAmp: itemFx.healAmp ?? 0,
     darkStarExecuteThreshold: 0,
     darkStarSupermassive: false,
+    gravesFrame: null,
+    gravesDoubleAttackChance: 0,
+    gravesAbilityDamageBonus: 0,
     gragasCarryActive: false,
     leonaCarryActive: false,
     attackCount: 0,
@@ -1162,6 +1175,52 @@ function applyHeroCarryTransforms(augmentApiNames: string[], units: CombatUnit[]
   }
 }
 
+/**
+ * 최신상 (TFT17_GravesTrait) Frame 변환 — 가장 강한 그레이브즈 1명에 적용.
+ *
+ * raw items (TFT17_GravesTrait_Offense_*):
+ *   CloseQuarters (맹공): { Range: -2, BaseHealth: 250, Omnivamp: 0.10, AttackDamage: 0.25 }
+ *     → 사거리 -2, 공격력 전사 변환, +HP 250, +AD 25%, +흡혈 10%
+ *   SharpshooterModule (위력): { AbilityDamagePercentIncrease: 0.05 }
+ *     → 정밀 (spellCanCrit) + 스킬 피해 +5%
+ *   DoubleTap (사수): { DoubleAttackChance: 0.25 }
+ *     → 25% 확률 2회 공격
+ *
+ * 본 PR (Phase 1) — Frame 3종 stat 적용 + DoubleTap chance flag + Sharp 정밀 / ability damage.
+ * 하위 업그레이드 (Buckshot, Heartseeker, GravBooster 등 30+) 는 후속 PR.
+ */
+function applyGravesFrameEffects(
+  units: CombatUnit[],
+  frame: 'CloseQuarters' | 'SharpshooterModule' | 'DoubleTap' | undefined,
+): void {
+  if (!frame) return;
+  const target = findStrongestUnitByApi(units, 'TFT17_Graves');
+  if (!target) return;
+  target.gravesFrame = frame;
+  if (frame === 'CloseQuarters') {
+    // 맹공: Range -2 (최소 1), +HP 250, +AD 25%, +흡혈 10%, role='Fighter' (공격력 전사 단순화).
+    target.stats.range = Math.max(1, target.stats.range - 2);
+    target.maxHp += 250;
+    target.currentHp += 250;
+    const baseAd = target.champion.stats.damage * (STAR_SCALING[target.starLevel] || 1);
+    target.stats.damage += baseAd * 0.25;
+    target.omnivamp += 0.10;
+    target.role = 'Fighter';
+    return;
+  }
+  if (frame === 'SharpshooterModule') {
+    // 위력: 정밀 (spellCanCrit) + 스킬 피해 +5%.
+    target.spellCanCrit = true;
+    target.gravesAbilityDamageBonus = 0.05;
+    return;
+  }
+  if (frame === 'DoubleTap') {
+    // 사수: 25% 확률 추가 공격 — eventBus on_attack hook 에서 처리.
+    target.gravesDoubleAttackChance = 0.25;
+    return;
+  }
+}
+
 /** 전쟁기계 — BaseDR을 damageReduction에 적용 */
 function applyJuggernautDR(activeTraits: ActiveTrait[], units: CombatUnit[]): void {
   const jugg = activeTraits.find(t => t.trait.apiName === 'TFT16_Juggernaut' && t.activeEffect);
@@ -1579,6 +1638,9 @@ function spawnFreljordTurrets(
             healAmp: 0,
             darkStarExecuteThreshold: 0,
             darkStarSupermassive: false,
+            gravesFrame: null,
+            gravesDoubleAttackChance: 0,
+            gravesAbilityDamageBonus: 0,
             gragasCarryActive: false,
             leonaCarryActive: false,
             attackCount: 0,
@@ -1722,6 +1784,9 @@ function trySpawnGalio(
     healAmp: 0,
     darkStarExecuteThreshold: 0,
     darkStarSupermassive: false,
+    gravesFrame: null,
+    gravesDoubleAttackChance: 0,
+    gravesAbilityDamageBonus: 0,
     gragasCarryActive: false,
     leonaCarryActive: false,
     attackCount: 0,
@@ -2443,6 +2508,9 @@ export function simulateCombat(
   // hero augment carry 변환 — 자폭(그라가스) / 방패 여전사(레오나).
   applyHeroCarryTransforms(playerAugApiNames, playerUnits);
   applyHeroCarryTransforms(enemyAugApiNames, enemies);
+  // 최신상 (GravesTrait) Frame — 가장 강한 그레이브즈 1명에 stat/메커닉 적용.
+  applyGravesFrameEffects(playerUnits, options.playerGravesFrame);
+  applyGravesFrameEffects(enemies, options.enemyGravesFrame);
   // 선봉대 보호막은 전투 시작 시점 (tick=0, time=0).
   applyVanguardEffects(playerActiveTraits, playerUnits, 0, 0, logs);
   applyVanguardEffects(enemyActiveTraits, enemies, 0, 0, logs);
@@ -3086,6 +3154,27 @@ export function simulateCombat(
             eventBus.emit('on_heal', { sourceId: unit.id, value: heal, tick });
           }
 
+          // 최신상 (GravesTrait) DoubleTap Frame — 25% 확률 추가 1회 공격 (동일 damage).
+          // 단순화: 같은 finalDamage 를 한 번 더 적용 + on_hit / on_damage 이벤트 emit.
+          if (unit.gravesDoubleAttackChance > 0 && target.state !== 'dead'
+              && rng.next() < unit.gravesDoubleAttackChance) {
+            target.currentHp -= finalDamage;
+            target.totalDamageTaken += finalDamage;
+            unit.totalDamageDealt += finalDamage;
+            eventBus.emit('on_hit', { sourceId: unit.id, targetId: target.id, value: finalDamage, damageType: 'physical', tick });
+            if (target.currentHp <= 0) {
+              target.currentHp = 0;
+              target.state = 'dead';
+              unit.killCount++;
+              if (unit.team === 'player') playerArbiterState.enemyDeathCount++;
+              else enemyArbiterState.enemyDeathCount++;
+              const dlog: CombatLog = { tick, time, type: 'death', sourceId: target.id, message: `${target.champion.name} 사망! (사수 프레임 추가 공격)` };
+              logs.push(dlog); tickLogs.push(dlog);
+              eventBus.emit('on_kill', { sourceId: unit.id, targetId: target.id, tick });
+              eventBus.emit('on_death', { sourceId: target.id, targetId: unit.id, tick });
+            }
+          }
+
           // Augment burn: apply burn DoT on auto-attack
           if (unit.augmentBurnPercent > 0) {
             const burnDmg = target.maxHp * unit.augmentBurnPercent;
@@ -3217,9 +3306,11 @@ export function simulateCombat(
             // 스킬 시전 후 cast time — 이 시간 동안 공격 불가
             unit.attackCooldown = config.pattern === 'self_buff' ? SELF_BUFF_CAST_TICKS : CAST_TICKS;
 
-            const { damage: rawAbilityDmg, type: dmgType } = getAbilityDamage(
+            const { damage: rawAbilityDmgBase, type: dmgType } = getAbilityDamage(
               unit.champion, unit.starLevel, unit.stats.ap, 0, config.damageVar
             );
+            // SharpshooterModule (위력 프레임) — 스킬 피해 +5% 가산.
+            const rawAbilityDmg = rawAbilityDmgBase * (1 + (unit.gravesAbilityDamageBonus ?? 0));
 
             // 자폭 (GragasCarry) — 일반 ability target 흐름 skip + self 에 데미지 + HP floor.
             // 사용자 명세: 그라가스 본인 데미지, 다른 아군 X, 자기 스킬로 죽지 않음 (HP >= 1).

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -509,6 +509,24 @@ export interface CombatUnit {
    */
   darkStarSupermassive: boolean;
   /**
+   * 최신상 (TFT17_GravesTrait) Frame 변환 — 가장 강한 그레이브즈 1명만 양수.
+   * 'CloseQuarters' = 맹공 프레임 (공격력 전사: 사거리-2, +HP/AD/흡혈)
+   * 'SharpshooterModule' = 위력 프레임 (정밀 + 스킬 피해 +5%)
+   * 'DoubleTap' = 사수 프레임 (25% 확률 2회 공격)
+   * null = Frame 미적용 (Graves 가 일반 챔프로 작동).
+   */
+  gravesFrame: 'CloseQuarters' | 'SharpshooterModule' | 'DoubleTap' | null;
+  /**
+   * Frame DoubleTap 활성 시 추가 공격 발동 확률 (0~1). 0 = 미활성.
+   * eventBus 'on_attack' hook 에서 rng.next() < chance 시 추가 hit.
+   */
+  gravesDoubleAttackChance: number;
+  /**
+   * Frame SharpshooterModule 활성 시 ability damage 추가 % (0~1, 0.05 = +5%).
+   * cast 처리 시 abilityDamage *= (1 + bonus). 0 = 미활성.
+   */
+  gravesAbilityDamageBonus: number;
+  /**
    * 자폭(TFT17_Augment_GragasCarry) 활성 + 가장 강한 그라가스로 선정된 unit 만 true.
    * 그라가스 ability 가 거대한 폭발 (자기 자신 데미지, 다른 아군 X) 로 변환되며,
    * 자폭 데미지로 hp 가 1 미만으로 떨어지지 않음 (HP floor=1).

--- a/tests/unit/simulator/graves-frame.test.ts
+++ b/tests/unit/simulator/graves-frame.test.ts
@@ -1,0 +1,142 @@
+/**
+ * 회귀 가드 — 최신상 (TFT17_GravesTrait) Frame 변환 (3종, Phase 1).
+ *
+ * 17.2 raw items:
+ *   CloseQuarters (맹공): Range -2, BaseHealth 250, AttackDamage 0.25, Omnivamp 0.10
+ *   SharpshooterModule (위력): AbilityDamagePercentIncrease 0.05 + 정밀
+ *   DoubleTap (사수): DoubleAttackChance 0.25
+ *
+ * 가장 강한 그레이브즈 1명에 적용 (성급 → 아이템 → 첫 번째).
+ * 본 Phase 는 Frame 3종 stat / 메커닉 적용. 하위 업그레이드 (30+) 는 후속 PR.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion, RawItem } from '@/types';
+
+const { champions, traits, items } = loadServerCatalogs();
+const apGraves = champions.find(c => c.apiName === 'TFT17_Graves')!;
+const apTwistedFate = champions.find(c => c.apiName === 'TFT17_TwistedFate')!;
+const dummyEnemy = champions.find(c => c.apiName === 'TFT17_Aatrox')!;
+const someItem = items.find(i => i.apiName?.startsWith('TFT_Item_'))!;
+
+function placed(c: RawChampion, q: number, r: number, starLevel: number = 2, eqItems: RawItem[] = []): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: eqItems };
+}
+
+describe('GravesTrait Frame — 가장 강한 그레이브즈 1명에 적용', () => {
+  it('CloseQuarters (맹공) → range -2, +HP 250, +AD 25%, +omnivamp 0.10, role=Fighter', () => {
+    const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+
+    const baseRange = apGraves.stats.range;
+    const baseDamage = apGraves.stats.damage;
+    const baseHp = apGraves.stats.hp;
+
+    const withFrame = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerGravesFrame: 'CloseQuarters',
+    });
+    const baseline = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+
+    const grav = withFrame.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!;
+    const gravBase = baseline.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!;
+
+    // gravesFrame flag 설정
+    expect(grav.gravesFrame).toBe('CloseQuarters');
+    // range -2 (최소 1)
+    expect(grav.stats.range).toBe(Math.max(1, baseRange - 2));
+    // maxHp 250 추가
+    expect(grav.maxHp - gravBase.maxHp).toBeCloseTo(250, 0);
+    // omnivamp +0.10
+    expect(grav.omnivamp - gravBase.omnivamp).toBeCloseTo(0.10, 2);
+    // role Fighter
+    expect(grav.role).toBe('Fighter');
+    // damage 증가 (base × 0.25 추가) — base × star × 0.25
+    expect(grav.stats.damage).toBeGreaterThan(gravBase.stats.damage);
+  });
+
+  it('SharpshooterModule (위력) → spellCanCrit + gravesAbilityDamageBonus 0.05', () => {
+    const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerGravesFrame: 'SharpshooterModule',
+    });
+    const grav = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!;
+    expect(grav.gravesFrame).toBe('SharpshooterModule');
+    expect(grav.spellCanCrit).toBe(true);
+    expect(grav.gravesAbilityDamageBonus).toBeCloseTo(0.05, 3);
+  });
+
+  it('DoubleTap (사수) → gravesDoubleAttackChance 0.25', () => {
+    const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerGravesFrame: 'DoubleTap',
+    });
+    const grav = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!;
+    expect(grav.gravesFrame).toBe('DoubleTap');
+    expect(grav.gravesDoubleAttackChance).toBeCloseTo(0.25, 3);
+  });
+
+  it('Frame 미지정 → Frame 효과 없음 (default 값)', () => {
+    const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const grav = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!;
+    expect(grav.gravesFrame).toBe(null);
+    expect(grav.gravesDoubleAttackChance).toBe(0);
+    expect(grav.gravesAbilityDamageBonus).toBe(0);
+  });
+
+  it('비-Graves unit → Frame 효과 없음 (TFT17_Graves 챔프만 적용)', () => {
+    const team: PlacedChampion[] = [placed(apTwistedFate, 0, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerGravesFrame: 'CloseQuarters', // TwistedFate 만 있음, Graves 없음 → 적용 안 됨
+    });
+    const tf = result.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    expect(tf.gravesFrame).toBe(null);
+  });
+
+  it('가장 강한 그레이브즈 1명에만 적용 — Graves 2명 (성급 차이) 시 3성 만', () => {
+    const team: PlacedChampion[] = [
+      placed(apGraves, 0, 0, 2),
+      placed(apGraves, 1, 0, 3),
+    ];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerGravesFrame: 'CloseQuarters',
+    });
+    const gravs = result.playerUnits.filter(u => u.champion.apiName === 'TFT17_Graves');
+    const star3 = gravs.find(u => u.starLevel === 3)!;
+    const star2 = gravs.find(u => u.starLevel === 2)!;
+    expect(star3.gravesFrame).toBe('CloseQuarters');
+    expect(star2.gravesFrame).toBe(null);
+  });
+
+  it('가장 강한 룰 — 동급 시 아이템 보유 unit 우선', () => {
+    const team: PlacedChampion[] = [
+      placed(apGraves, 0, 0, 2, []), // no items
+      placed(apGraves, 1, 0, 2, [someItem]), // 아이템 1개
+    ];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerGravesFrame: 'DoubleTap',
+    });
+    const gravs = result.playerUnits.filter(u => u.champion.apiName === 'TFT17_Graves');
+    const withItems = gravs.find(u => u.items.length > 0)!;
+    const noItems = gravs.find(u => u.items.length === 0)!;
+    expect(withItems.gravesFrame).toBe('DoubleTap');
+    expect(noItems.gravesFrame).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary

TODO 2 (Factory New) Phase 1 — 가장 강한 그레이브즈 1명에 Frame stat / 메커닉 적용. 하위 업그레이드 30+ 종은 후속 PR.

## Frame 3종 (17.2 raw items 기준)

| Frame | raw effects | 시뮬 처리 |
|-------|-------------|----------|
| **맹공 (CloseQuarters)** | `Range: -2, BaseHealth: 250, AttackDamage: 0.25, Omnivamp: 0.10` | 사거리 -2, +HP 250, +AD 25%, +흡혈 10%, role='Fighter' (공격력 전사) |
| **위력 (SharpshooterModule)** | `AbilityDamagePercentIncrease: 0.05` | 정밀 (`spellCanCrit=true`) + 스킬 피해 **+5%** |
| **사수 (DoubleTap)** | `DoubleAttackChance: 0.25` | 평타 후 **25% 확률 추가 1회 공격** |

## Changes

| 파일 | 변경 |
|------|------|
| `src/types/index.ts` | `CombatUnit.gravesFrame` + `gravesDoubleAttackChance` + `gravesAbilityDamageBonus` |
| `src/lib/simulator/engine/combatLoop.ts` | `applyGravesFrameEffects` 신규, `SimulateOptions.player/enemyGravesFrame`, `on_attack` 후 DoubleTap hook, cast 시 Sharp damage bonus |
| `tests/unit/simulator/graves-frame.test.ts` | 회귀 가드 7건 (신규) |

## "가장 강한 그레이브즈" 룰
`findStrongestUnitByApi` (Hero Carry 패턴 동일):
1. 성급 (starLevel) 최고
2. 동급 시 아이템 보유 unit 우선 (개수 많은 쪽)
3. tie → 첫 번째 (deterministic)

## DoubleTap 동작
```ts
// 평타 후 일반 finalDamage 적용 + omnivamp 처리 후
if (unit.gravesDoubleAttackChance > 0 && rng.next() < unit.gravesDoubleAttackChance) {
  target.currentHp -= finalDamage; // 동일 damage 한 번 더
  // on_hit emit + 사망 처리
}
```

## Test plan

- [x] `pnpm vitest run` — **440/448 PASS** (8 skipped — Fountain legacy)
  - `graves-frame.test.ts` — **7/7 PASS**
    - CloseQuarters: range -2, +HP 250, +AD 25%, +omnivamp 0.10, role=Fighter
    - SharpshooterModule: spellCanCrit + gravesAbilityDamageBonus 0.05
    - DoubleTap: gravesDoubleAttackChance 0.25
    - Frame 미지정 → default
    - 비-Graves unit → 미적용
    - 가장 강한 룰 (3성 우선)
    - 가장 강한 룰 (동급 시 아이템 보유)
- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — 0 errors

## Future (G2 Phase 2/3)

- **Phase 2** — 단순 stat 업그레이드 (~10 노드): LeechingImplants, HeavyPlating, PrecisionScope, Fission, Heartseeker, Tankbuster, Coolant, APRounds 등
- **Phase 3** — 특수 메커닉 (~20 노드): Buckshot/Choke, GravBooster, ReactiveArmor, LatentExplosion, RevUp, RipperBullets, Shockwave, EmergencyShielding 등 (이벤트 hook)
- **Phase 4** — `factory_new_upgrades.json` 데이터 파일 + actual-data `nextUpgradeRoundsRemaining` 통합

🤖 Generated with [Claude Code](https://claude.com/claude-code)