### PR TITLE
G2 Phase 3B-1 — 최신상 무기고 공격 횟수/sticky stack 4종

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-30T00:58:04.303Z",
+  "computedAt": "2026-04-30T01:03:34.067Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "b9033f3f6e4a8212eea67dd68e0405b80f10b5d5",
+  "engineSha": "a16c1290957e4a8d6fe7eb9b850c0d1aaad1e5ae",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-30T00:29:00.772Z",
+  "computedAt": "2026-04-30T00:58:04.303Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "29752aa29271321dd2e52bf92b1c4586a77acd1a",
+  "engineSha": "b9033f3f6e4a8212eea67dd68e0405b80f10b5d5",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-04-30T00:29:02.031Z",
+  "computedAt": "2026-04-30T00:58:05.572Z",
   "sourceGameMtime": 1777278310429,
-  "engineSha": "29752aa29271321dd2e52bf92b1c4586a77acd1a",
+  "engineSha": "b9033f3f6e4a8212eea67dd68e0405b80f10b5d5",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-04-30T00:58:05.572Z",
+  "computedAt": "2026-04-30T01:03:35.333Z",
   "sourceGameMtime": 1777278310429,
-  "engineSha": "b9033f3f6e4a8212eea67dd68e0405b80f10b5d5",
+  "engineSha": "a16c1290957e4a8d6fe7eb9b850c0d1aaad1e5ae",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/docs/meta/set17-graves-factory-tree.md
+++ b/docs/meta/set17-graves-factory-tree.md
@@ -199,8 +199,9 @@ Set 17 그레이브즈 전용 시너지 **`최신상`(GravesTrait)** 의 핵심 
 |---|---|---|---|
 | **Phase 1** | Frame 3종 (root) — stat / mechanic | #45 | ✅ 머지 완료 (8bccb64) |
 | **Phase 2** | 단순 stat upgrade 18종 | #46 | ✅ 머지 완료 (41d561f) |
-| **Phase 3A** | 메커닉 단순 트리거 / periodic 8종 | (본 PR) | 🟢 작업 중 |
-| **Phase 3B** | 메커닉 공격 횟수 변종 + onKill 7종 | — | ❌ 미구현 |
+| **Phase 3A** | 메커닉 단순 트리거 / periodic 8종 | #54 | ✅ 머지 완료 |
+| **Phase 3B-1** | 공격 횟수 변종 + sticky stack 4종 | (본 PR) | 🟢 작업 중 |
+| **Phase 3B-2** | onKill / dash / 누적 폭발 3종 | — | ❌ 미구현 |
 | **Phase 3C** | 메커닉 AOE / 투사체 10종 | — | ❌ 미구현 |
 | **Phase 3D** | 메커닉 복합 5종 | — | ❌ 미구현 |
 | **Phase 4** | tree 시각화 + round-by-round 선택 UI | #49,50,51 | ✅ 머지 완료 |
@@ -215,8 +216,13 @@ Tankbuster, Coolant/2, APRounds/2, SheerMass
 - **전투 시작 1회**: Shockwave (가까운 적 2명 maxHp×15% 마법 + 2s stun)
 - **onAttack debuff stack**: RipperBullets/2 (평타 시 적 armor/MR -1/-2)
 
