### PR TITLE
feat(builder): G2 Phase 4B — GravesWeaponModal 컴포넌트 + 데모 페이지

### DIFF
--- a/src/app/dev/graves-modal/page.tsx
+++ b/src/app/dev/graves-modal/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import GravesWeaponModal from '@/components/builder/GravesWeaponModal';
+import { FACTORY_NEW_TREE } from '@/data/factoryNewTree';
+
+/**
+ * 단독 데모 페이지 — GravesWeaponModal 검증용.
+ * PR #C 통합 전 컴포넌트 동작 sanity check.
+ *
+ * 접근: /dev/graves-modal (production build 시 일반 페이지처럼 노출됨 — 후속 PR
+ * 에서 dev-only 라우팅으로 제한할지 결정).
+ */
+export default function GravesModalDevPage() {
+  const [picks, setPicks] = useState<string[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const pickNames = picks
+    .map((suffix) => FACTORY_NEW_TREE[suffix]?.name ?? suffix)
+    .join(' → ');
+
+  return (
+    <main className="p-8 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-gray-100">
+        GravesWeaponModal 데모
+      </h1>
+      <p className="text-sm text-gray-400 mb-6">
+        그레이브즈 최신상 무기고 모달 단독 검증. picks 가 props 로 전달되어 라운드별
+        옵션이 변하는지, 이전/닫기 동작이 올바른지 테스트.
+      </p>
+
+      <div className="space-y-4">
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => setIsOpen(true)}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded font-medium"
+          >
+            모달 열기
+          </button>
+          <button
+            type="button"
+            onClick={() => setPicks([])}
+            disabled={picks.length === 0}
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            picks 리셋
+          </button>
+        </div>
+
+        <div className="p-4 bg-gray-800 border border-gray-700 rounded">
+          <div className="text-sm text-gray-400 mb-1">현재 상태:</div>
+          <div className="text-gray-100">
+            <span className="text-blue-400">picks.length</span> = {picks.length}
+            <span className="ml-3 text-blue-400">round</span> = {picks.length + 1}
+          </div>
+          {picks.length > 0 && (
+            <div className="mt-2 text-sm text-gray-300">
+              <span className="text-gray-400">trace: </span>
+              {pickNames}
+            </div>
+          )}
+          <details className="mt-3 text-xs text-gray-500">
+            <summary className="cursor-pointer hover:text-gray-300">raw picks JSON</summary>
+            <pre className="mt-2 p-2 bg-gray-900 rounded overflow-auto">
+              {JSON.stringify(picks, null, 2)}
+            </pre>
+          </details>
+        </div>
+
+        <div className="p-4 bg-gray-800/50 border border-gray-700/50 rounded text-xs text-gray-400">
+          <div className="font-semibold mb-1 text-gray-300">동작 검증 시나리오</div>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>모달 열기 → 라운드 1 (3 root frame 표시)</li>
+            <li>맹공 프레임 클릭 → 라운드 2 (4 children 표시)</li>
+            <li>긴급 보호막 클릭 → 라운드 3 (5 옵션: 긴급 보호막+ / 두꺼운 장갑판 + 맹공 sibling 3)</li>
+            <li>두꺼운 장갑판 클릭 → 라운드 4 (7 옵션 — 두꺼운 장갑판 children + sibling pool)</li>
+            <li>이전 버튼 → 한 단계 되돌리기</li>
+            <li>닫기 (× / 외부 클릭) → picks 그대로 유지</li>
+          </ul>
+        </div>
+      </div>
+
+      <GravesWeaponModal
+        isOpen={isOpen}
+        picks={picks}
+        onPicksChange={setPicks}
+        onClose={() => setIsOpen(false)}
+        unitLabel="데모 — 가상 그레이브즈 ★3"
+      />
+    </main>
+  );
+}

