### PR TITLE
fix(simulator): F2 — healAmp 8 heal 사이트 일관 적용

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -2722,7 +2722,8 @@ export function simulateCombat(
     if (hasMaokai && state.maokaiHealPct > 0) {
       for (const u of state.teamUnits) {
         if (u.state === 'dead') continue;
-        const heal = u.maxHp * state.maokaiHealPct;
+        // healAmp 곱셈 적용 — GrenadeMod_Radiant 등 회복량 증폭 효과 반영.
+        const heal = u.maxHp * state.maokaiHealPct * (1 + (u.healAmp ?? 0));
         u.currentHp = Math.min(u.maxHp, u.currentHp + heal);
       }
     }
@@ -2815,7 +2816,8 @@ export function simulateCombat(
       }
     }
     if (!lowest) return;
-    const healAmount = totalAbilityDmg * caster.stargazerFountainHealPercent;
+    // healAmp 곱셈 적용 — Fountain heal 은 17.2 비활성 (legacy) 이지만 reactivate 시 일관성 보장.
+    const healAmount = totalAbilityDmg * caster.stargazerFountainHealPercent * (1 + (lowest.healAmp ?? 0));
     lowest.currentHp = Math.min(lowest.maxHp, lowest.currentHp + healAmount);
     const healLog: CombatLog = {
       tick: castTick, time: castTime, type: 'ability',
@@ -2864,7 +2866,8 @@ export function simulateCombat(
       for (const h of huntressTeam) {
         if (h.state === 'dead') continue;
         if (h.stargazerHuntressHealPercent <= 0) continue;
-        const healAmount = h.maxHp * h.stargazerHuntressHealPercent;
+        // healAmp 곱셈 적용 — GrenadeMod_Radiant 등 회복량 증폭 효과 반영.
+        const healAmount = h.maxHp * h.stargazerHuntressHealPercent * (1 + (h.healAmp ?? 0));
         h.currentHp = Math.min(h.maxHp, h.currentHp + healAmount);
       }
     });
@@ -3290,7 +3293,8 @@ export function simulateCombat(
 
           if (unit.omnivamp > 0 && finalDamage > 0) {
             const grievousReduction = target.augmentGrievousWounds > 0 ? (1 - target.augmentGrievousWounds) : 1;
-            const heal = finalDamage * unit.omnivamp * grievousReduction;
+            // healAmp 곱셈 적용 — 모든 피해 흡혈 (omnivamp) 도 회복량 증폭 효과 대상.
+            const heal = finalDamage * unit.omnivamp * grievousReduction * (1 + (unit.healAmp ?? 0));
             unit.currentHp = Math.min(unit.maxHp, unit.currentHp + heal);
             eventBus.emit('on_heal', { sourceId: unit.id, value: heal, tick });
           }
@@ -3338,10 +3342,10 @@ export function simulateCombat(
             // 별돌보미 뱀(Serpent) — DoubleTap 추가 hit 도 중독 적용.
             triggerSerpentPoison(unit, target, extraFinal);
 
-            // omnivamp 도 추가 hit 에 적용 (attack 1회 와 동일).
+            // omnivamp 도 추가 hit 에 적용 (attack 1회 와 동일). healAmp 곱셈 적용.
             if (unit.omnivamp > 0 && extraFinal > 0) {
               const grievousReduction = target.augmentGrievousWounds > 0 ? (1 - target.augmentGrievousWounds) : 1;
-              const heal = extraFinal * unit.omnivamp * grievousReduction;
+              const heal = extraFinal * unit.omnivamp * grievousReduction * (1 + (unit.healAmp ?? 0));
               unit.currentHp = Math.min(unit.maxHp, unit.currentHp + heal);
               eventBus.emit('on_heal', { sourceId: unit.id, value: heal, tick });
             }
@@ -3427,10 +3431,11 @@ export function simulateCombat(
                 sDmg = applyShield(target, sDmg, eventBus, tick);
                 target.currentHp -= sDmg;
                 unit.totalDamageDealt += sDmg;
-                // 피오라 급소 회복
+                // 피오라 급소 회복 — healAmp 곱셈 적용.
                 const healPct = atkSc.healPercent as number | undefined;
                 if (healPct && sDmg > 0) {
-                  unit.currentHp = Math.min(unit.maxHp, unit.currentHp + sDmg * healPct);
+                  const healAmount = sDmg * healPct * (1 + (unit.healAmp ?? 0));
+                  unit.currentHp = Math.min(unit.maxHp, unit.currentHp + healAmount);
                 }
               }
             }
@@ -3681,10 +3686,10 @@ export function simulateCombat(
               }
             }
 
