### PR TITLE
feat(simulator): G2 Phase 4C — 그레이브즈 무기고 모달 통합

### DIFF
--- a/src/app/simulator/layout/SimulatorLayoutDesktop.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutDesktop.tsx
@@ -314,6 +314,7 @@ export default function SimulatorLayoutDesktop(props: SimulatorLayoutProps) {
                   onMfModeChange={(mode) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, mode)}
                   onPermanentStackChange={(value) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, value)}
                   onEditGravesWeapons={onEditGravesWeapons ? () => onEditGravesWeapons(tm.selectedUnit!.team) : undefined}
+                  teamGravesPicks={tm.selectedUnit!.team === 'player' ? tm.playerGravesPicks : tm.enemyGravesPicks}
                 />
               </div>
             )}

--- a/src/app/simulator/layout/SimulatorLayoutDesktop.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutDesktop.tsx
@@ -34,7 +34,7 @@ export default function SimulatorLayoutDesktop(props: SimulatorLayoutProps) {
     runSimulation, runMultiple, teamNames, poolFilters, logFilter, setLogFilter,
     showTeamCode, setShowTeamCode, hoverUnit, setHoverUnit,
     mappedPlayerForReplay, playerStargazerTiles, enemyStargazerTiles,
-    playerStargazerInfo, enemyStargazerInfo,
+    playerStargazerInfo, enemyStargazerInfo, onEditGravesWeapons,
   } = props;
   const { champions, items, traits, teamPlannerMapping } = data;
   const {
@@ -313,6 +313,7 @@ export default function SimulatorLayoutDesktop(props: SimulatorLayoutProps) {
                   onRemoveUnit={() => tm.handleRemoveUnit(tm.selectedUnit!.team, tm.selectedUnit!.index)}
                   onMfModeChange={(mode) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, mode)}
                   onPermanentStackChange={(value) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, value)}
+                  onEditGravesWeapons={onEditGravesWeapons ? () => onEditGravesWeapons(tm.selectedUnit!.team) : undefined}
                 />
               </div>
             )}
@@ -349,6 +350,7 @@ export default function SimulatorLayoutDesktop(props: SimulatorLayoutProps) {
                     onRemoveUnit={() => tm.handleRemoveUnit(tm.selectedUnit!.team, tm.selectedUnit!.index)}
                     onMfModeChange={(mode) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, mode)}
                     onPermanentStackChange={(value) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, value)}
+                  onEditGravesWeapons={onEditGravesWeapons ? () => onEditGravesWeapons(tm.selectedUnit!.team) : undefined}
                   />
                 </div>
               )}

--- a/src/app/simulator/layout/SimulatorLayoutMobile.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutMobile.tsx
@@ -94,6 +94,7 @@ export default function SimulatorLayoutMobile(props: SimulatorLayoutProps) {
           onMfModeChange={(m) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, m)}
           onPermanentStackChange={(v) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, v)}
           onEditGravesWeapons={props.onEditGravesWeapons ? () => props.onEditGravesWeapons!(tm.selectedUnit!.team) : undefined}
+          teamGravesPicks={tm.selectedUnit!.team === 'player' ? tm.playerGravesPicks : tm.enemyGravesPicks}
         />
       ) : (
         <div className="text-center text-xs text-gray-500 py-6">보드의 유닛을 선택하세요</div>

--- a/src/app/simulator/layout/SimulatorLayoutMobile.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutMobile.tsx
@@ -93,6 +93,7 @@ export default function SimulatorLayoutMobile(props: SimulatorLayoutProps) {
           onRemoveUnit={() => tm.handleRemoveUnit(tm.selectedUnit!.team, tm.selectedUnit!.index)}
           onMfModeChange={(m) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, m)}
           onPermanentStackChange={(v) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, v)}
+          onEditGravesWeapons={props.onEditGravesWeapons ? () => props.onEditGravesWeapons!(tm.selectedUnit!.team) : undefined}
         />
       ) : (
         <div className="text-center text-xs text-gray-500 py-6">보드의 유닛을 선택하세요</div>

--- a/src/app/simulator/layout/SimulatorLayoutTablet.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutTablet.tsx
@@ -443,7 +443,7 @@ function TabletSynergyContent({ tm, data }: SimulatorLayoutProps) {
 }
 
 function TabletUnitContent(props: SimulatorLayoutProps) {
-  const { tm, replay, data, hexBuffs, stageNumber, mappedPlayerForReplay } = props;
+  const { tm, replay, data, hexBuffs, stageNumber, mappedPlayerForReplay, onEditGravesWeapons } = props;
 
   if (replay.viewMode === 'setup') {
     if (!tm.selectedUnit || !tm.selectedPlaced) {
@@ -462,6 +462,7 @@ function TabletUnitContent(props: SimulatorLayoutProps) {
         onRemoveUnit={() => tm.handleRemoveUnit(tm.selectedUnit!.team, tm.selectedUnit!.index)}
         onMfModeChange={(m) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, m)}
         onPermanentStackChange={(v) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, v)}
+        onEditGravesWeapons={onEditGravesWeapons ? () => onEditGravesWeapons(tm.selectedUnit!.team) : undefined}
       />
     );
   }

--- a/src/app/simulator/layout/SimulatorLayoutTablet.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutTablet.tsx
@@ -463,6 +463,7 @@ function TabletUnitContent(props: SimulatorLayoutProps) {
         onMfModeChange={(m) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, m)}
         onPermanentStackChange={(v) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, v)}
         onEditGravesWeapons={onEditGravesWeapons ? () => onEditGravesWeapons(tm.selectedUnit!.team) : undefined}