--- a/src/components/builder/GravesWeaponModal.tsx
+++ b/src/components/builder/GravesWeaponModal.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Image from 'next/image';
+import { useItems } from '@/hooks/useGameData';
+import { getItemImage } from '@/data/imageMap';
+import {
+  FACTORY_NEW_TREE,
+  getNextOptions,
+  suffixToApiName,
+  apiNameToSuffix,
+  type FactoryNode,
+} from '@/data/factoryNewTree';
+import type { RawItem } from '@/types';
+
+interface GravesWeaponModalProps {
+  isOpen: boolean;
+  picks: string[];
+  onPicksChange: (picks: string[]) => void;
+  onClose: () => void;
+  /** 모달 헤더 라벨 — 어느 그레이브즈 unit 인지 표시 (선택). 예: 'A 팀 ★3' */
+  unitLabel?: string;
+}
+
+/**
+ * 그레이브즈 최신상 무기고 선택 모달.
+ *
+ * 동작:
+ *   - 라운드별 옵션 카드 표시 (Round 1: 3 root / Round 2+: 가변 N개)
+ *   - 카드 클릭 → onPicksChange([...picks, suffix])
+ *   - "이전" 버튼 → onPicksChange(picks.slice(0, -1)) — 한 단계만 되돌리기
+ *   - "닫기" → onClose() (picks 그대로 유지, 호출자가 store 에 저장)
+ *   - 카드 hover → desc tooltip
+ *
+ * 인게임과 다르게 모든 옵션 표시 (라운드 4 카드 제한 없음).
+ */
+export default function GravesWeaponModal({
+  isOpen,
+  picks,
+  onPicksChange,
+  onClose,
+  unitLabel,
+}: GravesWeaponModalProps) {
+  const { items, loading } = useItems();
+  const [hoveredSuffix, setHoveredSuffix] = useState<string | null>(null);
+
+  // suffix → RawItem lookup (icon / desc / effects 표시용)
+  const itemBySuffix = useMemo(() => {
+    const map = new Map<string, RawItem>();
+    for (const item of items) {
+      const suffix = apiNameToSuffix(item.apiName);
+      if (suffix) map.set(suffix, item);
+    }
+    return map;
+  }, [items]);
+
+  if (!isOpen) return null;
+
+  const round = picks.length + 1;
+  const options = getNextOptions(picks);
+  const canGoBack = picks.length > 0;
+
+  function handlePick(suffix: string) {
+    onPicksChange([...picks, suffix]);
+  }
+
+  function handleBack() {
+    if (canGoBack) onPicksChange(picks.slice(0, -1));
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="그레이브즈 무기고 선택"
+    >
+      <div
+        className="bg-gray-900 border border-gray-700 rounded-lg shadow-2xl p-5 max-w-5xl w-[90vw] max-h-[90vh] overflow-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex justify-between items-center mb-4">
+          <div>
+            <h2 className="text-lg font-bold text-gray-100">
+              그레이브즈 무기고 <span className="text-blue-400">— 라운드 {round}</span>
+            </h2>
+            {unitLabel && <div className="text-xs text-gray-400 mt-1">{unitLabel}</div>}
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-200 text-2xl leading-none px-2"
+            aria-label="모달 닫기"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* History strip */}
+        {picks.length > 0 && (
+          <div className="mb-4 flex flex-wrap items-center gap-2 px-3 py-2 bg-gray-800/50 rounded">
+            <span className="text-xs text-gray-400">선택 history:</span>
+            {picks.map((suffix, idx) => {
+              const node = FACTORY_NEW_TREE[suffix];
+              return (
+                <span key={`${suffix}-${idx}`} className="flex items-center gap-1">
+                  {idx > 0 && <span className="text-gray-600">→</span>}
+                  <span className="px-2 py-1 text-xs bg-blue-900/40 border border-blue-700/40 text-blue-200 rounded">
+                    {node?.name ?? suffix}
+                  </span>
+                </span>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Loading state */}
+        {loading && (
+          <div className="text-gray-400 py-8 text-center">아이템 데이터 로드 중...</div>
+        )}
+
+        {/* Options grid */}
+        {!loading && (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 mb-4">
+            {options.map((suffix) => {
+              const node = FACTORY_NEW_TREE[suffix];
+              const item = itemBySuffix.get(suffix);
+              const iconUrl = item ? getItemImage(item.apiName) : null;
+              const desc = item?.desc ?? '';
+              const isHovered = hoveredSuffix === suffix;
+              return (
+                <button
+                  key={suffix}
+                  type="button"
+                  onClick={() => handlePick(suffix)}
+                  onMouseEnter={() => setHoveredSuffix(suffix)}
+                  onMouseLeave={() => setHoveredSuffix(null)}
+                  className={`relative flex flex-col items-center gap-2 p-3 rounded-lg border transition-all
+                    ${isHovered
+                      ? 'bg-gray-700 border-blue-500 scale-[1.03] shadow-lg'
+                      : 'bg-gray-800 border-gray-700 hover:bg-gray-750 hover:border-gray-600'}`}
+                  aria-label={`${node?.name ?? suffix} 선택`}
+                  data-suffix={suffix}
+                >
+                  {iconUrl ? (
+                    <Image
+                      src={iconUrl}
+                      alt={node?.name ?? suffix}
+                      width={56}
+                      height={56}
+                      className="rounded"
+                      unoptimized
+                    />
+                  ) : (
+                    <div className="w-14 h-14 bg-gray-700 rounded" aria-hidden="true" />
+                  )}
+                  <div className="text-sm font-medium text-gray-100 text-center min-h-[2.5em] leading-tight">
+                    {node?.name ?? suffix}
+                  </div>
+                  <div className="flex items-center gap-1 text-xs">
+                    <span className="text-yellow-400">●</span>
+                    <span className="text-gray-300">{node?.cost ?? 0}</span>
+                  </div>
+
+                  {/* hover tooltip */}
+                  {isHovered && desc && (
+                    <div
+                      className="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 p-2 bg-black/95 border border-gray-600 rounded text-xs text-gray-200 shadow-xl pointer-events-none"
+                      role="tooltip"
+                    >
+                      {desc}
+                    </div>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!loading && options.length === 0 && (
+          <div className="py-8 text-center text-gray-400">
+            더 이상 선택 가능한 무기가 없습니다.
+            <div className="mt-2 text-xs">현재 picks: {picks.length}개</div>
+          </div>
+        )}
+
+        {/* Footer — 이전 / 도움말 */}
+        <div className="flex justify-between items-center pt-3 border-t border-gray-700">
+          <button
+            type="button"
+            onClick={handleBack}
+            disabled={!canGoBack}
+            className={`px-3 py-1.5 text-sm rounded border transition-colors
+              ${canGoBack
+                ? 'bg-gray-800 border-gray-600 text-gray-200 hover:bg-gray-700 hover:border-gray-500'
+                : 'bg-gray-800/50 border-gray-700 text-gray-500 cursor-not-allowed'}`}
+            aria-label="이전 라운드로 돌아가기"
+          >
+            ← 이전
+          </button>
+          <div className="text-xs text-gray-500">
+            라운드 {round} · {options.length}개 옵션 · 닫기 시 자동 저장
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Lookup helper — picks 가 변경됐을 때 시뮬에 전달할 raw upgrade ID 배열. */
+export function picksToUpgradeIds(picks: string[]): string[] {
+  // 현재 PR #46 의 simulateCombat 옵션 playerGravesUpgrades 와 동일 — suffix array.
+  return picks.filter((p) => FACTORY_NEW_TREE[p] !== undefined);
+}
+
+/** picks 의 첫 번째 root 가 frame 으로 매핑 — playerGravesFrame 옵션용. */
+export function picksToFrame(
+  picks: string[],
+): 'CloseQuarters' | 'SharpshooterModule' | 'DoubleTap' | undefined {
+  const first = picks[0];
+  if (first === 'CloseQuarters' || first === 'SharpshooterModule' || first === 'DoubleTap') {
+    return first;
+  }
+  return undefined;
+}
+
+// Re-export for convenience
+export { suffixToApiName };
+export type { FactoryNode };

--- a/tests/unit/components/graves-weapon-modal-helpers.test.ts
+++ b/tests/unit/components/graves-weapon-modal-helpers.test.ts
@@ -1,0 +1,56 @@
+/**
+ * GravesWeaponModal export helpers 단위 테스트.
+ *
+ * 컴포넌트 자체 (UI / interaction) 는 vitest 가 node 환경 + RTL 미설치 라
+ * 본 테스트에서 검증하지 않음 — `/dev/graves-modal` 데모 페이지에서 시각 검증.
+ *
+ * 본 테스트가 검증하는 것:
+ *   - picksToUpgradeIds — picks → 시뮬 옵션 ID 배열 변환
+ *   - picksToFrame — picks 첫 번째가 frame root 인지 매핑
+ *   - 잘못된 suffix 거부
+ */
+import { describe, it, expect } from 'vitest';
+import { picksToUpgradeIds, picksToFrame } from '@/components/builder/GravesWeaponModal';
+
+describe('picksToUpgradeIds — picks → 시뮬 upgrade ID', () => {
+  it('빈 picks → 빈 배열', () => {
+    expect(picksToUpgradeIds([])).toEqual([]);
+  });
+
+  it('정상 picks → 그대로 반환 (FACTORY_NEW_TREE 정의된 suffix 만)', () => {
+    expect(picksToUpgradeIds(['CloseQuarters', 'EmergencyShielding', 'HeavyPlating']))
+      .toEqual(['CloseQuarters', 'EmergencyShielding', 'HeavyPlating']);
+  });
+
+  it('정의되지 않은 suffix 는 필터링', () => {
+    expect(picksToUpgradeIds(['CloseQuarters', 'NonExistent', 'HeavyPlating']))
+      .toEqual(['CloseQuarters', 'HeavyPlating']);
+  });
+
+  it('multi-parent Choke 도 단일 entry', () => {
+    expect(picksToUpgradeIds(['CloseQuarters', 'Buckshot', 'Choke']))
+      .toEqual(['CloseQuarters', 'Buckshot', 'Choke']);
+  });
+});
+
+describe('picksToFrame — 첫 pick → frame', () => {
+  it('빈 picks → undefined', () => {
+    expect(picksToFrame([])).toBeUndefined();
+  });
+
+  it('CloseQuarters → CloseQuarters', () => {
+    expect(picksToFrame(['CloseQuarters', 'EmergencyShielding'])).toBe('CloseQuarters');
+  });
+
+  it('SharpshooterModule → SharpshooterModule', () => {
+    expect(picksToFrame(['SharpshooterModule', 'BlastRadius'])).toBe('SharpshooterModule');
+  });
+
+  it('DoubleTap → DoubleTap', () => {
+    expect(picksToFrame(['DoubleTap'])).toBe('DoubleTap');
+  });
+
+  it('첫 pick 이 root 가 아니면 undefined (방어 코드)', () => {
+    expect(picksToFrame(['HeavyPlating'])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
PR #48 (트리 데이터) 후속 — 라운드별 무기 선택 모달 컴포넌트 + 단독 데모 페이지.

## 변경

### \`src/components/builder/GravesWeaponModal.tsx\` (신규)
props: \`{ isOpen, picks, onPicksChange, onClose, unitLabel? }\`

**UI**:
- 헤더: \"그레이브즈 무기고 — 라운드 N\" + unitLabel + 닫기 버튼
- History strip: 선택 history 칩 (가로 → 표시)
- Options grid: 가변 N개 카드 (responsive 2/3/4/5 컬럼)
- 카드: 아이콘 + 한글 이름 + cost 배지
- 카드 hover → desc tooltip
- Footer: \"이전\" 버튼 + 라운드/옵션 수 status

**동작**:
- 카드 클릭 → \`onPicksChange([...picks, suffix])\`
- 이전 → \`onPicksChange(picks.slice(0, -1))\` (picks=[] 시 disabled)
- 닫기 (×/외부 클릭) → \`onClose()\` — picks 그대로 유지 (호출자가 store 에 저장)
- multi-parent Choke 자동 dedup

**이미지**: \`useItems()\` 의 raw items.json icon 필드 → \`getItemImage()\`.
인게임과 다르게 모든 옵션 표시 (라운드 4 카드 제한 없음).

**Export 헬퍼**:
- \`picksToUpgradeIds(picks)\` — 시뮬 옵션 ID 배열 변환
- \`picksToFrame(picks)\` — 첫 root → frame 매핑

### \`src/app/dev/graves-modal/page.tsx\` (신규)
단독 검증용 데모 페이지 — PR #C 통합 전 시각 검증.
- useState picks 관리, 모달 토글 버튼
- picks 상태 표시 (length / round / trace / raw JSON)
- 동작 시나리오 가이드 6개

### \`tests/unit/components/graves-weapon-modal-helpers.test.ts\` (신규)
RTL 미설치 (vitest node 환경) → export 헬퍼만 9 케이스:
- picksToUpgradeIds 4 (정상 / undefined / multi-parent / 빈)
- picksToFrame 5 (3 frame / 빈 / 비-root)

> 시각 / interaction 검증은 \`/dev/graves-modal\` 데모 페이지에서.

## 동작 검증 (데모 페이지)

1. 모달 열기 → 라운드 1 (3 root frame)
2. 맹공 프레임 클릭 → 라운드 2 (4 children)
3. 긴급 보호막 클릭 → 라운드 3 (5 옵션 — 긴급+/두꺼운장갑판 + 맹공 sibling 3)
4. 두꺼운 장갑판 클릭 → 라운드 4 (7 옵션 — 두꺼운장갑판 children + sibling pool)
5. 이전 버튼 → 한 단계 되돌리기
6. 닫기 → picks 그대로 유지

## Test plan
- [x] \`pnpm vitest run\`: 522/522 pass
- [x] \`pnpm lint\`: 0 errors
- [x] \`pnpm typecheck\`: clean
- [x] \`pnpm build\`: success — \`/dev/graves-modal\` 정적 라우트 빌드됨
- [x] (manual) 데모 페이지에서 시각 / interaction 검증

## 후속 PR
- **#C** /simulator 통합 — 자동 open + UnitDetailPanel 수정 + teamSlice 연동
- **#D** /actual-data 통합 — sidebar 버튼 + per-game store

🤖 Generated with [Claude Code](https://claude.com/claude-code)