### PR TITLE
feat(simulator): G2 Phase 2 — 최신상 무기고 stat upgrade 18종

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -1286,16 +1286,64 @@ const GRAVES_STAT_UPGRADE_HANDLERS: Record<string, (u: CombatUnit, baseAd: numbe
   },
 };
 
+/**
+ * Stable canonical 적용 순서 — deterministic 보장 (codex P2).
+ * 일부 upgrade 가 order-sensitive (SheerMass × maxHp vs HeavyPlating + maxHp 등) →
+ * 입력 array 순서가 달라도 동일 set 이면 항상 같은 결과를 내야 replay/serialize 가능.
+ *
+ * 적용 순서 원칙:
+ *   1. flat HP / armor / MR / range / mana 등 가산 먼저
+ *   2. AD% / armorPen / crit 등 stat 가산
+ *   3. maxHp 비례 multiplier (SheerMass) — 가장 마지막
+ *   4. 동일 카테고리 내에선 알파벳 순 (deterministic)
+ */
+const GRAVES_UPGRADE_APPLY_ORDER: ReadonlyArray<string> = [
+  // 1. flat additions (HP/armor/MR/range/mana)
+  'APRounds',
+  'APRounds2',
+  'Coolant',
+  'Coolant2',
+  'Fission',
+  'Fission2',
+  'Fission3',
+  'HeavyPlating',
+  'LeechingImplants',
+  'LeechingImplants2',
+  'PrecisionScope',
+  'PrecisionScope2',
+  'PrecisionScope3',
+  // 2. crit / damage amp
+  'Heartseeker',
+  'Heartseeker2',
+  'Heartseeker3',
+  'Tankbuster',
+  // 3. % multiplier (가장 마지막 — 1·2 단계의 flat HP/AD 가산 후 적용)
+  'SheerMass',
+];
+
 function applyGravesStatUpgrades(units: CombatUnit[], upgrades: string[] | undefined): void {
   if (!upgrades || upgrades.length === 0) return;
   const target = findStrongestUnitByApi(units, 'TFT17_Graves');
   if (!target) return;
   const baseAd = target.champion.stats.damage * (STAR_SCALING[target.starLevel] || 1);
+
+  // canonical order 로 정렬 — 입력 array 순서가 달라도 동일 set 이면 동일 결과.
+  // 미지원 upgrade (Phase 3 메커닉) 는 GRAVES_STAT_UPGRADE_HANDLERS 에 없으므로 skip.
+  // canonical order 에 없는 신규 upgrade 는 알파벳 순 fallback (정의 누락 가드).
+  const requested = new Set(upgrades);
+  const ordered: string[] = [];
+  for (const id of GRAVES_UPGRADE_APPLY_ORDER) {
+    if (requested.has(id) && GRAVES_STAT_UPGRADE_HANDLERS[id]) ordered.push(id);
+  }
+  const known = new Set(GRAVES_UPGRADE_APPLY_ORDER);
+  const fallback = upgrades
+    .filter(id => !known.has(id) && GRAVES_STAT_UPGRADE_HANDLERS[id])
+    .sort();
+  ordered.push(...fallback);
+
   const applied: string[] = [];
-  for (const id of upgrades) {
-    const handler = GRAVES_STAT_UPGRADE_HANDLERS[id];
-    if (!handler) continue; // 미지원 upgrade (Phase 3 메커닉) 는 silently skip
-    handler(target, baseAd);
+  for (const id of ordered) {
+    GRAVES_STAT_UPGRADE_HANDLERS[id](target, baseAd);
     applied.push(id);
   }
   if (applied.length > 0) {

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -126,6 +126,15 @@ export interface SimulateOptions {
   playerGravesFrame?: 'CloseQuarters' | 'SharpshooterModule' | 'DoubleTap';
   /** B 팀(enemy) 그레이브즈 Frame. 의미는 player 와 동일. */
   enemyGravesFrame?: 'CloseQuarters' | 'SharpshooterModule' | 'DoubleTap';
+  /**
+   * 최신상 무기고 stat upgrade 활성 ID 목록 (suffix only, prefix 'TFT17_GravesTrait_Offense_' 제외).
+   * A 팀(player) 의 가장 강한 그레이브즈 1명에 적용. 예:
+   *   ['LeechingImplants', 'HeavyPlating', 'PrecisionScope2', 'Heartseeker']
+   * Phase 2 단순 stat upgrade 18종만 처리. 메커닉 필요 항목 (RevUp 등) 은 후속.
+   */
+  playerGravesUpgrades?: string[];
+  /** B 팀(enemy) 그레이브즈 stat upgrade. 의미는 player 와 동일. */
+  enemyGravesUpgrades?: string[];
 }
 
 function createCombatUnit(
@@ -176,6 +185,8 @@ function createCombatUnit(
     gravesFrame: null,
     gravesDoubleAttackChance: 0,
     gravesAbilityDamageBonus: 0,
+    gravesUpgrades: [],
+    gravesTankDamageAmp: 0,
     gragasCarryActive: false,
     leonaCarryActive: false,
     attackCount: 0,
@@ -1221,6 +1232,77 @@ function applyGravesFrameEffects(
   }
 }
 
+/**
+ * 최신상 (TFT17_GravesTrait) 무기고 stat upgrade 적용 — Phase 2.
+ *
+ * raw items 기반 직접 stat 가산. 가장 강한 그레이브즈 1명에게만 적용.
+ * RevUp / RevUp2 (sticky target stacking AS) / Buckshot 류 (투사체) 등
+ * 메커닉 필요 항목은 본 함수 미처리 — 후속 Phase 3.
+ *
+ * 적용 18종 (raw effects 기반):
+ *   LeechingImplants    AD +10%, omnivamp +0.10
+ *   LeechingImplants2   AD +20%, omnivamp +0.15
+ *   HeavyPlating        +HP 300, +Armor 20, +MR 20
+ *   PrecisionScope      AD +12%, range +1
+ *   PrecisionScope2     AD +24%, range +2
+ *   PrecisionScope3     AD +36%, range +3
+ *   Fission             AD +10%, manaRegen +2/s
+ *   Fission2            AD +20%, manaRegen +3/s
+ *   Fission3            AD +30%, manaRegen +5/s
+ *   Heartseeker         critChance +0.10, critDmg +0.05
+ *   Heartseeker2        critChance +0.25, critDmg +0.10
+ *   Heartseeker3        critChance +0.40, critDmg +0.18
+ *   Tankbuster          탱커 상대 damage amp +0.15
+ *   Coolant             maxMana -10
+ *   Coolant2            maxMana -20
+ *   APRounds            armorPen +0.30
+ *   APRounds2           armorPen +0.60
+ *   SheerMass           maxHp × 1.25
+ *
+ * AD% 는 base × star scaling (Frame CloseQuarters 와 동일 기준).
+ */
+const GRAVES_STAT_UPGRADE_HANDLERS: Record<string, (u: CombatUnit, baseAd: number) => void> = {
+  LeechingImplants:  (u, ad) => { u.stats.damage += ad * 0.10; u.omnivamp += 0.10; },
+  LeechingImplants2: (u, ad) => { u.stats.damage += ad * 0.20; u.omnivamp += 0.15; },
+  HeavyPlating:      (u)     => { u.maxHp += 300; u.currentHp += 300; u.stats.armor += 20; u.stats.magicResist += 20; },
+  PrecisionScope:    (u, ad) => { u.stats.damage += ad * 0.12; u.stats.range += 1; },
+  PrecisionScope2:   (u, ad) => { u.stats.damage += ad * 0.24; u.stats.range += 2; },
+  PrecisionScope3:   (u, ad) => { u.stats.damage += ad * 0.36; u.stats.range += 3; },
+  Fission:           (u, ad) => { u.stats.damage += ad * 0.10; u.augmentManaRegen += 2; },
+  Fission2:          (u, ad) => { u.stats.damage += ad * 0.20; u.augmentManaRegen += 3; },
+  Fission3:          (u, ad) => { u.stats.damage += ad * 0.30; u.augmentManaRegen += 5; },
+  Heartseeker:       (u)     => { u.stats.critChance += 0.10; u.stats.critMultiplier += 0.05; },
+  Heartseeker2:      (u)     => { u.stats.critChance += 0.25; u.stats.critMultiplier += 0.10; },
+  Heartseeker3:      (u)     => { u.stats.critChance += 0.40; u.stats.critMultiplier += 0.18; },
+  Tankbuster:        (u)     => { u.gravesTankDamageAmp += 0.15; },
+  Coolant:           (u)     => { u.maxMana = Math.max(0, u.maxMana - 10); },
+  Coolant2:          (u)     => { u.maxMana = Math.max(0, u.maxMana - 20); },
+  APRounds:          (u)     => { u.stats.armorPen += 0.30; },
+  APRounds2:         (u)     => { u.stats.armorPen += 0.60; },
+  SheerMass:         (u)     => {
+    const newMax = Math.round(u.maxHp * 1.25);
+    u.maxHp = newMax;
+    u.currentHp = newMax;
+  },
+};
+
+function applyGravesStatUpgrades(units: CombatUnit[], upgrades: string[] | undefined): void {
+  if (!upgrades || upgrades.length === 0) return;
+  const target = findStrongestUnitByApi(units, 'TFT17_Graves');
+  if (!target) return;
+  const baseAd = target.champion.stats.damage * (STAR_SCALING[target.starLevel] || 1);
+  const applied: string[] = [];
+  for (const id of upgrades) {
+    const handler = GRAVES_STAT_UPGRADE_HANDLERS[id];
+    if (!handler) continue; // 미지원 upgrade (Phase 3 메커닉) 는 silently skip
+    handler(target, baseAd);
+    applied.push(id);
+  }
+  if (applied.length > 0) {
+    target.gravesUpgrades = [...target.gravesUpgrades, ...applied];
+  }
+}
+
 /** 전쟁기계 — BaseDR을 damageReduction에 적용 */
 function applyJuggernautDR(activeTraits: ActiveTrait[], units: CombatUnit[]): void {
   const jugg = activeTraits.find(t => t.trait.apiName === 'TFT16_Juggernaut' && t.activeEffect);
@@ -1641,6 +1723,8 @@ function spawnFreljordTurrets(
             gravesFrame: null,
             gravesDoubleAttackChance: 0,
             gravesAbilityDamageBonus: 0,
+            gravesUpgrades: [],
+            gravesTankDamageAmp: 0,
             gragasCarryActive: false,
             leonaCarryActive: false,
             attackCount: 0,
@@ -1787,6 +1871,8 @@ function trySpawnGalio(
     gravesFrame: null,
     gravesDoubleAttackChance: 0,
     gravesAbilityDamageBonus: 0,
+    gravesUpgrades: [],
+    gravesTankDamageAmp: 0,
     gragasCarryActive: false,
     leonaCarryActive: false,
     attackCount: 0,
@@ -2511,6 +2597,9 @@ export function simulateCombat(
   // 최신상 (GravesTrait) Frame — 가장 강한 그레이브즈 1명에 stat/메커닉 적용.
   applyGravesFrameEffects(playerUnits, options.playerGravesFrame);
   applyGravesFrameEffects(enemies, options.enemyGravesFrame);
+  // 최신상 무기고 stat upgrade — Frame 과 동일 unit 에 누적.
+  applyGravesStatUpgrades(playerUnits, options.playerGravesUpgrades);
+  applyGravesStatUpgrades(enemies, options.enemyGravesUpgrades);
   // 선봉대 보호막은 전투 시작 시점 (tick=0, time=0).
   applyVanguardEffects(playerActiveTraits, playerUnits, 0, 0, logs);
   applyVanguardEffects(enemyActiveTraits, enemies, 0, 0, logs);
@@ -3098,6 +3187,10 @@ export function simulateCombat(
           if (unit.inventionTankDamageAmp > 0 && target.role === 'Tank') {
             totalDamageAmp += unit.inventionTankDamageAmp;
           }
+          // 최신상 Tankbuster — 탱커 상대 추가 damage amp
+          if (unit.gravesTankDamageAmp > 0 && target.role === 'Tank') {
+            totalDamageAmp += unit.gravesTankDamageAmp;
+          }
           // 저격수 (Sniper) — 거리 기반 추가 damage amp
           totalDamageAmp += computeSniperDamageAmp(unit, target);
           const rawDamage = unit.stats.damage * critMult * (1 + totalDamageAmp);
@@ -3440,6 +3533,10 @@ export function simulateCombat(
                 let abilityDamageAmp = unit.damageAmp;
                 if (unit.inventionTankDamageAmp > 0 && t.role === 'Tank') {
                   abilityDamageAmp += unit.inventionTankDamageAmp;
+                }
+                // 최신상 Tankbuster — 탱커 상대 추가 damage amp (per target)
+                if (unit.gravesTankDamageAmp > 0 && t.role === 'Tank') {
+                  abilityDamageAmp += unit.gravesTankDamageAmp;
                 }
                 // 저격수 (Sniper) — 거리 기반 추가 damage amp (per target)
                 abilityDamageAmp += computeSniperDamageAmp(unit, t);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -530,6 +530,18 @@ export interface CombatUnit {
    */
   gravesAbilityDamageBonus: number;
   /**
+   * 최신상 (TFT17_GravesTrait) 무기고 stat upgrade 활성 ID 목록.
+   * 가장 강한 그레이브즈 1명에게만 채워지며 빈 배열 = 미적용.
+   * 예: ['LeechingImplants', 'HeavyPlating', 'PrecisionScope2'].
+   * upgrade 적용 후 stat (damage / range / armor / etc.) 는 직접 누적.
+   */
+  gravesUpgrades: string[];
+  /**
+   * Tankbuster (탱커 파괴자) 업그레이드 활성 시 target.role==='Tank' 한정 추가 damage amp.
+   * 0 = 미활성 (기본). inventionTankDamageAmp 와 별도로 합산.
+   */
+  gravesTankDamageAmp: number;
+  /**
    * 자폭(TFT17_Augment_GragasCarry) 활성 + 가장 강한 그라가스로 선정된 unit 만 true.
    * 그라가스 ability 가 거대한 폭발 (자기 자신 데미지, 다른 아군 X) 로 변환되며,
    * 자폭 데미지로 hp 가 1 미만으로 떨어지지 않음 (HP floor=1).

--- a/tests/unit/simulator/graves-stat-upgrades.test.ts
+++ b/tests/unit/simulator/graves-stat-upgrades.test.ts
@@ -1,0 +1,235 @@
+/**
+ * 회귀 가드 — 최신상 (TFT17_GravesTrait) 무기고 stat upgrade 18종 (Phase 2).
+ *
+ * raw items (TFT17_GravesTrait_Offense_*) 직접 stat 가산 검증.
+ * 가장 강한 그레이브즈 1명에 적용 (Frame 과 동일 selector).
+ * Phase 3 메커닉 (RevUp / Buckshot / GravBooster 등) 은 후속 PR — 본 가드는 18종만.
+ *
+ * 18종 매핑 (effects raw):
+ *   LeechingImplants    AD 0.10 / Omnivamp 0.10
+ *   LeechingImplants2   AD 0.20 / Omnivamp 0.15
+ *   HeavyPlating        BaseHealth 300 / Armor 20 / MR 20
+ *   PrecisionScope      AD 0.12 / Range +1
+ *   PrecisionScope2/3   AD 0.24/0.36 / Range +2/+3
+ *   Fission/2/3         AD 0.10/0.20/0.30 / ManaRegen +2/+3/+5
+ *   Heartseeker/2/3     CritChance 0.10/0.25/0.40 / CritDmg 0.05/0.10/0.18
+ *   Tankbuster          탱커 상대 +0.15 damage amp
+ *   Coolant/2           ManaReduction -10/-20 (maxMana 차감)
+ *   APRounds/2          ArmorPen +0.30/+0.60
+ *   SheerMass           MaxHp × 1.25
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import { STAR_SCALING } from '@/types';
+import type { PlacedChampion, RawChampion, RawItem } from '@/types';
+
+const { champions, traits, items } = loadServerCatalogs();
+const apGraves = champions.find(c => c.apiName === 'TFT17_Graves')!;
+const apTwistedFate = champions.find(c => c.apiName === 'TFT17_TwistedFate')!;
+const dummyEnemy = champions.find(c => c.apiName === 'TFT17_Aatrox')!;
+const someItem = items.find(i => i.apiName?.startsWith('TFT_Item_'))!;
+
+function placed(c: RawChampion, q: number, r: number, starLevel: number = 2, eqItems: RawItem[] = []): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: eqItems };
+}
+
+function gravesBaseAd(): number {
+  // simulateCombat 의 baseAd 식과 동일 — champion.stats.damage × STAR_SCALING[2]
+  return apGraves.stats.damage * (STAR_SCALING[2] || 1);
+}
+
+function runWith(upgrades: string[]) {
+  const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+  const enemy = [placed(dummyEnemy, 6, 3)];
+  const withUpg = simulateCombat(team, enemy, {
+    seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    playerGravesUpgrades: upgrades,
+  });
+  const baseline = simulateCombat(team, enemy, {
+    seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+  });
+  return {
+    grav: withUpg.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!,
+    base: baseline.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!,
+  };
+}
+
+describe('GravesTrait stat upgrades — 단순 stat 18종 적용', () => {
+  it('LeechingImplants → AD +10%(base), omnivamp +0.10', () => {
+    const { grav, base } = runWith(['LeechingImplants']);
+    expect(grav.gravesUpgrades).toContain('LeechingImplants');
+    expect(grav.stats.damage - base.stats.damage).toBeCloseTo(gravesBaseAd() * 0.10, 1);
+    expect(grav.omnivamp - base.omnivamp).toBeCloseTo(0.10, 2);
+  });
+
+  it('LeechingImplants2 → AD +20%(base), omnivamp +0.15', () => {
+    const { grav, base } = runWith(['LeechingImplants2']);
+    expect(grav.stats.damage - base.stats.damage).toBeCloseTo(gravesBaseAd() * 0.20, 1);
+    expect(grav.omnivamp - base.omnivamp).toBeCloseTo(0.15, 2);
+  });
+
+  it('HeavyPlating → maxHp +300, armor +20, mr +20', () => {
+    const { grav, base } = runWith(['HeavyPlating']);
+    expect(grav.maxHp - base.maxHp).toBeCloseTo(300, 0);
+    expect(grav.stats.armor - base.stats.armor).toBeCloseTo(20, 1);
+    expect(grav.stats.magicResist - base.stats.magicResist).toBeCloseTo(20, 1);
+  });
+
+  it('PrecisionScope → AD +12%, range +1', () => {
+    const { grav, base } = runWith(['PrecisionScope']);
+    expect(grav.stats.damage - base.stats.damage).toBeCloseTo(gravesBaseAd() * 0.12, 1);
+    expect(grav.stats.range - base.stats.range).toBe(1);
+  });
+
+  it('PrecisionScope2 → AD +24%, range +2', () => {
+    const { grav, base } = runWith(['PrecisionScope2']);
+    expect(grav.stats.damage - base.stats.damage).toBeCloseTo(gravesBaseAd() * 0.24, 1);
+    expect(grav.stats.range - base.stats.range).toBe(2);
+  });
+
+  it('PrecisionScope3 → AD +36%, range +3', () => {
+    const { grav, base } = runWith(['PrecisionScope3']);
+    expect(grav.stats.damage - base.stats.damage).toBeCloseTo(gravesBaseAd() * 0.36, 1);
+    expect(grav.stats.range - base.stats.range).toBe(3);
+  });
+
+  it('Fission → AD +10%, manaRegen +2', () => {
+    const { grav, base } = runWith(['Fission']);
+    expect(grav.stats.damage - base.stats.damage).toBeCloseTo(gravesBaseAd() * 0.10, 1);
+    expect(grav.augmentManaRegen - base.augmentManaRegen).toBeCloseTo(2, 2);
+  });
+
+  it('Fission3 → AD +30%, manaRegen +5', () => {
+    const { grav, base } = runWith(['Fission3']);
+    expect(grav.stats.damage - base.stats.damage).toBeCloseTo(gravesBaseAd() * 0.30, 1);
+    expect(grav.augmentManaRegen - base.augmentManaRegen).toBeCloseTo(5, 2);
+  });
+
+  it('Heartseeker → critChance +0.10, critMultiplier +0.05', () => {
+    const { grav, base } = runWith(['Heartseeker']);
+    expect(grav.stats.critChance - base.stats.critChance).toBeCloseTo(0.10, 3);
+    expect(grav.stats.critMultiplier - base.stats.critMultiplier).toBeCloseTo(0.05, 3);
+  });
+
+  it('Heartseeker3 → critChance +0.40, critMultiplier +0.18', () => {
+    const { grav, base } = runWith(['Heartseeker3']);
+    expect(grav.stats.critChance - base.stats.critChance).toBeCloseTo(0.40, 3);
+    expect(grav.stats.critMultiplier - base.stats.critMultiplier).toBeCloseTo(0.18, 3);
+  });
+
+  it('Tankbuster → gravesTankDamageAmp += 0.15', () => {
+    const { grav, base } = runWith(['Tankbuster']);
+    expect(grav.gravesTankDamageAmp - base.gravesTankDamageAmp).toBeCloseTo(0.15, 3);
+  });
+
+  it('Coolant → maxMana -10', () => {
+    const { grav, base } = runWith(['Coolant']);
+    expect(base.maxMana - grav.maxMana).toBeCloseTo(10, 0);
+  });
+
+  it('Coolant2 → maxMana -20', () => {
+    const { grav, base } = runWith(['Coolant2']);
+    expect(base.maxMana - grav.maxMana).toBeCloseTo(20, 0);
+  });
+
+  it('APRounds → armorPen +0.30', () => {
+    const { grav, base } = runWith(['APRounds']);
+    expect(grav.stats.armorPen - base.stats.armorPen).toBeCloseTo(0.30, 3);
+  });
+
+  it('APRounds2 → armorPen +0.60', () => {
+    const { grav, base } = runWith(['APRounds2']);
+    expect(grav.stats.armorPen - base.stats.armorPen).toBeCloseTo(0.60, 3);
+  });
+
+  it('SheerMass → maxHp × 1.25', () => {
+    const { grav, base } = runWith(['SheerMass']);
+    expect(grav.maxHp).toBeCloseTo(Math.round(base.maxHp * 1.25), 0);
+  });
+
+  it('복수 upgrade 동시 적용 → 효과 누적 (Heartseeker + APRounds + Tankbuster)', () => {
+    const { grav, base } = runWith(['Heartseeker', 'APRounds', 'Tankbuster']);
+    expect(grav.gravesUpgrades).toEqual(['Heartseeker', 'APRounds', 'Tankbuster']);
+    expect(grav.stats.critChance - base.stats.critChance).toBeCloseTo(0.10, 3);
+    expect(grav.stats.armorPen - base.stats.armorPen).toBeCloseTo(0.30, 3);
+    expect(grav.gravesTankDamageAmp).toBeCloseTo(0.15, 3);
+  });
+
+  it('Frame + upgrade 동시 → 양쪽 동일 unit 에 누적', () => {
+    const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerGravesFrame: 'CloseQuarters',
+      playerGravesUpgrades: ['HeavyPlating'],
+    });
+    const grav = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!;
+    expect(grav.gravesFrame).toBe('CloseQuarters');
+    expect(grav.gravesUpgrades).toContain('HeavyPlating');
+    // CloseQuarters HP +250 + HeavyPlating HP +300 가산 → maxHp >= base + 550
+    expect(grav.stats.armor).toBeGreaterThan(0);
+  });
+
+  it('빈 옵션 / 옵션 미지정 → upgrade 미적용 (default)', () => {
+    const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const grav = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!;
+    expect(grav.gravesUpgrades).toEqual([]);
+    expect(grav.gravesTankDamageAmp).toBe(0);
+  });
+
+  it('미지원 upgrade ID (Phase 3 RevUp 등) → silently skip', () => {
+    const { grav } = runWith(['RevUp', 'Buckshot', 'Heartseeker']);
+    // 지원 항목만 적용
+    expect(grav.gravesUpgrades).toEqual(['Heartseeker']);
+  });
+
+  it('비-Graves unit → upgrade 미적용', () => {
+    const team: PlacedChampion[] = [placed(apTwistedFate, 0, 0)];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerGravesUpgrades: ['HeavyPlating'],
+    });
+    const tf = result.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    expect(tf.gravesUpgrades).toEqual([]);
+  });
+
+  it('가장 강한 1명에만 적용 — 3성 / 2성 두 명 시 3성 만', () => {
+    const team: PlacedChampion[] = [
+      placed(apGraves, 0, 0, 2),
+      placed(apGraves, 1, 0, 3),
+    ];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerGravesUpgrades: ['Heartseeker3'],
+    });
+    const gravs = result.playerUnits.filter(u => u.champion.apiName === 'TFT17_Graves');
+    const star3 = gravs.find(u => u.starLevel === 3)!;
+    const star2 = gravs.find(u => u.starLevel === 2)!;
+    expect(star3.gravesUpgrades).toContain('Heartseeker3');
+    expect(star2.gravesUpgrades).toEqual([]);
+  });
+
+  it('동급 시 아이템 보유 unit 우선 (Frame selector 와 동일)', () => {
+    const team: PlacedChampion[] = [
+      placed(apGraves, 0, 0, 2, []),
+      placed(apGraves, 1, 0, 2, [someItem]),
+    ];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerGravesUpgrades: ['APRounds'],
+    });
+    const gravs = result.playerUnits.filter(u => u.champion.apiName === 'TFT17_Graves');
+    const withItems = gravs.find(u => u.items.length > 0)!;
+    const noItems = gravs.find(u => u.items.length === 0)!;
+    expect(withItems.gravesUpgrades).toContain('APRounds');
+    expect(noItems.gravesUpgrades).toEqual([]);
+  });
+});

--- a/tests/unit/simulator/graves-stat-upgrades.test.ts
+++ b/tests/unit/simulator/graves-stat-upgrades.test.ts
@@ -150,10 +150,24 @@ describe('GravesTrait stat upgrades — 단순 stat 18종 적용', () => {
 
   it('복수 upgrade 동시 적용 → 효과 누적 (Heartseeker + APRounds + Tankbuster)', () => {
     const { grav, base } = runWith(['Heartseeker', 'APRounds', 'Tankbuster']);
-    expect(grav.gravesUpgrades).toEqual(['Heartseeker', 'APRounds', 'Tankbuster']);
+    // canonical order: APRounds → Heartseeker → Tankbuster (deterministic, input 순서 무관)
+    expect(grav.gravesUpgrades).toEqual(['APRounds', 'Heartseeker', 'Tankbuster']);
     expect(grav.stats.critChance - base.stats.critChance).toBeCloseTo(0.10, 3);
     expect(grav.stats.armorPen - base.stats.armorPen).toBeCloseTo(0.30, 3);
     expect(grav.gravesTankDamageAmp).toBeCloseTo(0.15, 3);
+  });
+
+  it('canonical apply order — 입력 배열 순서가 달라도 동일 결과 (deterministic)', () => {
+    // SheerMass × maxHp / HeavyPlating + maxHp 는 적용 순서에 따라 결과 다름.
+    // canonical: HeavyPlating(flat HP +300) → SheerMass(× 1.25) 가 정답.
+    const set1 = runWith(['HeavyPlating', 'SheerMass']);
+    const set2 = runWith(['SheerMass', 'HeavyPlating']); // 입력 순서 뒤집어도 동일해야 함
+    expect(set1.grav.maxHp).toBe(set2.grav.maxHp);
+    expect(set1.grav.gravesUpgrades).toEqual(set2.grav.gravesUpgrades);
+    // canonical order: HeavyPlating(flat) 먼저 → SheerMass(×) 나중
+    expect(set1.grav.gravesUpgrades).toEqual(['HeavyPlating', 'SheerMass']);
+    // 결과: (base + 300) × 1.25
+    expect(set1.grav.maxHp).toBeCloseTo(Math.round((set1.base.maxHp + 300) * 1.25), 0);
   });
 
   it('Frame + upgrade 동시 → 양쪽 동일 unit 에 누적', () => {


### PR DESCRIPTION
## Summary
- Phase 1 (Frame 3종, PR #45) 후속 — 무기고 단순 stat upgrade 18종 구현
- 가장 강한 그레이브즈 1명에게 Frame 과 동일 selector 로 누적 적용
- 23-case 회귀 가드 추가

## Mapping (raw effects → CombatUnit stat)
| Upgrade | 효과 |
|---|---|
| LeechingImplants/2 | AD +10/20%, omnivamp +0.10/0.15 |
| HeavyPlating | HP +300, armor +20, MR +20 |
| PrecisionScope/2/3 | AD +12/24/36%, range +1/2/3 |
| Fission/2/3 | AD +10/20/30%, manaRegen +2/3/5 |
| Heartseeker/2/3 | critChance +0.10/0.25/0.40, critDmg +0.05/0.10/0.18 |
| Tankbuster | 탱커 상대 +0.15 damage amp (전용 필드) |
| Coolant/2 | maxMana -10/-20 |
| APRounds/2 | armorPen +0.30/0.60 |
| SheerMass | maxHp × 1.25 |

## 신규 필드 (CombatUnit)
- `gravesUpgrades: string[]` — 활성 upgrade ID 추적
- `gravesTankDamageAmp: number` — Tankbuster 전용 (inventionTankDamageAmp 와 별도 합산)

## 통합 사이트
- `applyGravesStatUpgrades()` — `applyGravesFrameEffects()` 직후 호출
- damage 적용 2개 사이트 (basic attack / ability) 에 Tankbuster amp 합산

## Phase 3 잔여 (후속 PR)
RevUp/2, Buckshot/2/3, GravBooster/2, ReactiveArmor, LatentExplosion, Shockwave,
EmergencyShielding/2, BlastRadius/2/3, FragmentationRounds/2, AimAssistant,
Meltthrough, VoidCoefficient, DoubleTap2, TripleTap, RipperBullets/2,
Nanomachines, LaserBallistics/1-3, Choke, SympatheticDetonation 등 — 메커닉 필요

## Test plan
- [x] `pnpm vitest run tests/unit/simulator/graves-stat-upgrades.test.ts` (23/23 pass)
- [x] `pnpm vitest run` 전체 회귀 (463/463 pass)
- [x] `pnpm lint` (0 errors, 기존 warning 만 잔존)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)