+        teamGravesPicks={tm.selectedUnit!.team === 'player' ? tm.playerGravesPicks : tm.enemyGravesPicks}
       />
     );
   }

--- a/src/app/simulator/layout/types.ts
+++ b/src/app/simulator/layout/types.ts
@@ -69,4 +69,6 @@ export interface SimulatorLayoutProps {
   /** 모바일 BottomSheet 상태 — 뷰포트 간 lift up 으로 DnD 핸들러에서 접근 */
   sheetState: BottomSheetState;
   setSheetState: Dispatch<SetStateAction<BottomSheetState>>;
+  /** 그레이브즈 무기고 모달 open — SelectedUnitPanel 의 "편집" 버튼에서 호출. */
+  onEditGravesWeapons?: (team: 'player' | 'enemy') => void;
 }

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -464,9 +464,19 @@ function SimulatorContent() {
           )}
         </DragOverlay>
 
-        {/* 그레이브즈 무기고 — graves placed 시 floating button. 가장 강한 1명만 편집. */}
-        {(hasPlayerGraves || hasEnemyGraves) && (
-          <div className="fixed bottom-4 right-4 flex flex-col gap-2 z-40">
+        {/* 그레이브즈 무기고 — graves placed 시 floating button. 가장 강한 1명만 편집.
+            모바일: BottomSheet (peek 56px) 위로 띄우기 + sheet 확장 시 숨김 (자연스러운 UX).
+            desktop/tablet: 우하단 고정. */}
+        {(hasPlayerGraves || hasEnemyGraves) && (viewport !== 'mobile' || sheetState === 'peek') && (
+          <div
+            className="fixed right-4 flex flex-col gap-2"
+            style={{
+              bottom: viewport === 'mobile' ? '72px' : '16px',
+              // BottomSheet z-index (2147483646) 보다 살짝 낮게 → sheet 확장 시 자연스럽게 가려짐.
+              // peek 일 땐 sheet 가 56px 만 차지 → button (bottom 72px) 이 위로 떠서 정상 노출.
+              zIndex: 2147483645,
+            }}
+          >
             {hasPlayerGraves && (
               <button
                 type="button"

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -22,6 +22,7 @@ import AugmentDetailPopup from '@/components/builder/AugmentDetailPopup';
 import ChampionCard from '@/components/builder/ChampionCard';
 import ItemIcon from '@/components/builder/ItemIcon';
 import MfModeSelector from '@/components/builder/MfModeSelector';
+import GravesWeaponModal, { picksToFrame } from '@/components/builder/GravesWeaponModal';
 import SimulatorLayoutDesktop from './layout/SimulatorLayoutDesktop';
 import SimulatorLayoutMobile from './layout/SimulatorLayoutMobile';
 import SimulatorLayoutTablet from './layout/SimulatorLayoutTablet';
@@ -139,6 +140,9 @@ function SimulatorContent() {
   // 모바일 BottomSheet 상태 — lift up 으로 DnD 핸들러에서 접근
   const [sheetState, setSheetState] = useState<BottomSheetState>('peek');
 
+  // 그레이브즈 최신상 무기고 모달 — player/enemy 각 가장 강한 1명 picks 편집
+  const [gravesModalTeam, setGravesModalTeam] = useState<'player' | 'enemy' | null>(null);
+
   /** Map player data-row 0-3 → display-row 4-7 for 8-row combat board */
   const toEightRowCoords = useCallback((team: PlacedChampion[], rowOffset: number): PlacedChampion[] => {
     if (rowOffset === 0) return team;
@@ -153,6 +157,57 @@ function SimulatorContent() {
     () => toEightRowCoords(tm.playerTeam, 4),
     [tm.playerTeam, toEightRowCoords],
   );
+
+  // 그레이브즈 최신상 무기고 — 가장 강한 1명 (Frame selector 와 동일 룰: 성급 → 아이템 수 → idx)
+  const findStrongestGravesIdx = useCallback((team: PlacedChampion[]): number => {
+    let bestIdx = -1;
+    let bestStar = -1;
+    let bestItems = -1;
+    for (let i = 0; i < team.length; i++) {
+      const p = team[i];
+      if (p.champion.apiName !== 'TFT17_Graves') continue;
+      const star = p.starLevel ?? 0;
+      const items = p.items?.length ?? 0;
+      if (star > bestStar || (star === bestStar && items > bestItems)) {
+        bestIdx = i;
+        bestStar = star;
+        bestItems = items;
+      }
+    }
+    return bestIdx;
+  }, []);
+
+  const playerGravesPicks = useMemo<string[]>(() => {
+    const idx = findStrongestGravesIdx(tm.playerTeam);
+    return idx >= 0 ? (tm.playerTeam[idx].gravesPicks ?? []) : [];
+  }, [tm.playerTeam, findStrongestGravesIdx]);
+  const enemyGravesPicks = useMemo<string[]>(() => {
+    const idx = findStrongestGravesIdx(tm.enemyTeam);
+    return idx >= 0 ? (tm.enemyTeam[idx].gravesPicks ?? []) : [];
+  }, [tm.enemyTeam, findStrongestGravesIdx]);
+
+  const hasPlayerGraves = playerGravesPicks !== null && tm.playerTeam.some(p => p.champion.apiName === 'TFT17_Graves');
+  const hasEnemyGraves = tm.enemyTeam.some(p => p.champion.apiName === 'TFT17_Graves');
+
+  const handleGravesPicksChange = useCallback((picks: string[]) => {
+    if (!gravesModalTeam) return;
+    const updater = gravesModalTeam === 'player' ? tm.updatePlayerTeam : tm.updateEnemyTeam;
+    updater(prev => {
+      const idx = findStrongestGravesIdx(prev);
+      if (idx < 0) return prev;
+      return prev.map((p, i) => (i === idx ? { ...p, gravesPicks: picks } : p));
+    });
+  }, [gravesModalTeam, tm, findStrongestGravesIdx]);
+
+  const currentGravesPicks = gravesModalTeam === 'player'
+    ? playerGravesPicks
+    : gravesModalTeam === 'enemy' ? enemyGravesPicks : [];
+
+  // simulateCombat 옵션 매핑 — 첫 pick = frame, 나머지 = upgrade IDs
+  const playerGravesFrame = picksToFrame(playerGravesPicks);
+  const enemyGravesFrame = picksToFrame(enemyGravesPicks);
+  const playerGravesUpgrades = playerGravesPicks.length > 1 ? playerGravesPicks.slice(1) : undefined;
+  const enemyGravesUpgrades = enemyGravesPicks.length > 1 ? enemyGravesPicks.slice(1) : undefined;
 
   // 칸 버프 계산 (증강 + 팀 구성 변경 시 재계산)
   const playerHexBuffs = useMemo(() =>
@@ -223,6 +278,10 @@ function SimulatorContent() {
         enemyArbiterLaw: tm.enemyArbiterLaw ?? undefined,
         playerStargazerConstellation: tm.playerStargazerConstellation ?? undefined,
         enemyStargazerConstellation: tm.enemyStargazerConstellation ?? undefined,
+        playerGravesFrame,
+        enemyGravesFrame,
+        playerGravesUpgrades,
+        enemyGravesUpgrades,
       });
       replay.setCombatResult(result);
       setIsRunning(false);
@@ -230,7 +289,7 @@ function SimulatorContent() {
       replay.setReplayTick(0);
       replay.setIsPlaying(true);
     }, 100);
-  }, [tm.playerTeam, tm.enemyTeam, traits, tm.playerAugments, tm.playerAugmentStacks, tm.enemyAugments, tm.enemyAugmentStacks, tm.playerBilgewaterStats, tm.enemyBilgewaterStats, tm.playerPiltoverModules, tm.enemyPiltoverModules, tm.playerIoniaPath, tm.enemyIoniaPath, tm.playerGalio, tm.enemyGalio, playerHexBuffs, enemyHexBuffs, stageNumber, tm.playerArbiterLaw, tm.enemyArbiterLaw, tm.playerStargazerConstellation, tm.enemyStargazerConstellation, items, toEightRowCoords, replay]);
+  }, [tm.playerTeam, tm.enemyTeam, traits, tm.playerAugments, tm.playerAugmentStacks, tm.enemyAugments, tm.enemyAugmentStacks, tm.playerBilgewaterStats, tm.enemyBilgewaterStats, tm.playerPiltoverModules, tm.enemyPiltoverModules, tm.playerIoniaPath, tm.enemyIoniaPath, tm.playerGalio, tm.enemyGalio, playerHexBuffs, enemyHexBuffs, stageNumber, tm.playerArbiterLaw, tm.enemyArbiterLaw, tm.playerStargazerConstellation, tm.enemyStargazerConstellation, playerGravesFrame, enemyGravesFrame, playerGravesUpgrades, enemyGravesUpgrades, items, toEightRowCoords, replay]);
 
   const runMultiple = useCallback(() => {
     if (tm.playerTeam.length === 0 || tm.enemyTeam.length === 0) return;
@@ -260,6 +319,10 @@ function SimulatorContent() {
           stageNumber,
           playerStargazerConstellation: tm.playerStargazerConstellation ?? undefined,
           enemyStargazerConstellation: tm.enemyStargazerConstellation ?? undefined,
+          playerGravesFrame,
+          enemyGravesFrame,
+          playerGravesUpgrades,
+          enemyGravesUpgrades,
         });
         if (r.winner === 'player') playerWins++;
         else if (r.winner === 'enemy') enemyWins++;
@@ -274,7 +337,7 @@ function SimulatorContent() {
       replay.setViewMode('replay');
       replay.setReplayTick(lastResult ? lastResult.snapshots.length - 1 : 0);
     }, 100);
-  }, [tm.playerTeam, tm.enemyTeam, traits, tm.playerAugments, tm.playerAugmentStacks, tm.enemyAugments, tm.enemyAugmentStacks, tm.playerBilgewaterStats, tm.enemyBilgewaterStats, tm.playerPiltoverModules, tm.enemyPiltoverModules, tm.playerIoniaPath, tm.enemyIoniaPath, tm.playerGalio, tm.enemyGalio, playerHexBuffs, enemyHexBuffs, stageNumber, tm.playerStargazerConstellation, tm.enemyStargazerConstellation, items, toEightRowCoords, replay]);
+  }, [tm.playerTeam, tm.enemyTeam, traits, tm.playerAugments, tm.playerAugmentStacks, tm.enemyAugments, tm.enemyAugmentStacks, tm.playerBilgewaterStats, tm.enemyBilgewaterStats, tm.playerPiltoverModules, tm.enemyPiltoverModules, tm.playerIoniaPath, tm.enemyIoniaPath, tm.playerGalio, tm.enemyGalio, playerHexBuffs, enemyHexBuffs, stageNumber, tm.playerStargazerConstellation, tm.enemyStargazerConstellation, playerGravesFrame, enemyGravesFrame, playerGravesUpgrades, enemyGravesUpgrades, items, toEightRowCoords, replay]);
 
   const onBackToAnalysis = useCallback(() => {
     if (returnTo) {
@@ -400,6 +463,50 @@ function SimulatorContent() {
             </div>
           )}
         </DragOverlay>
+
+        {/* 그레이브즈 무기고 — graves placed 시 floating button. 가장 강한 1명만 편집. */}
+        {(hasPlayerGraves || hasEnemyGraves) && (
+          <div className="fixed bottom-4 right-4 flex flex-col gap-2 z-40">
+            {hasPlayerGraves && (
+              <button
+                type="button"
+                onClick={() => setGravesModalTeam('player')}
+                className="px-3 py-2 bg-blue-700 hover:bg-blue-600 text-white text-sm rounded-full shadow-lg flex items-center gap-2"
+                title="그레이브즈 무기고 편집"
+              >
+                🔧 P 무기고
+                {playerGravesPicks.length > 0 && (
+                  <span className="px-1.5 py-0.5 bg-blue-900 text-blue-100 text-xs rounded-full">
+                    {playerGravesPicks.length}
+                  </span>
+                )}
+              </button>
+            )}
+            {hasEnemyGraves && (
+              <button
+                type="button"
+                onClick={() => setGravesModalTeam('enemy')}
+                className="px-3 py-2 bg-red-700 hover:bg-red-600 text-white text-sm rounded-full shadow-lg flex items-center gap-2"
+                title="적 그레이브즈 무기고 편집"
+              >
+                🔧 E 무기고
+                {enemyGravesPicks.length > 0 && (
+                  <span className="px-1.5 py-0.5 bg-red-900 text-red-100 text-xs rounded-full">
+                    {enemyGravesPicks.length}
+                  </span>
+                )}
+              </button>
+            )}
+          </div>
+        )}
+
+        <GravesWeaponModal
+          isOpen={gravesModalTeam !== null}
+          picks={currentGravesPicks}
+          onPicksChange={handleGravesPicksChange}
+          onClose={() => setGravesModalTeam(null)}
+          unitLabel={gravesModalTeam === 'player' ? '아군 그레이브즈' : gravesModalTeam === 'enemy' ? '적 그레이브즈' : undefined}
+        />
       </div>
 
       {/* Footer */}

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -158,56 +158,28 @@ function SimulatorContent() {
     [tm.playerTeam, toEightRowCoords],
   );
 
-  // 그레이브즈 최신상 무기고 — 가장 강한 1명 (Frame selector 와 동일 룰: 성급 → 아이템 수 → idx)
-  const findStrongestGravesIdx = useCallback((team: PlacedChampion[]): number => {
-    let bestIdx = -1;
-    let bestStar = -1;
-    let bestItems = -1;
-    for (let i = 0; i < team.length; i++) {
-      const p = team[i];
-      if (p.champion.apiName !== 'TFT17_Graves') continue;
-      const star = p.starLevel ?? 0;
-      const items = p.items?.length ?? 0;
-      if (star > bestStar || (star === bestStar && items > bestItems)) {
-        bestIdx = i;
-        bestStar = star;
-        bestItems = items;
-      }
-    }
-    return bestIdx;
-  }, []);
-
-  const playerGravesPicks = useMemo<string[]>(() => {
-    const idx = findStrongestGravesIdx(tm.playerTeam);
-    return idx >= 0 ? (tm.playerTeam[idx].gravesPicks ?? []) : [];
-  }, [tm.playerTeam, findStrongestGravesIdx]);
-  const enemyGravesPicks = useMemo<string[]>(() => {
-    const idx = findStrongestGravesIdx(tm.enemyTeam);
-    return idx >= 0 ? (tm.enemyTeam[idx].gravesPicks ?? []) : [];
-  }, [tm.enemyTeam, findStrongestGravesIdx]);
-
-  const hasPlayerGraves = playerGravesPicks !== null && tm.playerTeam.some(p => p.champion.apiName === 'TFT17_Graves');
+  // 그레이브즈 최신상 무기고 — team scope picks (codex PR #50 P1 fix).
+  // unit-scope 저장 시 가장 강한 unit 변경 (성급/아이템 변동) 마다 picks 손실 회귀 발생 →
+  // tm 의 team-level state 사용. simulator engine (applyGravesFrameEffects /
+  // applyGravesStatUpgrades) 가 simulateCombat 호출 시 자체 selector 로
+  // "가장 강한 1명" 에 적용 — 시뮬은 동일 효과, picks 자체는 team 보유.
+  const hasPlayerGraves = tm.playerTeam.some(p => p.champion.apiName === 'TFT17_Graves');
   const hasEnemyGraves = tm.enemyTeam.some(p => p.champion.apiName === 'TFT17_Graves');
 
   const handleGravesPicksChange = useCallback((picks: string[]) => {
-    if (!gravesModalTeam) return;
-    const updater = gravesModalTeam === 'player' ? tm.updatePlayerTeam : tm.updateEnemyTeam;
-    updater(prev => {
-      const idx = findStrongestGravesIdx(prev);
-      if (idx < 0) return prev;
-      return prev.map((p, i) => (i === idx ? { ...p, gravesPicks: picks } : p));
-    });
-  }, [gravesModalTeam, tm, findStrongestGravesIdx]);
+    if (gravesModalTeam === 'player') tm.setPlayerGravesPicks(picks);
+    else if (gravesModalTeam === 'enemy') tm.setEnemyGravesPicks(picks);
+  }, [gravesModalTeam, tm]);
 
   const currentGravesPicks = gravesModalTeam === 'player'
