### PR TITLE
feat(data): G2 Phase 4A — 그레이브즈 무기고 트리 데이터 + getNextOptions

### DIFF
--- a/src/data/factoryNewTree.ts
+++ b/src/data/factoryNewTree.ts
@@ -1,0 +1,629 @@
+/**
+ * 그레이브즈 최신상(GravesTrait) 무기고 트리 — 51 노드.
+ *
+ * 출처: lolchess.gg/rewards/set17/factory-new + 사용자 인게임 검수.
+ * 구조 문서: docs/meta/set17-graves-factory-tree.md
+ *
+ * 알고리즘 (시뮬레이터 — 인게임과 다르게 모든 옵션 표시):
+ *   Round 1: 3 root frames (고정)
+ *   Round 2: 선택 root 의 직속 children 모두 (맹공 4 / 위력 5 / 사수 4)
+ *   Round 3+: 마지막 pick 의 children + 이전 picks 의 children 중 아직 선택 안 된 것 모두
+ *
+ * Multi-parent 노드:
+ *   - 초크 (Choke) — 3 parent: LeechingImplants2 / Buckshot / APRounds
+ */
+
+export type FactoryFrame = 'CloseQuarters' | 'SharpshooterModule' | 'DoubleTap';
+
+export interface FactoryNode {
+  /** apiName 접미사 (TFT17_GravesTrait_Offense_<suffix>) */
+  suffix: string;
+  /** 한글 이름 */
+  name: string;
+  /** raw effects 의 cost — 0/2/3/5/6 */
+  cost: 0 | 2 | 3 | 5 | 6;
+  /** 속한 frame path. multi-parent 노드 (초크) 는 첫 도달 path 기준 — 표시는 frames 배열로 */
+  frame: FactoryFrame;
+  /** 본 노드가 속할 수 있는 모든 frame (multi-parent 시 2 이상) */
+  frames: FactoryFrame[];
+  /** 직속 parent 노드 suffix 목록 (root 는 빈 배열). multi-parent 시 2 이상. */
+  parents: string[];
+  /** 직속 child 노드 suffix 목록 */
+  children: string[];
+}
+
+export const FRAME_ROOTS: ReadonlyArray<FactoryFrame> = [
+  'CloseQuarters',
+  'SharpshooterModule',
+  'DoubleTap',
+];
+
+/**
+ * 51 노드 트리. parents/children 양쪽 정의 (편의를 위해 redundancy 허용).
+ *
+ * Frame 정의:
+ *   맹공 (CloseQuarters): 19 노드
+ *   위력 (SharpshooterModule): 19 노드
+ *   사수 (DoubleTap): 13 노드
+ */
+export const FACTORY_NEW_TREE: Record<string, FactoryNode> = {
+  // ============================================================
+  // 🟦 맹공 프레임 (CloseQuarters) — 19 노드
+  // ============================================================
+  CloseQuarters: {
+    suffix: 'CloseQuarters',
+    name: '맹공 프레임',
+    cost: 0,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: [],
+    children: ['LeechingImplants', 'Buckshot', 'Meltthrough', 'EmergencyShielding'],
+  },
+
+  // 흡수 임플란트 line
+  LeechingImplants: {
+    suffix: 'LeechingImplants',
+    name: '흡수 임플란트',
+    cost: 0,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['CloseQuarters'],
+    children: ['LeechingImplants2'],
+  },
+  LeechingImplants2: {
+    suffix: 'LeechingImplants2',
+    name: '흡수 임플란트+',
+    cost: 2,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['LeechingImplants'],
+    children: ['Choke'],
+  },
+
+  // 산탄 사격 line + Choke (multi-parent)
+  Buckshot: {
+    suffix: 'Buckshot',
+    name: '산탄 사격',
+    cost: 2,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['CloseQuarters'],
+    children: ['Buckshot2', 'Choke'],
+  },
+  Buckshot2: {
+    suffix: 'Buckshot2',
+    name: '산탄 사격+',
+    cost: 3,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['Buckshot'],
+    children: ['Buckshot3'],
+  },
+  Buckshot3: {
+    suffix: 'Buckshot3',
+    name: '산탄 사격++',
+    cost: 3,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['Buckshot2'],
+    children: ['LaserBallistics'],
+  },
+  LaserBallistics: {
+    suffix: 'LaserBallistics',
+    name: '레이저 탄도학',
+    cost: 6,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['Buckshot3'],
+    children: [],
+  },
+
+  // 용융 관통 line
+  Meltthrough: {
+    suffix: 'Meltthrough',
+    name: '용융 관통',
+    cost: 2,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['CloseQuarters'],
+    children: ['GravBooster'],
+  },
+  GravBooster: {
+    suffix: 'GravBooster',
+    name: '중력 증폭기',
+    cost: 3,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['Meltthrough'],
+    children: ['GravBooster2'],
+  },
+  GravBooster2: {
+    suffix: 'GravBooster2',
+    name: '중력 증폭기+',
+    cost: 6,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['GravBooster'],
+    children: [],
+  },
+
+  // 긴급 보호막 line + 두꺼운 장갑판 sub-tree
+  EmergencyShielding: {
+    suffix: 'EmergencyShielding',
+    name: '긴급 보호막',
+    cost: 0,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['CloseQuarters'],
+    children: ['EmergencyShielding2', 'HeavyPlating'],
+  },
+  EmergencyShielding2: {
+    suffix: 'EmergencyShielding2',
+    name: '긴급 보호막+',
+    cost: 2,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['EmergencyShielding'],
+    children: [],
+  },
+  HeavyPlating: {
+    suffix: 'HeavyPlating',
+    name: '두꺼운 장갑판',
+    cost: 3,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['EmergencyShielding'],
+    children: ['Shockwave', 'SheerMass', 'ReactiveArmor'],
+  },
+  Shockwave: {
+    suffix: 'Shockwave',
+    name: '충격파',
+    cost: 6,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['HeavyPlating'],
+    children: [],
+  },
+  SheerMass: {
+    suffix: 'SheerMass',
+    name: '순수 질량',
+    cost: 5,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['HeavyPlating'],
+    children: ['Nanomachines'],
+  },
+  Nanomachines: {
+    suffix: 'Nanomachines',
+    name: '나노머신',
+    cost: 6,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['SheerMass'],
+    children: [],
+  },
+  ReactiveArmor: {
+    suffix: 'ReactiveArmor',
+    name: '반응형 방어구',
+    cost: 6,
+    frame: 'CloseQuarters',
+    frames: ['CloseQuarters'],
+    parents: ['HeavyPlating'],
+    children: [],
+  },
+
+  // ============================================================
+  // 🟥 위력 프레임 (SharpshooterModule) — 19 노드
+  // 직속 children 5개 (인게임은 4 random, 시뮬은 5 다 표시)
+  // ============================================================
+  SharpshooterModule: {
+    suffix: 'SharpshooterModule',
+    name: '위력 프레임',
+    cost: 0,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: [],
+    children: ['BlastRadius', 'Heartseeker', 'Tankbuster', 'Coolant', 'Fission'],
+  },
+
+  // 폭발 반경 sub-tree
+  BlastRadius: {
+    suffix: 'BlastRadius',
+    name: '폭발 반경',
+    cost: 2,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['SharpshooterModule'],
+    children: ['BlastRadius2', 'SympatheticDetonation'],
+  },
+  BlastRadius2: {
+    suffix: 'BlastRadius2',
+    name: '폭발 반경+',
+    cost: 3,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['BlastRadius'],
+    children: ['BlastRadius3'],
+  },
+  BlastRadius3: {
+    suffix: 'BlastRadius3',
+    name: '폭발 반경++',
+    cost: 6,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['BlastRadius2'],
+    children: [],
+  },
+  SympatheticDetonation: {
+    suffix: 'SympatheticDetonation',
+    name: '공감성 폭발',
+    cost: 6,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['BlastRadius'],
+    children: [],
+  },
+
+  // 심장추적자 line
+  Heartseeker: {
+    suffix: 'Heartseeker',
+    name: '심장추적자',
+    cost: 2,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['SharpshooterModule'],
+    children: ['Heartseeker2'],
+  },
+  Heartseeker2: {
+    suffix: 'Heartseeker2',
+    name: '심장추적자+',
+    cost: 3,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['Heartseeker'],
+    children: ['Heartseeker3'],
+  },
+  Heartseeker3: {
+    suffix: 'Heartseeker3',
+    name: '심장추적자++',
+    cost: 6,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['Heartseeker2'],
+    children: [],
+  },
+
+  // 탱커 파괴자 sub-tree (Choke multi-parent)
+  Tankbuster: {
+    suffix: 'Tankbuster',
+    name: '탱커 파괴자',
+    cost: 0,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['SharpshooterModule'],
+    children: ['LatentExplosion', 'APRounds'],
+  },
+  LatentExplosion: {
+    suffix: 'LatentExplosion',
+    name: '지연 폭발',
+    cost: 3,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['Tankbuster'],
+    children: [],
+  },
+  APRounds: {
+    suffix: 'APRounds',
+    name: '철갑탄',
+    cost: 3,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['Tankbuster'],
+    children: ['APRounds2', 'Choke'],
+  },
+  APRounds2: {
+    suffix: 'APRounds2',
+    name: '철갑탄+',
+    cost: 6,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['APRounds'],
+    children: [],
+  },
+
+  // 초크 — multi-parent (3 parents: LeechingImplants2 / Buckshot / APRounds)
+  Choke: {
+    suffix: 'Choke',
+    name: '초크',
+    cost: 5,
+    frame: 'CloseQuarters', // 가장 먼저 도달 path 기준
+    frames: ['CloseQuarters', 'SharpshooterModule'],
+    parents: ['LeechingImplants2', 'Buckshot', 'APRounds'],
+    children: [],
+  },
+
+  // 냉각수 line
+  Coolant: {
+    suffix: 'Coolant',
+    name: '냉각수',
+    cost: 2,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['SharpshooterModule'],
+    children: ['Coolant2'],
+  },
+  Coolant2: {
+    suffix: 'Coolant2',
+    name: '냉각수+',
+    cost: 3,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['Coolant'],
+    children: ['VoidCoefficient'],
+  },
+  VoidCoefficient: {
+    suffix: 'VoidCoefficient',
+    name: '공허 계수',
+    cost: 6,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['Coolant2'],
+    children: [],
+  },
+
+  // 분열 line
+  Fission: {
+    suffix: 'Fission',
+    name: '분열',
+    cost: 0,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['SharpshooterModule'],
+    children: ['Fission2'],
+  },
+  Fission2: {
+    suffix: 'Fission2',
+    name: '분열+',
+    cost: 3,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['Fission'],
+    children: ['Fission3'],
+  },
+  Fission3: {
+    suffix: 'Fission3',
+    name: '분열++',
+    cost: 6,
+    frame: 'SharpshooterModule',
+    frames: ['SharpshooterModule'],
+    parents: ['Fission2'],
+    children: [],
+  },
+
+  // ============================================================
+  // 🟨 사수 프레임 (DoubleTap) — 13 노드
+  // 직속 children 4개
+  // ============================================================
+  DoubleTap: {
+    suffix: 'DoubleTap',
+    name: '사수 프레임',
+    cost: 0,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: [],
+    children: ['PrecisionScope', 'DoubleTap2', 'RipperBullets', 'FragmentationRounds'],
+  },
+
+  // 정밀 조준경 line + 조준 보정 sibling
+  PrecisionScope: {
+    suffix: 'PrecisionScope',
+    name: '정밀 조준경',
+    cost: 0,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['DoubleTap'],
+    children: ['PrecisionScope2', 'AimAssistant'],
+  },
+  PrecisionScope2: {
+    suffix: 'PrecisionScope2',
+    name: '정밀 조준경+',
+    cost: 2,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['PrecisionScope'],
+    children: ['PrecisionScope3'],
+  },
+  PrecisionScope3: {
+    suffix: 'PrecisionScope3',
+    name: '정밀 조준경++',
+    cost: 5,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['PrecisionScope2'],
+    children: [],
+  },
+  AimAssistant: {
+    suffix: 'AimAssistant',
+    name: '조준 보정',
+    cost: 6,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['PrecisionScope'],
+    children: [],
+  },
+
+  // 한 발에 두 놈 sub-tree (엔진 가동 sibling 변경)
+  DoubleTap2: {
+    suffix: 'DoubleTap2',
+    name: '한 발에 두 놈',
+    cost: 2,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['DoubleTap'],
+    children: ['TripleTap', 'RevUp'],
+  },
+  TripleTap: {
+    suffix: 'TripleTap',
+    name: '한 발에 세 놈',
+    cost: 3,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['DoubleTap2'],
+    children: [],
+  },
+  RevUp: {
+    suffix: 'RevUp',
+    name: '엔진 가동',
+    cost: 3,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['DoubleTap2'],
+    children: ['RevUp2'],
+  },
+  RevUp2: {
+    suffix: 'RevUp2',
+    name: '엔진 가동+',
+    cost: 6,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['RevUp'],
+    children: [],
+  },
+
+  // 파쇄 탄환 line
+  RipperBullets: {
+    suffix: 'RipperBullets',
+    name: '파쇄 탄환',
+    cost: 2,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['DoubleTap'],
+    children: ['RipperBullets2'],
+  },
+  RipperBullets2: {
+    suffix: 'RipperBullets2',
+    name: '파쇄 탄환+',
+    cost: 3,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['RipperBullets'],
+    children: [],
+  },
+
+  // 파편탄 line
+  FragmentationRounds: {
+    suffix: 'FragmentationRounds',
+    name: '파편탄',
+    cost: 2,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['DoubleTap'],
+    children: ['FragmentationRounds2'],
+  },
+  FragmentationRounds2: {
+    suffix: 'FragmentationRounds2',
+    name: '파편탄+',
+    cost: 3,
+    frame: 'DoubleTap',
+    frames: ['DoubleTap'],
+    parents: ['FragmentationRounds'],
+    children: [],
+  },
+};
+
+// ============================================================
+// Helper functions
+// ============================================================
+
+/** 모든 노드의 suffix 목록. */
+export function getAllSuffixes(): string[] {
+  return Object.keys(FACTORY_NEW_TREE);
+}
+
+/** Root 인지 검사. */
+export function isRoot(suffix: string): boolean {
+  return (FRAME_ROOTS as readonly string[]).includes(suffix);
+}
+
+/** raw apiName ('TFT17_GravesTrait_Offense_<suffix>') 으로 변환. */
+export function suffixToApiName(suffix: string): string {
+  return `TFT17_GravesTrait_Offense_${suffix}`;
+}
+
+/** apiName 에서 suffix 추출 (TFT17_GravesTrait_Offense_<suffix> 가 아니면 null). */
+export function apiNameToSuffix(apiName: string): string | null {
+  const match = apiName.match(/^TFT17_GravesTrait_Offense_(.+)$/);
+  return match ? match[1] : null;
+}
+
+/**
+ * picks history 기반 다음 라운드 옵션 생성.
+ *
+ * 알고리즘 (시뮬레이터 — 인게임 4 카드 제한 없이 모든 옵션 표시):
+ *   - Round 1 (picks=[]): 3 root frames
+ *   - Round 2 (picks.length=1): 선택 root 의 children 모두 (맹공 4 / 위력 5 / 사수 4)
+ *   - Round 3+ (picks.length>=2): 마지막 pick 의 children +
+ *       이전 picks 의 children 중 아직 선택 안 된 것 모두
+ *
+ * 이미 선택한 노드 (picks 안에 있는) 는 옵션에서 제외.
+ * Multi-parent 노드 (Choke) 는 어떤 parent 를 거쳐도 1번만 등장 (Set dedup).
+ *
+ * @returns suffix 배열 (정렬: tree 정의 순서 — deterministic)
+ */
+export function getNextOptions(picks: ReadonlyArray<string>): string[] {
+  if (picks.length === 0) {
+    return [...FRAME_ROOTS];
+  }
+
+  const pickSet = new Set(picks);
+  const optionSet = new Set<string>();
+
+  // 마지막 pick 의 children
+  const lastPick = picks[picks.length - 1];
+  const lastNode = FACTORY_NEW_TREE[lastPick];
+  if (lastNode) {
+    for (const child of lastNode.children) {
+      if (!pickSet.has(child)) optionSet.add(child);
+    }
+  }
+
+  // Round 3+: 이전 picks 의 children 중 아직 선택 안 된 것
+  if (picks.length >= 2) {
+    for (let i = picks.length - 2; i >= 0; i--) {
+      const node = FACTORY_NEW_TREE[picks[i]];
+      if (!node) continue;
+      for (const child of node.children) {
+        if (!pickSet.has(child)) optionSet.add(child);
+      }
+    }
+  }
+
+  // tree 정의 순서대로 정렬 (deterministic)
+  const allSuffixes = getAllSuffixes();
+  const orderIndex = new Map(allSuffixes.map((s, i) => [s, i]));
+  return [...optionSet].sort(
+    (a, b) => (orderIndex.get(a) ?? 0) - (orderIndex.get(b) ?? 0),
+  );
+}
+
+/**
+ * picks 가 valid 한 트리 path 인지 검사.
+ *
+ * 규칙:
+ *   - 첫 pick 은 root
+ *   - 이후 모든 pick 은 getNextOptions(picks[0..i-1]) 안에 있어야 함
+ *   - 중복 pick 금지
+ */
+export function validatePicks(picks: ReadonlyArray<string>): { valid: boolean; reason?: string } {
+  if (picks.length === 0) return { valid: true };
+  const seen = new Set<string>();
+  for (let i = 0; i < picks.length; i++) {
+    const p = picks[i];
+    if (!FACTORY_NEW_TREE[p]) return { valid: false, reason: `unknown suffix: ${p}` };
+    if (seen.has(p)) return { valid: false, reason: `duplicate pick: ${p}` };
+    seen.add(p);
+    const allowed = getNextOptions(picks.slice(0, i));
+    if (!allowed.includes(p)) return { valid: false, reason: `${p} not in options at round ${i + 1}` };
+  }
+  return { valid: true };
+}