-### Phase 3B/3C/3D 메커닉 잔여 23종 분류
-- **3B 공격 횟수 / onKill (~7)**: DoubleTap2, TripleTap, RevUp/2, GravBooster/2, LatentExplosion
+### Phase 3B-1 4종 (공격 횟수 변종 + sticky stack)
+- DoubleTap2 (35% chance — Frame DoubleTap 25% 와 max() override)
+- TripleTap (18% chance × 추가 2 hit, DoubleTap 와 mutual exclusive roll)
+- RevUp/2 (sticky target 연속 공격 stack — AS +8/15% per stack, max +80/150%)
+
+### Phase 3B-2/3C/3D 메커닉 잔여 18종 분류
+- **3B-2 onKill / dash (~3)**: GravBooster/2, LatentExplosion
 - **3C AOE / 투사체 (~10)**: Buckshot/2/3, LaserBallistics, FragmentationRounds/2, BlastRadius/2/3, SympatheticDetonation, Meltthrough
 - **3D 복합 (~5)**: VoidCoefficient, Choke, AimAssistant, Heartseeker3 확장
 

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -196,6 +196,11 @@ function createCombatUnit(
     gravesShockwaveActive: false,
     gravesReactivePerStack: 0,
     gravesReactiveStackCount: 0,
+    gravesTripleAttackChance: 0,
+    gravesRevUpPerStack: 0,
+    gravesRevUpMaxBonus: 0,
+    gravesRevUpStickyTargetId: null,
+    gravesRevUpStackCount: 0,
     gragasCarryActive: false,
     leonaCarryActive: false,
     attackCount: 0,
@@ -1320,6 +1325,21 @@ const GRAVES_STAT_UPGRADE_HANDLERS: Record<string, (u: CombatUnit, baseAd: numbe
   },
   Shockwave:          (u)     => { u.gravesShockwaveActive = true; },
   ReactiveArmor:      (u)     => { u.gravesReactivePerStack = Math.max(u.gravesReactivePerStack, 4); },
+  // Phase 3B-1 — DoubleTap2/TripleTap chance + RevUp/2 sticky stack.
+  // DoubleTap2 (35%) 는 Frame DoubleTap (25%) 와 같은 필드 max() override.
+  DoubleTap2:         (u)     => { u.gravesDoubleAttackChance = Math.max(u.gravesDoubleAttackChance, 0.35); },
+  TripleTap:          (u)     => { u.gravesTripleAttackChance = Math.max(u.gravesTripleAttackChance, 0.18); },
+  RevUp:              (u)     => {
+    if (u.gravesRevUpPerStack < 0.08) {
+      u.gravesRevUpPerStack = 0.08;
+      u.gravesRevUpMaxBonus = 0.80;
+    }
+  },
+  RevUp2:             (u)     => {
+    // tier 2 가 더 높으니 항상 override.
+    u.gravesRevUpPerStack = 0.15;
+    u.gravesRevUpMaxBonus = 1.50;
+  },
 };
 
 /**
@@ -1361,7 +1381,13 @@ const GRAVES_UPGRADE_APPLY_ORDER: ReadonlyArray<string> = [
   'RipperBullets',
   'RipperBullets2',
   'Shockwave',
-  // 4. % multiplier (가장 마지막 — 1·2 단계의 flat HP/AD 가산 후 적용)
+  // 4. Phase 3B-1 — chance / sticky stack (정렬 — 결정성).
+  //    RevUp 먼저, RevUp2 가 override (강제 max-tier 가지므로 순서 중요).
+  'DoubleTap2',
+  'RevUp',
+  'RevUp2',
+  'TripleTap',
+  // 5. % multiplier (가장 마지막 — 1·2 단계의 flat HP/AD 가산 후 적용)
   'SheerMass',
 ];
 
@@ -1827,6 +1853,15 @@ function getEffectiveAttackSpeed(unit: CombatUnit): number {
     as *= (1 + missingPct * asPerPct * apScale);
   }
 
+  // 최신상 RevUp/2 — 같은 대상 연속 공격 stack 한정 AS 가산 (cap = MaxBonus).
+  if (unit.gravesRevUpPerStack > 0 && unit.gravesRevUpStackCount > 0) {
+    const bonus = Math.min(
+      unit.gravesRevUpStackCount * unit.gravesRevUpPerStack,
+      unit.gravesRevUpMaxBonus,
+    );
+    as *= (1 + bonus);
+  }
+
   return as;
 }
 
@@ -1912,6 +1947,11 @@ function spawnFreljordTurrets(
             gravesShockwaveActive: false,
             gravesReactivePerStack: 0,
             gravesReactiveStackCount: 0,
+            gravesTripleAttackChance: 0,
+            gravesRevUpPerStack: 0,
+            gravesRevUpMaxBonus: 0,
+            gravesRevUpStickyTargetId: null,
+            gravesRevUpStackCount: 0,
             gragasCarryActive: false,
             leonaCarryActive: false,
             attackCount: 0,
@@ -2069,6 +2109,11 @@ function trySpawnGalio(
     gravesShockwaveActive: false,
     gravesReactivePerStack: 0,
     gravesReactiveStackCount: 0,
+    gravesTripleAttackChance: 0,
+    gravesRevUpPerStack: 0,
+    gravesRevUpMaxBonus: 0,
+    gravesRevUpStickyTargetId: null,
+    gravesRevUpStackCount: 0,
     gragasCarryActive: false,
     leonaCarryActive: false,
     attackCount: 0,
@@ -3447,6 +3492,17 @@ export function simulateCombat(
           target.totalDamageTaken += finalDamage;
           unit.totalDamageDealt += finalDamage;
 
+          // 최신상 RevUp/2 — sticky target 매칭 시 stack++, 다른 대상 시 reset.
+          // 한 공격 = 1 stack (DoubleTap/TripleTap extra hit 은 별도 카운트 안 함).
+          if (unit.gravesRevUpPerStack > 0) {
+            if (unit.gravesRevUpStickyTargetId === target.id) {
+              unit.gravesRevUpStackCount++;
+            } else {
+              unit.gravesRevUpStickyTargetId = target.id;
+              unit.gravesRevUpStackCount = 0;
+            }
+          }
+
           // 최신상 EmergencyShielding/2 — codex P1: damage application 직후 즉시 체크
           // (1-tick burst 시 후속 hit 부터 shield 흡수 보장).
           maybeTriggerEmergencyShield(target);
@@ -3476,13 +3532,25 @@ export function simulateCombat(
             eventBus.emit('on_heal', { sourceId: unit.id, value: heal, tick });
           }
 
-          // 최신상 (GravesTrait) DoubleTap Frame — 25% 확률 추가 1회 공격.
+          // 최신상 (GravesTrait) DoubleTap / TripleTap — 추가 hit 발동.
+          //   - DoubleTap Frame (25%) + DoubleTap2 weapon (35%) 는 같은 필드 max() override.
+          //   - TripleTap weapon (18%) 은 별개 roll — 발동 시 2 추가 hit, DoubleTap path skip (mutual exclusive).
           // codex P1 가드: rawDamage 부터 mitigation pipeline 다시 거쳐야 (shielded target
           // 에 첫 hit post-shield 값 재사용 시 under-damage 발생).
           // codex P2 가드: 풀 attack 이벤트 emit (on_attack/on_damage/on_hit/on_hit_taken)
           // — item runtime counter 등 attack-count 기반 시스템 정확 작동.
-          if (unit.gravesDoubleAttackChance > 0 && target.state !== 'dead'
-              && rng.next() < unit.gravesDoubleAttackChance) {
+          let extraHits = 0;
+          let extraHitReason = '사수 프레임 추가 공격';
+          if (target.state !== 'dead') {
+            if (unit.gravesTripleAttackChance > 0 && rng.next() < unit.gravesTripleAttackChance) {
+              extraHits = 2;
+              extraHitReason = '한 발에 세 놈 추가 공격';
+            } else if (unit.gravesDoubleAttackChance > 0 && rng.next() < unit.gravesDoubleAttackChance) {
+              extraHits = 1;
+            }
+          }
+          for (let extraHitIdx = 0; extraHitIdx < extraHits; extraHitIdx++) {
+            if (target.state === 'dead') break;
             // 새 hit — rawDamage 재사용 (동일 source stats 기반) + mitigation 재계산.
             // 단, crit 은 첫 hit 와 동일하게 취급 (rawDamage 에 critMult 이미 포함).
             let extraFinal = applyResistance(rawDamage, target.stats.armor, unit.stats.armorPen);
@@ -3498,7 +3566,7 @@ export function simulateCombat(
             unit.totalDamageDealt += extraFinal;
             unit.attackCount++;
 
-            // 최신상 EmergencyShielding/2 — codex P1: DoubleTap 추가 hit 직후도 즉시 체크.
+            // 최신상 EmergencyShielding/2 — codex P1: DoubleTap/TripleTap 추가 hit 직후도 즉시 체크.
             maybeTriggerEmergencyShield(target);
 
             // 풀 attack 이벤트 emit — 일반 평타와 동일 path.
@@ -3507,13 +3575,13 @@ export function simulateCombat(
             eventBus.emit('on_damage', { sourceId: target.id, targetId: unit.id, value: extraFinal, damageType: 'physical', tick });
             eventBus.emit('on_hit_taken', { sourceId: target.id, targetId: unit.id, value: extraFinal, damageType: 'physical', tick });
 
-            // 최신상 RipperBullets/2 — DoubleTap 추가 hit 도 동일하게 armor/MR shred.
+            // 최신상 RipperBullets/2 — 추가 hit 도 동일하게 armor/MR shred.
             // state 'dead' 마킹은 아래 currentHp <= 0 분기에서 처리 → 여기선 currentHp 만 가드.
             if (unit.gravesRipperReduce > 0 && target.currentHp > 0) {
               target.stats.armor = Math.max(0, target.stats.armor - unit.gravesRipperReduce);
               target.stats.magicResist = Math.max(0, target.stats.magicResist - unit.gravesRipperReduce);
             }
-            // 최신상 ReactiveArmor — DoubleTap 추가 hit 도 stack 누적.
+            // 최신상 ReactiveArmor — 추가 hit 도 stack 누적.
             if (target.gravesReactivePerStack > 0 && target.gravesReactiveStackCount < 50 && target.currentHp > 0) {
               target.stats.armor += target.gravesReactivePerStack;
               target.stats.magicResist += target.gravesReactivePerStack;
@@ -3526,13 +3594,13 @@ export function simulateCombat(
               unit.killCount++;
               if (unit.team === 'player') playerArbiterState.enemyDeathCount++;
               else enemyArbiterState.enemyDeathCount++;
-              const dlog: CombatLog = { tick, time, type: 'death', sourceId: target.id, message: `${target.champion.name} 사망! (사수 프레임 추가 공격)` };
+              const dlog: CombatLog = { tick, time, type: 'death', sourceId: target.id, message: `${target.champion.name} 사망! (${extraHitReason})` };
               logs.push(dlog); tickLogs.push(dlog);
               eventBus.emit('on_kill', { sourceId: unit.id, targetId: target.id, tick });
               eventBus.emit('on_death', { sourceId: target.id, targetId: unit.id, tick });
             }
 
-            // 별돌보미 뱀(Serpent) — DoubleTap 추가 hit 도 중독 적용.
+            // 별돌보미 뱀(Serpent) — 추가 hit 도 중독 적용.
             triggerSerpentPoison(unit, target, extraFinal);
 
             // omnivamp 도 추가 hit 에 적용 (attack 1회 와 동일). healAmp 곱셈 적용.

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -3494,12 +3494,14 @@ export function simulateCombat(
 
           // 최신상 RevUp/2 — sticky target 매칭 시 stack++, 다른 대상 시 reset.
           // 한 공격 = 1 stack (DoubleTap/TripleTap extra hit 은 별도 카운트 안 함).
+          // codex P2: sticky target 을 잡는 hit 도 자체로 1 stack — raw "AttackSpeedPerAttack"
+          // semantics 정합. 0 으로 reset 하면 다음 attack 까지 AS bonus 1 stack 늦게 시작.
           if (unit.gravesRevUpPerStack > 0) {
             if (unit.gravesRevUpStickyTargetId === target.id) {
               unit.gravesRevUpStackCount++;
             } else {
               unit.gravesRevUpStickyTargetId = target.id;
-              unit.gravesRevUpStackCount = 0;
+              unit.gravesRevUpStackCount = 1;
             }
           }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -575,6 +575,23 @@ export interface CombatUnit {
   /** ReactiveArmor 누적 stack 수. 0..50 사이 제한. */
   gravesReactiveStackCount: number;
   /**
+   * TripleTap (한 발에 세 놈) 업그레이드 — N% 확률 추가 2 hit (총 3회).
+   * 0 = 미활성 / 0.18 = 활성. DoubleTap Frame / DoubleTap2 와 별개 roll —
+   * TripleTap 발동 시 DoubleTap path skip (중복 방지).
+   */
+  gravesTripleAttackChance: number;
+  /**
+   * RevUp/2 (엔진 가동) 업그레이드 — 같은 대상 연속 공격마다 AS +N% stack.
+   * 0 = 미활성 / 0.08 = RevUp / 0.15 = RevUp2.
+   */
+  gravesRevUpPerStack: number;
+  /** RevUp/2 누적 AS bonus 한도. 0 / 0.80 (RevUp) / 1.50 (RevUp2). */
+  gravesRevUpMaxBonus: number;
+  /** RevUp/2 sticky target id — 마지막 공격 대상. 다른 대상 공격 시 stack reset. */
+  gravesRevUpStickyTargetId: string | null;
+  /** RevUp/2 누적 stack 수. 같은 target 연속 공격 시 ++, 다른 target 시 0. */
+  gravesRevUpStackCount: number;
+  /**
    * 자폭(TFT17_Augment_GragasCarry) 활성 + 가장 강한 그라가스로 선정된 unit 만 true.
    * 그라가스 ability 가 거대한 폭발 (자기 자신 데미지, 다른 아군 X) 로 변환되며,
    * 자폭 데미지로 hp 가 1 미만으로 떨어지지 않음 (HP floor=1).

--- a/tests/unit/simulator/graves-factory-phase3b-1.test.ts
+++ b/tests/unit/simulator/graves-factory-phase3b-1.test.ts
@@ -1,0 +1,153 @@
+/**
+ * 회귀 가드 — 최신상 (TFT17_GravesTrait) 무기고 Phase 3B-1 — 메커닉 4종.
+ *
+ * 적용 4종 (raw effects):
+ *   DoubleTap2  DoubleAttackChance=0.35   (Frame DoubleTap 25% 와 max() override)
+ *   TripleTap   TripleAttackChance=0.18   (별개 roll, 발동 시 추가 2 hit, DoubleTap path skip)
+ *   RevUp       AttackSpeedPerAttack=0.08, MaxAttackSpeed=0.80
+ *   RevUp2      AttackSpeedPerAttack=0.15, MaxAttackSpeed=1.50
+ *
+ * Phase 3B-2 (GravBooster/2 + LatentExplosion) 는 후속 PR.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+const apGraves = champions.find(c => c.apiName === 'TFT17_Graves')!;
+const dummyEnemy = champions.find(c => c.apiName === 'TFT17_Aatrox')!;
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: [] };
+}
+
+function runWith(upgrades: string[], frame?: 'CloseQuarters' | 'SharpshooterModule' | 'DoubleTap') {
+  const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+  const enemy: PlacedChampion[] = [placed(dummyEnemy, 6, 3)];
+  return simulateCombat(team, enemy, {
+    seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    playerGravesUpgrades: upgrades,
+    playerGravesFrame: frame,
+  });
+}
+
+function gravesOf(result: ReturnType<typeof runWith>) {
+  return result.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!;
+}
+
+describe('GravesTrait Phase 3B-1 — DoubleTap2 (35% chance, Frame override)', () => {
+  it('DoubleTap2 → gravesDoubleAttackChance = 0.35', () => {
+    const grav = gravesOf(runWith(['DoubleTap2']));
+    expect(grav.gravesDoubleAttackChance).toBeCloseTo(0.35, 3);
+    expect(grav.gravesUpgrades).toContain('DoubleTap2');
+  });
+
+  it('Frame DoubleTap (0.25) + DoubleTap2 (0.35) 동시 활성 → max 0.35', () => {
+    const grav = gravesOf(runWith(['DoubleTap2'], 'DoubleTap'));
+    expect(grav.gravesDoubleAttackChance).toBeCloseTo(0.35, 3);
+  });
+
+  it('DoubleTap2 미사용 + Frame DoubleTap 만 → 0.25 유지', () => {
+    const grav = gravesOf(runWith([], 'DoubleTap'));
+    expect(grav.gravesDoubleAttackChance).toBeCloseTo(0.25, 3);
+  });
+});
+
+describe('GravesTrait Phase 3B-1 — TripleTap (18% chance, 추가 2 hit)', () => {
+  it('TripleTap → gravesTripleAttackChance = 0.18', () => {
+    const grav = gravesOf(runWith(['TripleTap']));
+    expect(grav.gravesTripleAttackChance).toBeCloseTo(0.18, 3);
+    expect(grav.gravesUpgrades).toContain('TripleTap');
+  });
+
+  it('미사용 시 gravesTripleAttackChance = 0', () => {
+    const grav = gravesOf(runWith([]));
+    expect(grav.gravesTripleAttackChance).toBe(0);
+  });
+
+  it('TripleTap 활성 시 평균 attackCount 증가 (chance proc 시 +2 hit)', () => {
+    // 기준선
+    const baseGrav = gravesOf(runWith([]));
+    // TripleTap 활성 + DoubleTap 둘 다 미사용 (분리된 영향 측정)
+    const tripleGrav = gravesOf(runWith(['TripleTap']));
+    // attackCount = 평타 횟수. TripleTap proc 시 +2 hit per 평타.
+    expect(tripleGrav.attackCount).toBeGreaterThanOrEqual(baseGrav.attackCount);
+    // 18% chance × N 평타 → 약 18%×2 = 36% 평균 추가. 적어도 1번 proc 발생할 정도면 차이.
+    if (baseGrav.attackCount >= 5) {
+      expect(tripleGrav.attackCount).toBeGreaterThan(baseGrav.attackCount);
+    }
+  });
+});
+
+describe('GravesTrait Phase 3B-1 — RevUp/2 (sticky target AS stack)', () => {
+  it('RevUp → perStack 0.08 / maxBonus 0.80', () => {
+    const grav = gravesOf(runWith(['RevUp']));
+    expect(grav.gravesRevUpPerStack).toBeCloseTo(0.08, 3);
+    expect(grav.gravesRevUpMaxBonus).toBeCloseTo(0.80, 3);
+    expect(grav.gravesUpgrades).toContain('RevUp');
+  });
+
+  it('RevUp2 → perStack 0.15 / maxBonus 1.50 (RevUp override)', () => {
+    const grav = gravesOf(runWith(['RevUp', 'RevUp2']));
+    // RevUp2 는 항상 override (canonical order: RevUp 먼저, RevUp2 가 덮어씀)
+    expect(grav.gravesRevUpPerStack).toBeCloseTo(0.15, 3);
+    expect(grav.gravesRevUpMaxBonus).toBeCloseTo(1.50, 3);
+  });
+
+  it('RevUp2 단독 → perStack 0.15', () => {
+    const grav = gravesOf(runWith(['RevUp2']));
+    expect(grav.gravesRevUpPerStack).toBeCloseTo(0.15, 3);
+    expect(grav.gravesRevUpMaxBonus).toBeCloseTo(1.50, 3);
+  });
+
+  it('RevUp 활성 + 평타 N회 → 같은 target stack 누적 (1명 적 시나리오)', () => {
+    const grav = gravesOf(runWith(['RevUp']));
+    // 같은 적 1명 → 모든 평타 sticky target match → stack 누적.
+    // 첫 hit 은 stickyId=null → reset (stack=0), 두 번째 hit 부터 stack++.
+    expect(grav.gravesRevUpStickyTargetId).not.toBeNull();
+    if (grav.attackCount >= 2) {
+      expect(grav.gravesRevUpStackCount).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('미사용 시 RevUp 필드 default (0/0/null/0)', () => {
+    const grav = gravesOf(runWith([]));
+    expect(grav.gravesRevUpPerStack).toBe(0);
+    expect(grav.gravesRevUpMaxBonus).toBe(0);
+    expect(grav.gravesRevUpStickyTargetId).toBeNull();
+    expect(grav.gravesRevUpStackCount).toBe(0);
+  });
+
+  it('RevUp 활성 시 같은 적 kill duration 단축 (AS stack → DPS 증가)', () => {
+    // 단일 적 시나리오: hit 수는 동일 (같은 HP) 하지만 AS bonus 로 더 빠르게 kill.
+    // duration 비교 → DPS = totalDamage / duration 으로 환산.
+    const baseRes = runWith([]);
+    const revUpRes = runWith(['RevUp2']);
+    expect(revUpRes.duration).toBeLessThan(baseRes.duration);
+    // RevUp stack 도 누적 확인
+    const revUpGrav = gravesOf(revUpRes);
+    expect(revUpGrav.gravesRevUpStackCount).toBeGreaterThan(0);
+  });
+});
+
+describe('GravesTrait Phase 3B-1 — TripleTap vs DoubleTap mutual exclusive', () => {
+  it('TripleTap + DoubleTap2 동시 활성 → TripleTap 우선 roll (proc 시 DoubleTap path skip)', () => {
+    // 코드 상 if-else if 구조. TripleTap proc 시 extraHits=2, DoubleTap roll 안 함.
+    // 기능 검증은 chance roll seed-dependent — 본 테스트는 두 필드 모두 set 됐는지만 확인.
+    const grav = gravesOf(runWith(['TripleTap', 'DoubleTap2']));
+    expect(grav.gravesTripleAttackChance).toBeCloseTo(0.18, 3);
+    expect(grav.gravesDoubleAttackChance).toBeCloseTo(0.35, 3);
+  });
+});
+
+describe('GravesTrait Phase 3B-1 — deterministic ordering', () => {
+  it('입력 순서 무관 (RevUp 먼저 vs RevUp2 먼저) → 동일 RevUp2 결과', () => {
+    const a = gravesOf(runWith(['RevUp', 'RevUp2']));
+    const b = gravesOf(runWith(['RevUp2', 'RevUp']));
+    expect(a.gravesRevUpPerStack).toBe(b.gravesRevUpPerStack);
+    expect(a.gravesRevUpMaxBonus).toBe(b.gravesRevUpMaxBonus);
+    // 같은 seed 라면 시뮬 결과도 동일
+    expect(a.totalDamageDealt).toBeCloseTo(b.totalDamageDealt, 1);
+  });
+});

--- a/tests/unit/simulator/graves-factory-phase3b-1.test.ts
+++ b/tests/unit/simulator/graves-factory-phase3b-1.test.ts
@@ -104,9 +104,9 @@ describe('GravesTrait Phase 3B-1 — RevUp/2 (sticky target AS stack)', () => {
   it('RevUp 활성 + 평타 N회 → 같은 target stack 누적 (1명 적 시나리오)', () => {
     const grav = gravesOf(runWith(['RevUp']));
     // 같은 적 1명 → 모든 평타 sticky target match → stack 누적.
-    // 첫 hit 은 stickyId=null → reset (stack=0), 두 번째 hit 부터 stack++.
+    // codex P2 fix: sticky target 잡는 첫 hit 도 stack=1 → N hit 후 stack=N.
     expect(grav.gravesRevUpStickyTargetId).not.toBeNull();
-    if (grav.attackCount >= 2) {
+    if (grav.attackCount >= 1) {
       expect(grav.gravesRevUpStackCount).toBeGreaterThanOrEqual(1);
     }
   });

--- a/tests/unit/simulator/graves-stat-upgrades.test.ts
+++ b/tests/unit/simulator/graves-stat-upgrades.test.ts
@@ -196,9 +196,9 @@ describe('GravesTrait stat upgrades — 단순 stat 18종 적용', () => {
     expect(grav.gravesTankDamageAmp).toBe(0);
   });
 
-  it('미지원 upgrade ID (Phase 3 RevUp 등) → silently skip', () => {
-    const { grav } = runWith(['RevUp', 'Buckshot', 'Heartseeker']);
-    // 지원 항목만 적용
+  it('미지원 upgrade ID (Phase 3C/3D 항목) → silently skip', () => {
+    // Buckshot (3C 미구현) + GravBooster (3B-2 미구현) + Heartseeker (Phase 2 구현됨).
+    const { grav } = runWith(['Buckshot', 'GravBooster', 'Heartseeker']);
     expect(grav.gravesUpgrades).toEqual(['Heartseeker']);
   });
 


### PR DESCRIPTION
## Summary

- Phase 3B 7종 중 **4종 우선 적용** (단순/중간 복잡도). GravBooster/2 + LatentExplosion 은 후속 3B-2 PR.
- 기존 DoubleTap Frame inline 블럭 → for loop 리팩터로 TripleTap 통합.

## 적용 4종 (raw effects 정확 매핑)

| weapon | raw effects | 메커니즘 |
|---|---|---|
| DoubleTap2 | DoubleAttackChance=0.35 | Frame DoubleTap (25%) 와 같은 필드 max() override |
| TripleTap | TripleAttackChance=0.18 | 별개 roll, 추가 2 hit, DoubleTap path skip (mutual exclusive) |
| RevUp | AttackSpeedPerAttack=0.08, MaxAttackSpeed=0.80 | sticky target 연속 공격 stack — AS +8% per, max +80% |
| RevUp2 | AttackSpeedPerAttack=0.15, MaxAttackSpeed=1.50 | AS +15% per, max +150% (RevUp override) |

## 구현 디테일

### CombatUnit 확장 (5 fields)
- `gravesTripleAttackChance` (0 / 0.18)
- `gravesRevUpPerStack` (0 / 0.08 / 0.15) + `gravesRevUpMaxBonus` (0 / 0.80 / 1.50)
- `gravesRevUpStickyTargetId` (string | null) + `gravesRevUpStackCount` (mutable)

### Hot loop 변경
- 기존 DoubleTap if-block → `for (let i=0; i<extraHits; i++)` 루프
- `extraHits` 계산: TripleTap proc 우선 (2 hit) → DoubleTap proc (1 hit) → 0
- `getEffectiveAttackSpeed()` 에 RevUp 누적 bonus 가산 (`Math.min(stack*per, max)`)
- 평타 first hit 시 sticky target tracking — match 시 stack++, mismatch 시 reset

### canonical apply order
- 'DoubleTap2', 'RevUp', 'RevUp2', 'TripleTap' 추가 (정렬 — 결정성)
- RevUp 먼저 / RevUp2 가 항상 override (강제 max-tier)

## 영향 측정 (회귀 없음)

양 게임 (mountain / well) 모두 **Graves 미사용** → Phase 3B-1 opt-in 특성상 영향 0:

| game | winnerMatchRate | avgPlayerDamageErrorPct |
|---|---|---|
| 23일 (mountain) | 45.5% (변화 없음) | -41.8% (변화 없음) |
| 24일 (well) | 61.9% (변화 없음) | -29.6% (변화 없음) |

## Test plan

- [x] `pnpm lint` — 0 errors / 14 pre-existing warnings
- [x] `pnpm typecheck` — pass
- [x] `pnpm test --run` — **561 passed** / 8 skipped (3B-1 신규 14 assertions 포함)
- [x] `pnpm build` — pass
- [x] `tests/unit/simulator/graves-factory-phase3b-1.test.ts` (14): field 설정, tier override, sticky tracking, RevUp DPS 증가 (kill duration 단축으로 검증)
- [x] `graves-stat-upgrades.test.ts`: 'Phase 3 RevUp silent skip' → 'Phase 3C/3D Buckshot/GravBooster silent skip' 으로 갱신
- [x] `DIFF_GAME_ID=*` cache regen — 동일 metric 확인

## 후속 PR

- **Phase 3B-2 (3종)**: GravBooster (처치 관여 시 dash + AS buff) / GravBooster2 / LatentExplosion (누적 피해 → 처치 시 폭발)
- **Phase 3C (10종)**: AOE / 투사체
- **Phase 3D (5종)**: 복합 메커닉

🤖 Generated with [Claude Code](https://claude.com/claude-code)