### PR TITLE
feat(actual-data): G2 Phase 4D — 그레이브즈 무기고 모달 통합

### DIFF
--- a/src/components/actual-data/PvPRoundEditor.tsx
+++ b/src/components/actual-data/PvPRoundEditor.tsx
@@ -9,6 +9,7 @@ import type { DragData, RawChampion, RawItem, HexCoord } from '@/types';
 import { offsetToAxial } from '@/types';
 import ChampionCard from '@/components/builder/ChampionCard';
 import ItemIcon from '@/components/builder/ItemIcon';
+import GravesWeaponModal from '@/components/builder/GravesWeaponModal';
 import TeamEditor from './TeamEditor';
 import OpponentPanel from './OpponentPanel';
 import DamageChartInput from './DamageChartInput';
@@ -85,6 +86,34 @@ export default function PvPRoundEditor({ index, round }: { index: number; round:
   }, [round.playerTeam.units, index, updatePlayerTeam]);
 
   const championCatalog = useMemo(() => new Map(champions.map(c => [c.apiName, c])), [champions]);
+
+  // 그레이브즈 무기고 — 모달 state + onPicksChange 핸들러
+  const [gravesModalTeam, setGravesModalTeam] = useState<'player' | 'opponent' | null>(null);
+  const hasPlayerGraves = round.playerTeam.units.some(u => u.championId === 'TFT17_Graves');
+  const hasOpponentGraves = round.opponent.units.some(u => u.championId === 'TFT17_Graves');
+  const playerPicks = round.playerTeam.factoryNew?.upgradePath ?? [];
+  const opponentPicks = round.opponent.factoryNew?.upgradePath ?? [];
+  const currentPicks = gravesModalTeam === 'player'
+    ? playerPicks
+    : gravesModalTeam === 'opponent' ? opponentPicks : [];
+
+  const handleGravesPicksChange = useCallback((picks: string[]) => {
+    if (gravesModalTeam === 'player') {
+      updatePlayerTeam(index, {
+        factoryNew: {
+          ...round.playerTeam.factoryNew,
+          upgradePath: picks,
+        },
+      });
+    } else if (gravesModalTeam === 'opponent') {
+      updateOpponent(index, {
+        factoryNew: {
+          ...round.opponent.factoryNew,
+          upgradePath: picks,
+        },
+      });
+    }
+  }, [gravesModalTeam, index, round.playerTeam.factoryNew, round.opponent.factoryNew, updatePlayerTeam, updateOpponent]);
 
   return (
     <DndContext
@@ -240,6 +269,57 @@ export default function PvPRoundEditor({ index, round }: { index: number; round:
           </div>
         )}
       </DragOverlay>
+
+      {/* 그레이브즈 무기고 — graves placed 시 floating button. round 별로 picks 저장. */}
+      {(hasPlayerGraves || hasOpponentGraves) && (
+        <div
+          className="fixed right-4 flex flex-col gap-2"
+          style={{ bottom: '16px', zIndex: 2147483645 }}
+        >
+          {hasPlayerGraves && (
+            <button
+              type="button"
+              onClick={() => setGravesModalTeam('player')}
+              className="px-3 py-2 bg-blue-700 hover:bg-blue-600 text-white text-sm rounded-full shadow-lg flex items-center gap-2"
+              title="내 팀 그레이브즈 무기고 편집"
+            >
+              🔧 내 무기고
+              {playerPicks.length > 0 && (
+                <span className="px-1.5 py-0.5 bg-blue-900 text-blue-100 text-xs rounded-full">
+                  {playerPicks.length}
+                </span>
+              )}
+            </button>
+          )}
+          {hasOpponentGraves && (
+            <button
+              type="button"
+              onClick={() => setGravesModalTeam('opponent')}
+              className="px-3 py-2 bg-red-700 hover:bg-red-600 text-white text-sm rounded-full shadow-lg flex items-center gap-2"
+              title="상대 그레이브즈 무기고 편집"
+            >
+              🔧 상대 무기고
+              {opponentPicks.length > 0 && (
+                <span className="px-1.5 py-0.5 bg-red-900 text-red-100 text-xs rounded-full">
+                  {opponentPicks.length}
+                </span>
+              )}
+            </button>
+          )}
+        </div>
+      )}
+
+      <GravesWeaponModal
+        isOpen={gravesModalTeam !== null}
+        picks={currentPicks}
+        onPicksChange={handleGravesPicksChange}
+        onClose={() => setGravesModalTeam(null)}
+        unitLabel={
+          gravesModalTeam === 'player' ? `내 팀 — 라운드 ${round.roundName}`
+          : gravesModalTeam === 'opponent' ? `상대 — 라운드 ${round.roundName}`
+          : undefined
+        }
+      />
     </DndContext>
   );
 }