--- a/tests/unit/data/factory-new-tree.test.ts
+++ b/tests/unit/data/factory-new-tree.test.ts
@@ -1,0 +1,302 @@
+/**
+ * 회귀 가드 — 그레이브즈 최신상 무기고 트리 (51 노드).
+ *
+ * 검증 항목:
+ *   1. 51 노드 정의 + 카운트
+ *   2. 3 roots + 직속 children 수 (맹공 4 / 위력 5 / 사수 4)
+ *   3. multi-parent (초크 3 parent)
+ *   4. parents/children 양방향 정합성 (모든 child 의 parents 가 정의 일치)
+ *   5. getNextOptions 시나리오 (Round 1/2/3+, 사용자 예시 트레이스)
+ *   6. validatePicks 검증
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  FACTORY_NEW_TREE,
+  FRAME_ROOTS,
+  getAllSuffixes,
+  isRoot,
+  suffixToApiName,
+  apiNameToSuffix,
+  getNextOptions,
+  validatePicks,
+  type FactoryNode,
+} from '@/data/factoryNewTree';
+
+describe('FactoryNewTree — 51 노드 정의 + 정합성', () => {
+  it('총 49 unique 노드 (lolchess 51 visible 은 Choke 중복 표시)', () => {
+    // Choke 가 multi-parent (3) 라 visual 상 3번 등장 → unique 49.
+    // FrameDefense / FrameSupport / Backup 은 미구현으로 제외.
+    expect(getAllSuffixes()).toHaveLength(49);
+  });
+
+  it('3 root: CloseQuarters / SharpshooterModule / DoubleTap', () => {
+    expect(FRAME_ROOTS).toEqual(['CloseQuarters', 'SharpshooterModule', 'DoubleTap']);
+    for (const root of FRAME_ROOTS) {
+      const node = FACTORY_NEW_TREE[root];
+      expect(node).toBeDefined();
+      expect(node.parents).toEqual([]);
+      expect(isRoot(root)).toBe(true);
+    }
+  });
+
+  it('비-root 모든 노드 → parents 길이 >= 1', () => {
+    for (const [suffix, node] of Object.entries(FACTORY_NEW_TREE)) {
+      if (isRoot(suffix)) continue;
+      expect(node.parents.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('parents/children 양방향 정합성 — 모든 child 의 parents 에 본인 포함', () => {
+    for (const [suffix, node] of Object.entries(FACTORY_NEW_TREE)) {
+      for (const child of node.children) {
+        const childNode = FACTORY_NEW_TREE[child];
+        expect(childNode, `child ${child} of ${suffix} not defined`).toBeDefined();
+        expect(childNode.parents, `${child}.parents missing ${suffix}`).toContain(suffix);
+      }
+      for (const parent of node.parents) {
+        const parentNode = FACTORY_NEW_TREE[parent];
+        expect(parentNode, `parent ${parent} of ${suffix} not defined`).toBeDefined();
+        expect(parentNode.children, `${parent}.children missing ${suffix}`).toContain(suffix);
+      }
+    }
+  });
+
+  it('맹공 프레임 children 4개', () => {
+    expect(FACTORY_NEW_TREE.CloseQuarters.children).toEqual([
+      'LeechingImplants', 'Buckshot', 'Meltthrough', 'EmergencyShielding',
+    ]);
+  });
+
+  it('위력 프레임 children 5개 (인게임 4 random, 시뮬은 5 다)', () => {
+    expect(FACTORY_NEW_TREE.SharpshooterModule.children).toEqual([
+      'BlastRadius', 'Heartseeker', 'Tankbuster', 'Coolant', 'Fission',
+    ]);
+  });
+
+  it('사수 프레임 children 4개', () => {
+    expect(FACTORY_NEW_TREE.DoubleTap.children).toEqual([
+      'PrecisionScope', 'DoubleTap2', 'RipperBullets', 'FragmentationRounds',
+    ]);
+  });
+});
+
+describe('FactoryNewTree — multi-parent (Choke)', () => {
+  it('Choke 가 3 parent (LeechingImplants2 / Buckshot / APRounds)', () => {
+    const choke = FACTORY_NEW_TREE.Choke;
+    expect(choke.parents.sort()).toEqual(['APRounds', 'Buckshot', 'LeechingImplants2'].sort());
+    // 양방향: 3 parent 의 children 에 Choke 포함
+    expect(FACTORY_NEW_TREE.LeechingImplants2.children).toContain('Choke');
+    expect(FACTORY_NEW_TREE.Buckshot.children).toContain('Choke');
+    expect(FACTORY_NEW_TREE.APRounds.children).toContain('Choke');
+  });
+
+  it('Choke frames = [CloseQuarters, SharpshooterModule]', () => {
+    expect(FACTORY_NEW_TREE.Choke.frames.sort()).toEqual(['CloseQuarters', 'SharpshooterModule'].sort());
+  });
+});
+
+describe('FactoryNewTree — 트리 분기 사용자 검수 반영', () => {
+  it('맹공 → 흡수 임플란트+ → 초크', () => {
+    expect(FACTORY_NEW_TREE.LeechingImplants2.children).toEqual(['Choke']);
+  });
+
+  it('맹공 → 산탄 사격 children = [산탄 사격+, 초크]', () => {
+    expect(FACTORY_NEW_TREE.Buckshot.children).toEqual(['Buckshot2', 'Choke']);
+  });
+
+  it('맹공 → 긴급 보호막 children = [긴급 보호막+, 두꺼운 장갑판]', () => {
+    expect(FACTORY_NEW_TREE.EmergencyShielding.children).toEqual([
+      'EmergencyShielding2', 'HeavyPlating',
+    ]);
+  });
+
+  it('맹공 → 두꺼운 장갑판 children = [충격파, 순수 질량, 반응형 방어구]', () => {
+    expect(FACTORY_NEW_TREE.HeavyPlating.children).toEqual([
+      'Shockwave', 'SheerMass', 'ReactiveArmor',
+    ]);
+  });
+
+  it('맹공 → 순수 질량 → 나노머신', () => {
+    expect(FACTORY_NEW_TREE.SheerMass.children).toEqual(['Nanomachines']);
+  });
+
+  it('위력 → 폭발 반경 children = [폭발 반경+, 공감성 폭발]', () => {
+    expect(FACTORY_NEW_TREE.BlastRadius.children).toEqual(['BlastRadius2', 'SympatheticDetonation']);
+  });
+
+  it('위력 → 철갑탄 children = [철갑탄+, 초크]', () => {
+    expect(FACTORY_NEW_TREE.APRounds.children).toEqual(['APRounds2', 'Choke']);
+  });
+
+  it('사수 → 정밀 조준경 children = [정밀 조준경+, 조준 보정]', () => {
+    expect(FACTORY_NEW_TREE.PrecisionScope.children).toEqual(['PrecisionScope2', 'AimAssistant']);
+  });
+
+  it('사수 → 한 발에 두 놈 children = [한 발에 세 놈, 엔진 가동]', () => {
+    expect(FACTORY_NEW_TREE.DoubleTap2.children).toEqual(['TripleTap', 'RevUp']);
+  });
+
+  it('사수 → 엔진 가동 → 엔진 가동+', () => {
+    expect(FACTORY_NEW_TREE.RevUp.children).toEqual(['RevUp2']);
+  });
+});
+
+describe('FactoryNewTree — apiName 변환', () => {
+  it('suffixToApiName / apiNameToSuffix round-trip', () => {
+    for (const suffix of getAllSuffixes()) {
+      const api = suffixToApiName(suffix);
+      expect(api).toBe(`TFT17_GravesTrait_Offense_${suffix}`);
+      expect(apiNameToSuffix(api)).toBe(suffix);
+    }
+  });
+
+  it('apiNameToSuffix — 비-Graves apiName 은 null', () => {
+    expect(apiNameToSuffix('TFT17_Augment_GragasCarry')).toBe(null);
+    expect(apiNameToSuffix('garbage')).toBe(null);
+  });
+});
+
+describe('getNextOptions — Round 1 (picks=[])', () => {
+  it('빈 picks → 3 roots', () => {
+    expect(getNextOptions([])).toEqual(['CloseQuarters', 'SharpshooterModule', 'DoubleTap']);
+  });
+});
+
+describe('getNextOptions — Round 2 (선택 root 의 children)', () => {
+  it('맹공 선택 → 4 children', () => {
+    expect(getNextOptions(['CloseQuarters'])).toEqual([
+      'LeechingImplants', 'Buckshot', 'Meltthrough', 'EmergencyShielding',
+    ]);
+  });
+
+  it('위력 선택 → 5 children (시뮬 5 다 표시)', () => {
+    expect(getNextOptions(['SharpshooterModule'])).toEqual([
+      'BlastRadius', 'Heartseeker', 'Tankbuster', 'Coolant', 'Fission',
+    ]);
+  });
+
+  it('사수 선택 → 4 children', () => {
+    expect(getNextOptions(['DoubleTap'])).toEqual([
+      'PrecisionScope', 'DoubleTap2', 'RipperBullets', 'FragmentationRounds',
+    ]);
+  });
+});
+
+describe('getNextOptions — Round 3+ (마지막 pick children + 이전 sibling pool)', () => {
+  it('맹공 → 긴급 보호막 → options = 긴급보호막.children + (맹공.children − 긴급보호막)', () => {
+    const opts = getNextOptions(['CloseQuarters', 'EmergencyShielding']);
+    // 긴급보호막.children: EmergencyShielding2, HeavyPlating
+    // 맹공.children − 긴급보호막: LeechingImplants, Buckshot, Meltthrough
+    // 합친 5개 (tree 정의 순서대로 정렬)
+    expect(opts.sort()).toEqual([
+      'Buckshot', 'EmergencyShielding2', 'HeavyPlating', 'LeechingImplants', 'Meltthrough',
+    ].sort());
+  });
+
+  it('맹공 → 긴급 보호막 → 두꺼운 장갑판 → 7개 옵션 (사용자 예시)', () => {
+    const opts = getNextOptions(['CloseQuarters', 'EmergencyShielding', 'HeavyPlating']);
+    // 두꺼운장갑판.children: Shockwave, SheerMass, ReactiveArmor
+    // 긴급.children − 두꺼운장갑판: EmergencyShielding2
+    // 맹공.children − 긴급: LeechingImplants, Buckshot, Meltthrough
+    // 합친 7개
+    expect(opts.sort()).toEqual([
+      'Buckshot', 'EmergencyShielding2', 'LeechingImplants', 'Meltthrough',
+      'ReactiveArmor', 'SheerMass', 'Shockwave',
+    ].sort());
+  });
+
+  it('위력 → 탱커 파괴자 → 철갑탄 → 옵션에 multi-parent Choke 포함', () => {
+    const opts = getNextOptions(['SharpshooterModule', 'Tankbuster', 'APRounds']);
+    expect(opts).toContain('Choke');
+    expect(opts).toContain('APRounds2');
+    // 탱커파괴자 sibling: LatentExplosion (지연 폭발)
+    expect(opts).toContain('LatentExplosion');
+  });
+
+  it('multi-parent Choke — 다른 path 로 도달 시도 시 1번만 등장', () => {
+    // 맹공 → 산탄 사격 (Choke 옵션 1) → 산탄 사격+ (Choke sibling 으로 다시 추가 시도)
+    const opts = getNextOptions(['CloseQuarters', 'Buckshot', 'Buckshot2']);
+    const chokeCount = opts.filter(o => o === 'Choke').length;
+    expect(chokeCount).toBe(1);
+  });
+
+  it('이미 선택한 노드는 옵션에서 제외', () => {
+    const opts = getNextOptions(['CloseQuarters', 'EmergencyShielding']);
+    expect(opts).not.toContain('CloseQuarters');
+    expect(opts).not.toContain('EmergencyShielding');
+  });
+
+  it('deterministic — 동일 picks 는 동일 옵션 순서', () => {
+    const a = getNextOptions(['CloseQuarters', 'EmergencyShielding', 'HeavyPlating']);
+    const b = getNextOptions(['CloseQuarters', 'EmergencyShielding', 'HeavyPlating']);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('validatePicks', () => {
+  it('빈 picks → valid', () => {
+    expect(validatePicks([])).toEqual({ valid: true });
+  });
+
+  it('정상 path → valid', () => {
+    expect(validatePicks(['CloseQuarters', 'EmergencyShielding', 'HeavyPlating'])).toEqual({ valid: true });
+  });
+
+  it('첫 pick 이 root 가 아니면 invalid', () => {
+    const r = validatePicks(['LeechingImplants']);
+    expect(r.valid).toBe(false);
+  });
+
+  it('children 이 아닌 노드 선택 시 invalid', () => {
+    // 맹공 → 직접 두꺼운 장갑판 (긴급 보호막 거치지 않음)
+    const r = validatePicks(['CloseQuarters', 'HeavyPlating']);
+    expect(r.valid).toBe(false);
+  });
+
+  it('중복 pick → invalid', () => {
+    const r = validatePicks(['CloseQuarters', 'EmergencyShielding', 'EmergencyShielding']);
+    expect(r.valid).toBe(false);
+  });
+
+  it('정의되지 않은 suffix → invalid', () => {
+    const r = validatePicks(['CloseQuarters', 'NonExistent' as string]);
+    expect(r.valid).toBe(false);
+  });
+
+  it('multi-parent 노드 — 어느 parent 거쳐도 valid', () => {
+    expect(validatePicks(['CloseQuarters', 'LeechingImplants', 'LeechingImplants2', 'Choke']).valid).toBe(true);
+    expect(validatePicks(['CloseQuarters', 'Buckshot', 'Choke']).valid).toBe(true);
+    expect(validatePicks(['SharpshooterModule', 'Tankbuster', 'APRounds', 'Choke']).valid).toBe(true);
+  });
+});
+
+describe('FactoryNewTree — frame 분포 (Choke 가 맹공+위력 양쪽 포함)', () => {
+  it('맹공 frame 18 노드 (17 own + Choke)', () => {
+    const closeQ: FactoryNode[] = Object.values(FACTORY_NEW_TREE).filter(
+      n => n.frames.includes('CloseQuarters'),
+    );
+    expect(closeQ.length).toBe(18);
+  });
+
+  it('위력 frame 19 노드 (18 own + Choke)', () => {
+    const sharp: FactoryNode[] = Object.values(FACTORY_NEW_TREE).filter(
+      n => n.frames.includes('SharpshooterModule'),
+    );
+    expect(sharp.length).toBe(19);
+  });
+
+  it('사수 frame 13 노드', () => {
+    const dt: FactoryNode[] = Object.values(FACTORY_NEW_TREE).filter(
+      n => n.frames.includes('DoubleTap'),
+    );
+    expect(dt.length).toBe(13);
+  });
+
+  it('총합: 18 + 19 + 13 = 50 (Choke 가 2 frame 에 카운트되므로 unique 49 + 1)', () => {
+    const closeQ = Object.values(FACTORY_NEW_TREE).filter(n => n.frames.includes('CloseQuarters')).length;
+    const sharp = Object.values(FACTORY_NEW_TREE).filter(n => n.frames.includes('SharpshooterModule')).length;
+    const dt = Object.values(FACTORY_NEW_TREE).filter(n => n.frames.includes('DoubleTap')).length;
+    expect(closeQ + sharp + dt).toBe(50);
+    expect(getAllSuffixes()).toHaveLength(49);
+  });
+});


### PR DESCRIPTION
## Summary
G2 Phase 4 (그레이브즈 무기고 모달) 의 첫 단계 — 트리 데이터 구조 + 라운드별 옵션 생성 알고리즘 + 회귀 가드.

## 변경

### `src/data/factoryNewTree.ts` (신규, 502 lines)
49 unique 노드 트리:

| Frame | own 노드 | + Choke | 합계 |
|---|---|---|---|
| 맹공 (CloseQuarters) | 17 | ✓ | 18 |
| 위력 (SharpshooterModule) | 18 | ✓ | 19 |
| 사수 (DoubleTap) | 13 |  | 13 |
| **unique** |  |  | **49** |

**사용자 검수 트리 반영**:
- 맹공 → 흡수 임플란트+ → 초크 (multi-parent path 1)
- 맹공 → 산탄 사격 → 초크 (multi-parent path 2)
- 위력 → 철갑탄 → 초크 (multi-parent path 3)
- 맹공 → 두꺼운 장갑판 → [충격파, 순수 질량, 반응형 방어구]
- 위력 → 폭발 반경 → [폭발 반경+, 공감성 폭발]
- 사수 → 정밀 조준경 → [정밀 조준경+, 조준 보정]
- 사수 → 한 발에 두 놈 → [한 발에 세 놈, 엔진 가동]

### `getNextOptions(picks)` 알고리즘 (시뮬 — 인게임 4 카드 제한 없음)
- **Round 1** (picks=[]): 3 root frames
- **Round 2** (picks.length=1): 선택 root 의 children 모두 (맹공 4 / 위력 5 / 사수 4)
- **Round 3+** (picks.length>=2): 마지막 pick 의 children + 이전 picks 의 children 중 아직 선택 안 된 것 모두
- multi-parent Choke 는 Set dedup
- tree 정의 순서대로 deterministic 정렬

### `validatePicks(picks)` 검증
- 첫 pick 은 root
- 이후 모든 pick 은 \`getNextOptions(picks[0..i-1])\` 안에 있어야 함
- 중복 pick / 정의되지 않은 suffix 거부

### Helper API
- \`getAllSuffixes()\` — 49 unique suffix 목록
- \`isRoot(suffix)\`
- \`suffixToApiName\` / \`apiNameToSuffix\` round-trip

## 회귀 가드 (42 cases)

\`tests/unit/data/factory-new-tree.test.ts\`:
1. 49 노드 정의 + 3 roots + parents/children 양방향 정합성
2. 사용자 검수 분기 10건 (맹공/위력/사수 path)
3. multi-parent Choke (3 parents, 2 frames)
4. apiName round-trip 49 + invalid 케이스
5. getNextOptions Round 1/2/3+ 시나리오
6. **사용자 예시 트레이스**: 맹공 → 긴급 보호막 → 두꺼운 장갑판 → 7개 옵션 검증
7. multi-parent Choke 옵션 1번만 등장 (Set dedup)
8. validatePicks 7 케이스 (root / non-root / 중복 / multi-parent)
9. frame 분포 카운트

## 후속 PR

| PR | 범위 |
|---|---|
| **#B** | \`GravesWeaponModal\` 컴포넌트 + Storybook-like 단독 검증 페이지 |
| **#C** | /simulator 통합 — 자동 open + UnitDetailPanel 수정 + teamSlice 연동 |
| **#D** | /actual-data 통합 — sidebar 버튼 + per-game store |

## Test plan
- [x] \`pnpm vitest run tests/unit/data/factory-new-tree.test.ts\`: 42/42 pass
- [x] \`pnpm vitest run\` 전체: 489/489 pass
- [x] \`pnpm lint\`: 0 errors
- [x] \`pnpm typecheck\`: clean
- [x] \`pnpm build\`: success

🤖 Generated with [Claude Code](https://claude.com/claude-code)