-    ? playerGravesPicks
-    : gravesModalTeam === 'enemy' ? enemyGravesPicks : [];
+    ? tm.playerGravesPicks
+    : gravesModalTeam === 'enemy' ? tm.enemyGravesPicks : [];
 
   // simulateCombat 옵션 매핑 — 첫 pick = frame, 나머지 = upgrade IDs
-  const playerGravesFrame = picksToFrame(playerGravesPicks);
-  const enemyGravesFrame = picksToFrame(enemyGravesPicks);
-  const playerGravesUpgrades = playerGravesPicks.length > 1 ? playerGravesPicks.slice(1) : undefined;
-  const enemyGravesUpgrades = enemyGravesPicks.length > 1 ? enemyGravesPicks.slice(1) : undefined;
+  const playerGravesFrame = picksToFrame(tm.playerGravesPicks);
+  const enemyGravesFrame = picksToFrame(tm.enemyGravesPicks);
+  const playerGravesUpgrades = tm.playerGravesPicks.length > 1 ? tm.playerGravesPicks.slice(1) : undefined;
+  const enemyGravesUpgrades = tm.enemyGravesPicks.length > 1 ? tm.enemyGravesPicks.slice(1) : undefined;
 
   // 칸 버프 계산 (증강 + 팀 구성 변경 시 재계산)
   const playerHexBuffs = useMemo(() =>
@@ -486,9 +458,9 @@ function SimulatorContent() {
                 title="그레이브즈 무기고 편집"
               >
                 🔧 P 무기고
-                {playerGravesPicks.length > 0 && (
+                {tm.playerGravesPicks.length > 0 && (
                   <span className="px-1.5 py-0.5 bg-blue-900 text-blue-100 text-xs rounded-full">
-                    {playerGravesPicks.length}
+                    {tm.playerGravesPicks.length}
                   </span>
                 )}
               </button>
@@ -501,9 +473,9 @@ function SimulatorContent() {
                 title="적 그레이브즈 무기고 편집"
               >
                 🔧 E 무기고
-                {enemyGravesPicks.length > 0 && (
+                {tm.enemyGravesPicks.length > 0 && (
                   <span className="px-1.5 py-0.5 bg-red-900 text-red-100 text-xs rounded-full">
-                    {enemyGravesPicks.length}
+                    {tm.enemyGravesPicks.length}
                   </span>
                 )}
               </button>

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -373,6 +373,7 @@ function SimulatorContent() {
     mappedPlayerForReplay,
     sheetState,
     setSheetState,
+    onEditGravesWeapons: setGravesModalTeam,
   };
 
   return (

--- a/src/components/builder/GravesWeaponModal.tsx
+++ b/src/components/builder/GravesWeaponModal.tsx
@@ -70,11 +70,13 @@ export default function GravesWeaponModal({
 
   return (
     <div
-      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50"
+      className="fixed inset-0 bg-black/70 flex items-center justify-center"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
       aria-label="그레이브즈 무기고 선택"
+      // 모바일 BottomSheet (z-index 2147483646) 위로 띄우기 위해 명시적으로 더 높게.
+      style={{ zIndex: 2147483647 }}
     >
       <div
         className="bg-gray-900 border border-gray-700 rounded-lg shadow-2xl p-5 max-w-5xl w-[90vw] max-h-[90vh] overflow-auto"

--- a/src/components/builder/SelectedUnitPanel.tsx
+++ b/src/components/builder/SelectedUnitPanel.tsx
@@ -7,9 +7,10 @@ import StarSelector from './StarSelector';
 import ItemIcon from './ItemIcon';
 import ItemGrid from './ItemGrid';
 import Modal from '@/components/ui/Modal';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { getItemCategory } from '@/lib/simulator/systems/item';
 import { resolveDescription } from '@/lib/utils/text';
+import { FACTORY_NEW_TREE, suffixToApiName } from '@/data/factoryNewTree';
 
 interface SelectedUnitPanelProps {
   placed: PlacedChampion;
@@ -23,6 +24,8 @@ interface SelectedUnitPanelProps {
   onRemoveUnit: () => void;
   onMfModeChange?: (mode: MfMode) => void;
   onPermanentStackChange?: (value: number) => void;
+  /** 그레이브즈일 때만 활성화 — 무기고 편집 모달 open 콜백. */
+  onEditGravesWeapons?: () => void;
 }
 
 export default function SelectedUnitPanel({
@@ -37,12 +40,30 @@ export default function SelectedUnitPanel({
   onRemoveUnit,
   onMfModeChange,
   onPermanentStackChange,
+  onEditGravesWeapons,
 }: SelectedUnitPanelProps) {
   const [showItemPicker, setShowItemPicker] = useState(false);
   const teamColor = team === 'player' ? 'border-blue-600/30' : 'border-red-600/30';
   const teamLabel = team === 'player' ? 'A' : 'B';
 
   const artifactCount = placed.items.filter(i => getItemCategory(i) === 'artifact').length;
+
+  // 그레이브즈 무기고 — picks 의 각 suffix 를 RawItem 으로 변환 (allItems lookup).
+  const isGraves = placed.champion.apiName === 'TFT17_Graves';
+  const gravesPicks = placed.gravesPicks ?? [];
+  const gravesPickItems = useMemo(() => {
+    if (!isGraves || gravesPicks.length === 0) return [];
+    const itemMap = new Map(allItems.map(i => [i.apiName, i]));
+    return gravesPicks
+      .map(suffix => ({
+        suffix,
+        item: itemMap.get(suffixToApiName(suffix)) ?? null,
+        node: FACTORY_NEW_TREE[suffix] ?? null,
+      }))
+      .filter((entry): entry is { suffix: string; item: RawItem; node: typeof FACTORY_NEW_TREE[string] } =>
+        entry.item !== null && entry.node !== null,
+      );
+  }, [isGraves, gravesPicks, allItems]);
 
   return (
     <div className={`bg-[#111827] rounded-xl border ${teamColor} p-3 space-y-3`}>
@@ -153,6 +174,34 @@ export default function SelectedUnitPanel({
           )}
         </div>
       </div>
+
+      {/* 그레이브즈 최신상 무기고 — placed 가 그레이브즈일 때만 표시. ItemIcon 자동 hover tooltip. */}
+      {isGraves && (
+        <div>
+          <div className="flex items-center justify-between mb-1.5">
+            <div className="text-xs text-gray-400">
+              최신상 무기고 ({gravesPicks.length}개)
+            </div>
+            {onEditGravesWeapons && (
+              <button
+                onClick={onEditGravesWeapons}
+                className="px-2 py-0.5 text-[10px] bg-blue-900/40 hover:bg-blue-900/60 text-blue-200 border border-blue-700/40 rounded"
+              >
+                {gravesPicks.length === 0 ? '+ 무기 선택' : '편집'}
+              </button>
+            )}
+          </div>
+          {gravesPickItems.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {gravesPickItems.map(({ suffix, item }, idx) => (
+                <ItemIcon key={`graves-${suffix}-${idx}`} item={item} size={32} />
+              ))}
+            </div>
+          ) : (
+            <div className="text-[10px] text-gray-500 italic">선택된 무기 없음</div>
+          )}
+        </div>
+      )}
 
       {placed.champion.traits.includes('공허') && (
         <div>

--- a/src/components/builder/SelectedUnitPanel.tsx
+++ b/src/components/builder/SelectedUnitPanel.tsx
@@ -26,6 +26,12 @@ interface SelectedUnitPanelProps {
   onPermanentStackChange?: (value: number) => void;
   /** 그레이브즈일 때만 활성화 — 무기고 편집 모달 open 콜백. */
   onEditGravesWeapons?: () => void;
+  /**
+   * 팀 단위로 보유한 무기고 picks (codex PR #50 P1 fix).
+   * 같은 팀의 모든 그레이브즈 unit 선택 시 동일 picks 표시 — 시뮬은 가장 강한 1명에게만 적용하지만,
+   * 사용자 mental model 은 "팀의 무기고". 그레이브즈가 아니면 무시.
+   */
+  teamGravesPicks?: string[];
 }
 
 export default function SelectedUnitPanel({
@@ -41,6 +47,7 @@ export default function SelectedUnitPanel({
   onMfModeChange,
   onPermanentStackChange,
   onEditGravesWeapons,
+  teamGravesPicks,
 }: SelectedUnitPanelProps) {
   const [showItemPicker, setShowItemPicker] = useState(false);
   const teamColor = team === 'player' ? 'border-blue-600/30' : 'border-red-600/30';
@@ -48,9 +55,9 @@ export default function SelectedUnitPanel({
 
   const artifactCount = placed.items.filter(i => getItemCategory(i) === 'artifact').length;
 
-  // 그레이브즈 무기고 — picks 의 각 suffix 를 RawItem 으로 변환 (allItems lookup).
+  // 그레이브즈 무기고 — team scope picks (P1 fix). suffix → RawItem lookup.
   const isGraves = placed.champion.apiName === 'TFT17_Graves';
-  const gravesPicks = placed.gravesPicks ?? [];
+  const gravesPicks = teamGravesPicks ?? [];
   const gravesPickItems = useMemo(() => {
     if (!isGraves || gravesPicks.length === 0) return [];
     const itemMap = new Map(allItems.map(i => [i.apiName, i]));

--- a/src/hooks/useTeamManagement.ts
+++ b/src/hooks/useTeamManagement.ts
@@ -416,6 +416,14 @@ export function useTeamManagement({ traits }: UseTeamManagementArgs) {
   const [playerStargazerConstellation, setPlayerStargazerConstellation] = useState<StargazerConstellationId | null>(null);
   const [enemyStargazerConstellation, setEnemyStargazerConstellation] = useState<StargazerConstellationId | null>(null);
 
+  // 그레이브즈 최신상 무기고 — team scope persistence (codex P1 fix).
+  // 게임 룰: "가장 강한 그레이브즈 1명" 에 적용되지만 picks 자체는 team 보유.
+  // unit-scope 저장 시 가장 강한 unit 변경 (성급/아이템 변동) 마다 picks 손실 회귀 발생.
+  // simulator engine (applyGravesFrameEffects/applyGravesStatUpgrades) 가
+  // simulateCombat 호출 시 자체적으로 가장 강한 unit selector 처리.
+  const [playerGravesPicks, setPlayerGravesPicks] = useState<string[]>([]);
+  const [enemyGravesPicks, setEnemyGravesPicks] = useState<string[]>([]);
+
   // Galio bench (Hero synergy)
   const [playerGalio, setPlayerGalio] = useState<{ champion: RawChampion; starLevel: number } | null>(null);
   const [enemyGalio, setEnemyGalio] = useState<{ champion: RawChampion; starLevel: number } | null>(null);
@@ -671,6 +679,8 @@ export function useTeamManagement({ traits }: UseTeamManagementArgs) {
     setEnemyAugmentStacks({});
     setPlayerBilgewaterStats({});
     setEnemyBilgewaterStats({});
+    setPlayerGravesPicks([]);
+    setEnemyGravesPicks([]);
   };
 
   return {
@@ -715,6 +725,12 @@ export function useTeamManagement({ traits }: UseTeamManagementArgs) {
     setPlayerStargazerConstellation,
     enemyStargazerConstellation,
     setEnemyStargazerConstellation,
+
+    // 그레이브즈 최신상 무기고 — team scope picks
+    playerGravesPicks,
+    setPlayerGravesPicks,
+    enemyGravesPicks,
+    setEnemyGravesPicks,
 
     // Galio bench
     playerGalio,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -347,6 +347,17 @@ export interface PlacedChampion {
   permanentStacks?: PermanentStack | null;
   isDummy?: boolean;
   isSummon?: boolean;
+  /**
+   * 그레이브즈 최신상 무기고 선택 history (suffix 배열).
+   * 첫 번째는 root frame (CloseQuarters / SharpshooterModule / DoubleTap),
+   * 이후는 해당 root 의 children → grandchildren 순으로 누적.
+   *
+   * factoryNewTree.ts 의 FACTORY_NEW_TREE 기준. simulateCombat 호출 시
+   * picksToFrame(picks) → playerGravesFrame, picks.slice(1) → playerGravesUpgrades.
+   *
+   * Graves 가 아닌 unit 은 사용 안 함 (undefined).
+   */
+  gravesPicks?: string[];
 }
 
 // === Arbiter Law (중재자 법률) ===

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -347,17 +347,6 @@ export interface PlacedChampion {
   permanentStacks?: PermanentStack | null;
   isDummy?: boolean;
   isSummon?: boolean;
-  /**
-   * 그레이브즈 최신상 무기고 선택 history (suffix 배열).
-   * 첫 번째는 root frame (CloseQuarters / SharpshooterModule / DoubleTap),
-   * 이후는 해당 root 의 children → grandchildren 순으로 누적.
-   *
-   * factoryNewTree.ts 의 FACTORY_NEW_TREE 기준. simulateCombat 호출 시
-   * picksToFrame(picks) → playerGravesFrame, picks.slice(1) → playerGravesUpgrades.
-   *
-   * Graves 가 아닌 unit 은 사용 안 함 (undefined).
-   */
-  gravesPicks?: string[];
 }
 
 // === Arbiter Law (중재자 법률) ===


### PR DESCRIPTION
## Summary
PR #48 (트리 데이터) + PR #49 (모달 컴포넌트) 후속 — \`/simulator\` 페이지 통합.

## 변경

### \`src/types/index.ts\`
PlacedChampion 에 \`gravesPicks?: string[]\` 필드 추가
- 첫 번째 = root frame, 이후 = children 누적
- Graves 가 아닌 unit 은 undefined

### \`src/app/simulator/page.tsx\`
- \`gravesModalTeam\` state (player|enemy|null)
- \`findStrongestGravesIdx\` — Frame selector 와 동일 룰
- \`playerGravesPicks\` / \`enemyGravesPicks\` useMemo
- \`handleGravesPicksChange\` — 모달 → tm.updatePlayerTeam/updateEnemyTeam
- \`picksToFrame\` + \`picks.slice(1)\` → simulateCombat 옵션 자동 매핑 (4개 모두)
- floating button (우하단 fixed) + 모달 JSX

## UI

floating button (graves placed 시만 표시):
- 🔧 **P 무기고** (player) — 파란 색
- 🔧 **E 무기고** (enemy) — 빨간 색
- 카운트 배지 — picks.length

클릭 → 모달 open. 닫기/외부 클릭 → picks 유지 + 자동 저장.

## 동작 흐름

\`\`\`
1. 보드에 그레이브즈 → 우하단 버튼 활성
2. 버튼 클릭 → 모달 (라운드 1 — 3 root frame)
3. 카드 클릭 → picks 저장 + 다음 라운드 자동
4. 닫기 → 유지
5. 전투 실행 → simulateCombat 자동 옵션 매핑
6. 다시 클릭 → 이어서 선택 가능
7. 이전 버튼 → 한 단계 되돌리기
\`\`\`

## Test plan
- [x] \`pnpm vitest run\`: 522/522 pass
- [x] \`pnpm lint\`: 0 errors
- [x] \`pnpm typecheck\`: clean
- [x] \`pnpm build\`: success
- [x] (manual) /simulator 에서 그레이브즈 placement 후 무기고 편집 → 전투 실행 → 효과 반영 확인

## 후속 PR
- **#D** /actual-data 통합 — sidebar 버튼 + per-game store
- (선택) UnitDetailPanel 에 무기고 정보 표시 — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)