-            // 전체 피해량 기반 흡혈
+            // 전체 피해량 기반 흡혈 — healAmp 곱셈 적용.
             if (unit.omnivamp > 0 && totalAbilityDmg > 0) {
               const grievousReduction = target.augmentGrievousWounds > 0 ? (1 - target.augmentGrievousWounds) : 1;
-              const heal = totalAbilityDmg * unit.omnivamp * grievousReduction;
+              const heal = totalAbilityDmg * unit.omnivamp * grievousReduction * (1 + (unit.healAmp ?? 0));
               unit.currentHp = Math.min(unit.maxHp, unit.currentHp + heal);
             }
 
@@ -3726,7 +3731,9 @@ export function simulateCombat(
                   ? (healVal < 1 ? Math.round(unit.maxHp * healVal) : Math.round(healVal * (1 + unit.stats.ap / 100)))
                   : 0;
                 if (healAmount > 0) {
-                  unit.currentHp = Math.min(unit.maxHp, unit.currentHp + healAmount);
+                  // healAmp 곱셈 적용 — ability self-heal 도 회복량 증폭 효과 대상.
+                  const finalHeal = healAmount * (1 + (unit.healAmp ?? 0));
+                  unit.currentHp = Math.min(unit.maxHp, unit.currentHp + finalHeal);
                 }
               }
             }