--- a/src/components/actual-data/PvPRoundEditor.tsx
+++ b/src/components/actual-data/PvPRoundEditor.tsx
@@ -270,11 +270,14 @@ export default function PvPRoundEditor({ index, round }: { index: number; round:
         )}
       </DragOverlay>
 
-      {/* 그레이브즈 무기고 — graves placed 시 floating button. round 별로 picks 저장. */}
-      {(hasPlayerGraves || hasOpponentGraves) && (
+      {/* 그레이브즈 무기고 — graves placed 시 floating button. round 별로 picks 저장.
+          modal open 일 때 button 숨김 → modal isolation 보장 (codex P2: picks 가
+          의도하지 않은 팀에 적용되는 mid-flow 전환 방지). z-index 도 modal (z-50) 보다
+          낮은 z-40 으로 — modal 안에서도 background button 가시성 차단. */}
+      {(hasPlayerGraves || hasOpponentGraves) && gravesModalTeam === null && (
         <div
           className="fixed right-4 flex flex-col gap-2"
-          style={{ bottom: '16px', zIndex: 2147483645 }}
+          style={{ bottom: '16px', zIndex: 40 }}
         >
           {hasPlayerGraves && (
             <button


### PR DESCRIPTION
## Summary
PR #50 (/simulator 통합) 의 actual-data 버전 — PvPRoundEditor 에 라운드별 그레이브즈 무기고 편집 기능 추가.

## 변경

### \`src/components/actual-data/PvPRoundEditor.tsx\` (+80 lines)
- \`GravesWeaponModal\` import + \`gravesModalTeam\` state (player|opponent|null)
- 그레이브즈 unit 감지 — \`round.{playerTeam,opponent}.units.some(u => u.championId === 'TFT17_Graves')\`
- picks lookup — \`round.{playerTeam,opponent}.factoryNew?.upgradePath\` (기존 schema 활용)
- \`handleGravesPicksChange\` → \`updatePlayerTeam\` / \`updateOpponent\` 의 \`factoryNew.upgradePath\` 변경
- floating button (우하단 fixed):
  - 🔧 **내 무기고** (player team graves 시, 파란)
  - 🔧 **상대 무기고** (opponent graves 시, 빨간)
  - 카운트 배지 — picks.length

## 데이터 스키마

**변경 없음** — \`TeamFactoryNewStateSchema.upgradePath: string[]\` 이미 존재 (\`src/lib/actualData/schema.ts\`):

\`\`\`ts
factoryNew: { upgradePath: string[]; nextUpgradeRoundsRemaining?: number }
\`\`\`

라운드별로 \`upgradePath\` 가 따로 저장되어 라운드 전환 시 각자 보존.

## 동작

1. PvP 라운드에 그레이브즈 → 우하단 floating button 활성
2. 클릭 → 모달 (헤더에 \"내 팀/상대 — 라운드 X-Y\" 표시)
3. 카드 선택 → \`factoryNew.upgradePath\` 저장 (자동 persist)
4. 다른 라운드 이동 시 picks 그대로 유지
5. **라운드 별 독립 picks** — 같은 게임의 라운드 4-1, 4-2, 4-3 각각 다른 picks 가능

## Test plan
- [x] \`pnpm vitest run\`: 522/522 pass
- [x] \`pnpm lint\`: 0 errors
- [x] \`pnpm typecheck\`: clean
- [x] \`pnpm build\`: success
- [ ] (manual) /actual-data PvP 라운드에 그레이브즈 placement → 무기고 편집 → 다른 라운드 가도 picks 유지 확인

## 후속 (별도 PR)
- ShrineRound 등 다른 round type 도 graves 무기고 표시 (현재 PvP only)
- \`/api/simulate\` route 에 \`playerGravesUpgrades\` / \`playerGravesFrame\` 옵션 추가
  → server-side 전투 시뮬에서도 무기고 효과 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)