--- a/tests/unit/simulator/heal-amp-integration.test.ts
+++ b/tests/unit/simulator/heal-amp-integration.test.ts
@@ -80,21 +80,49 @@ describe('healAmp 곱셈 동작 — combatLoop heal 사이트 8곳 일관 적용
 
 describe('healAmp 적용 사이트 코드 grep — 회귀 안전성', () => {
   /**
-   * 8 사이트 모두 `(1 + (X.healAmp ?? 0))` 패턴을 코드에 포함하는지 grep 가드.
-   * source 코드 자체를 문자열로 읽어 패턴 매칭 — 미적용 회귀 시 즉시 실패.
+   * 9 사이트 모두 `(1 + (X.healAmp ?? 0))` 패턴 + 사이트별 fingerprint 검증.
+   * 1 곳이라도 빠지면 실패 (codex P2 — `>=8` 으로는 1개 누락 검출 불가능).
+   *
+   * 카운트 변경 시 (heal site 추가 / 제거) 본 expectedCount + sites 배열 갱신 필수 —
+   * 의도된 gate.
    */
-  it('combatLoop.ts 가 8 heal 사이트 모두에 healAmp 곱셈 포함', async () => {
+  it('combatLoop.ts 가 9 heal 사이트 모두에 healAmp 곱셈 포함 (정확 카운트)', async () => {
     const fs = await import('node:fs');
     const path = await import('node:path');
     const file = fs.readFileSync(
       path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
       'utf8',
     );
-    // 모든 heal 사이트의 healAmp 곱셈 패턴
     const patternA = /\* \(1 \+ \(\w+\.healAmp \?\? 0\)\)/g;
     const matches = file.match(patternA);
     expect(matches, 'healAmp 곱셈 패턴이 코드에 포함되어야 함').toBeDefined();
-    // 8 heal 사이트 + 기존 1곳 (Fountain stacking) = 최소 8 매치
-    expect(matches!.length).toBeGreaterThanOrEqual(8);
+    // PR #52: 8 신규 사이트 + 기존 1 (Fountain stacking, line 3122) = 정확 9 매치.
+    // 새 heal 사이트 추가 시 본 카운트도 갱신 필수.
+    expect(matches!.length).toBe(9);
+  });
+
+  it('각 heal 사이트별 fingerprint — 의미 단위 회귀 가드', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // 각 heal 사이트의 핵심 expression 직접 매치 — 1곳이라도 빠지면 실패.
+    const sites: Array<{ name: string; pattern: RegExp }> = [
+      { name: 'Maokai N.O.V.A teamwide heal', pattern: /u\.maxHp \* state\.maokaiHealPct \* \(1 \+ \(u\.healAmp \?\? 0\)\)/ },
+      { name: 'Fountain heal (legacy)', pattern: /totalAbilityDmg \* caster\.stargazerFountainHealPercent \* \(1 \+ \(lowest\.healAmp \?\? 0\)\)/ },
+      { name: 'Stargazer 사냥꾼 표식 사망 heal', pattern: /h\.maxHp \* h\.stargazerHuntressHealPercent \* \(1 \+ \(h\.healAmp \?\? 0\)\)/ },
+      { name: 'basic attack omnivamp', pattern: /finalDamage \* unit\.omnivamp \* grievousReduction \* \(1 \+ \(unit\.healAmp \?\? 0\)\)/ },
+      { name: 'extra hit (DoubleTap) omnivamp', pattern: /extraFinal \* unit\.omnivamp \* grievousReduction \* \(1 \+ \(unit\.healAmp \?\? 0\)\)/ },
+      { name: 'Fiora 급소 회복 (atkSc.healPercent)', pattern: /sDmg \* healPct \* \(1 \+ \(unit\.healAmp \?\? 0\)\)/ },
+      { name: 'ability omnivamp', pattern: /totalAbilityDmg \* unit\.omnivamp \* grievousReduction \* \(1 \+ \(unit\.healAmp \?\? 0\)\)/ },
+      { name: 'ability self-heal (Heal/APHeal/PercentMaximumHealthHealing)', pattern: /healAmount \* \(1 \+ \(unit\.healAmp \?\? 0\)\)/ },
+      // 기존 1곳 (Fountain stacking, line 3122) — `healBase * (1 + (u.healAmp ?? 0))`
+      { name: 'Fountain stacking heal (PR #41 기존)', pattern: /healBase \* \(1 \+ \(u\.healAmp \?\? 0\)\)/ },
+    ];
+    for (const { name, pattern } of sites) {
+      expect(file, `heal 사이트 missing: ${name}`).toMatch(pattern);
+    }
   });
 });

--- a/tests/unit/simulator/heal-amp-integration.test.ts
+++ b/tests/unit/simulator/heal-amp-integration.test.ts
@@ -1,0 +1,100 @@
+/**
+ * 회귀 가드 — healAmp (회복량 증폭) 가 모든 heal 사이트에 일관 적용되는지 검증.
+ *
+ * 도입 배경:
+ *   PsyOps GrenadeMod_Radiant (IncreasedHealing 0.22) 는 raw item effect 로
+ *   unit.healAmp 에 0.22 누적. 이 healAmp 는 모든 heal site 에 (1 + healAmp)
+ *   곱셈으로 적용되어야 하는데, 17.2 fetch 시점엔 일부 heal (Fountain stacking) 만
+ *   적용되고 omnivamp / 마오카이 N.O.V.A / 사냥꾼 표식 / ability self-heal 등
+ *   8 사이트 미적용 회귀 발생.
+ *
+ * 본 테스트는 unit.healAmp 를 직접 set 하여 healAmp 가 곱셈으로 동작하는지
+ * 단위 검증. 실제 GrenadeMod_Radiant 시뮬은 별도 PR #41 가드에서 처리.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits, items } = loadServerCatalogs();
+const apTwistedFate = champions.find(c => c.apiName === 'TFT17_TwistedFate')!;
+const apAatrox = champions.find(c => c.apiName === 'TFT17_Aatrox')!;
+// Bloodthirster — 기본 omnivamp 0.25 (정규 raw item)
+const bloodthirster = items.find(i => i.apiName === 'TFT_Item_Bloodthirster')!;
+
+function placed(c: RawChampion, q: number, r: number, starLevel: number = 2, eqItems = []): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: eqItems };
+}
+
+describe('healAmp — omnivamp heal 통합 (line 3294 / 3349 / 3692)', () => {
+  it('Bloodthirster 흡혈검 (omnivamp 0.25) 만 보유 시 healAmp=0 → 입힌 피해의 25% 회복', () => {
+    const team: PlacedChampion[] = [
+      placed(apTwistedFate, 0, 0, 2, [bloodthirster] as never[]),
+    ];
+    const enemy: PlacedChampion[] = [placed(apAatrox, 6, 3, 2)];
+
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+
+    const tf = result.playerUnits.find(u => u.champion.apiName === 'TFT17_TwistedFate')!;
+    expect(tf.omnivamp).toBeGreaterThan(0); // bloodthirster 효과 적용됨
+    expect(tf.healAmp).toBe(0); // healAmp 미적용
+  });
+
+  it('healAmp 자체가 default 0 (CombatUnit init 기본값)', () => {
+    const team = [placed(apTwistedFate, 0, 0, 2)];
+    const enemy = [placed(apAatrox, 6, 3, 2)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    expect(result.playerUnits[0].healAmp).toBe(0);
+  });
+});
+
+describe('healAmp 곱셈 동작 — combatLoop heal 사이트 8곳 일관 적용', () => {
+  /**
+   * 본 테스트는 codebase 정합성 가드 — heal 곱셈이 빠진 회귀 검출.
+   *
+   * Production 시뮬에서 healAmp 부여 source 는 GrenadeMod_Radiant (PsyOps,
+   * 본인 unit 만, 자동 swap) 1종 뿐. healAmp 효과 자체의 시뮬 검증은 별도
+   * (PR #41 psyops-heal-amp.test.ts).
+   *
+   * 본 가드는 "healAmp=0 일 때 회복이 변하지 않음" + "코드 grep 으로
+   * 8 사이트 모두 (1 + healAmp) 곱셈 포함" 을 보장.
+   */
+  it('healAmp=0 시 시뮬 결과는 healAmp 적용 전과 동일 (회귀 안전성)', () => {
+    const team: PlacedChampion[] = [
+      placed(apTwistedFate, 0, 0, 2, [bloodthirster] as never[]),
+    ];
+    const enemy: PlacedChampion[] = [placed(apAatrox, 6, 3, 2)];
+
+    const result = simulateCombat(team, enemy, {
+      seed: 42, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    // 시뮬 정상 종료 + heal 사이트가 healAmp=0 일 때도 정상 동작
+    expect(result.winner).toBeDefined();
+    expect(result.duration).toBeGreaterThan(0);
+  });
+});
+
+describe('healAmp 적용 사이트 코드 grep — 회귀 안전성', () => {
+  /**
+   * 8 사이트 모두 `(1 + (X.healAmp ?? 0))` 패턴을 코드에 포함하는지 grep 가드.
+   * source 코드 자체를 문자열로 읽어 패턴 매칭 — 미적용 회귀 시 즉시 실패.
+   */
+  it('combatLoop.ts 가 8 heal 사이트 모두에 healAmp 곱셈 포함', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // 모든 heal 사이트의 healAmp 곱셈 패턴
+    const patternA = /\* \(1 \+ \(\w+\.healAmp \?\? 0\)\)/g;
+    const matches = file.match(patternA);
+    expect(matches, 'healAmp 곱셈 패턴이 코드에 포함되어야 함').toBeDefined();
+    // 8 heal 사이트 + 기존 1곳 (Fountain stacking) = 최소 8 매치
+    expect(matches!.length).toBeGreaterThanOrEqual(8);
+  });
+});


### PR DESCRIPTION
## Summary
PsyOps GrenadeMod_Radiant (IncreasedHealing 0.22) 도입 시 healAmp 가 1 사이트만 적용 → 나머지 8 사이트 미적용 회귀 일괄 수정.

## 회귀 시나리오 (이전)
- GrenadeMod_Radiant 보유 unit 의 healAmp = 0.22
- omnivamp / 마오카이 N.O.V.A / 사냥꾼 표식 / ability self-heal 사용 시 +22% 적용 안 됨
- 회복량 차이만큼 시뮬 정확도 저하

## 수정한 8 heal 사이트

| # | 라인 | 효과 | 변경 |
|---|---|---|---|
| 1 | 2725 | 마오카이 N.O.V.A 6초 후 teamwide heal | `× (1 + u.healAmp)` |
| 2 | 2820 | Fountain heal (legacy 비활성) | `× (1 + lowest.healAmp)` |
| 3 | 2870 | 사냥꾼 표식 사망 heal | `× (1 + h.healAmp)` |
| 4 | 3297 | basic attack omnivamp | `× (1 + unit.healAmp)` |
| 5 | 3349 | extra hit (DoubleTap) omnivamp | `× (1 + unit.healAmp)` |
| 6 | 3437 | Fiora 급소 회복 (atkSc.healPercent) | `× (1 + unit.healAmp)` |
| 7 | 3692 | ability omnivamp | `× (1 + unit.healAmp)` |
| 8 | 3729 | ability self-heal (Heal/APHeal/PercentMaximumHealthHealing) | `× (1 + unit.healAmp)` |

> **omnivamp** = TFT 한국어 \"모든 피해 흡혈\" (basic + ability + true 모두 회복).

## 회귀 가드 (\`tests/unit/simulator/heal-amp-integration.test.ts\`, 4 cases)
- healAmp default 0 검증
- Bloodthirster omnivamp + healAmp=0 시뮬 정상 종료
- **combatLoop.ts grep 가드** — \`* (1 + (X.healAmp ?? 0))\` 패턴 8+ 매치
  → 향후 새 heal 사이트 추가 시 healAmp 곱셈 누락 회귀 즉시 차단

## Test plan
- [x] \`pnpm vitest run\`: 526/526 pass (신규 4 cases)
- [x] \`pnpm lint\`: 0 errors
- [x] \`pnpm typecheck\`: clean
- [x] \`pnpm build\`: success

## Note
- Fountain heal 은 17.2 비활성 (legacy) 이지만 reactivate 시 일관성 보장 위해 같이 적용.
- healAmp 부여 source 는 현재 GrenadeMod_Radiant 1종 — 향후 다른 \"회복량 증폭\" augment 도입 시 자동 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)