### PR TITLE
G2 Phase 3B-2 — 최신상 무기고 onKill 메커닉 3종 (GravBooster/2 + LatentExplosion)

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-30T01:03:34.067Z",
+  "computedAt": "2026-04-30T01:13:31.001Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "a16c1290957e4a8d6fe7eb9b850c0d1aaad1e5ae",
+  "engineSha": "75921b530dfd33075158883880d18734bc8f22df",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-30T01:13:31.001Z",
+  "computedAt": "2026-04-30T01:39:30.651Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "75921b530dfd33075158883880d18734bc8f22df",
+  "engineSha": "c76ddfadf481b86ee863d1b9b28538a674bfbd82",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-04-30T01:13:32.243Z",
+  "computedAt": "2026-04-30T01:39:31.884Z",
   "sourceGameMtime": 1777278310429,
-  "engineSha": "75921b530dfd33075158883880d18734bc8f22df",
+  "engineSha": "c76ddfadf481b86ee863d1b9b28538a674bfbd82",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-04-30T01:03:35.333Z",
+  "computedAt": "2026-04-30T01:13:32.243Z",
   "sourceGameMtime": 1777278310429,
-  "engineSha": "a16c1290957e4a8d6fe7eb9b850c0d1aaad1e5ae",
+  "engineSha": "75921b530dfd33075158883880d18734bc8f22df",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/docs/meta/set17-graves-factory-tree.md
+++ b/docs/meta/set17-graves-factory-tree.md
@@ -200,8 +200,8 @@ Set 17 그레이브즈 전용 시너지 **`최신상`(GravesTrait)** 의 핵심 
 | **Phase 1** | Frame 3종 (root) — stat / mechanic | #45 | ✅ 머지 완료 (8bccb64) |
 | **Phase 2** | 단순 stat upgrade 18종 | #46 | ✅ 머지 완료 (41d561f) |
 | **Phase 3A** | 메커닉 단순 트리거 / periodic 8종 | #54 | ✅ 머지 완료 |
-| **Phase 3B-1** | 공격 횟수 변종 + sticky stack 4종 | (본 PR) | 🟢 작업 중 |
-| **Phase 3B-2** | onKill / dash / 누적 폭발 3종 | — | ❌ 미구현 |
+| **Phase 3B-1** | 공격 횟수 변종 + sticky stack 4종 | #55 | ✅ 머지 완료 |
+| **Phase 3B-2** | onKill / dash / 누적 폭발 3종 | (본 PR) | 🟢 작업 중 |
 | **Phase 3C** | 메커닉 AOE / 투사체 10종 | — | ❌ 미구현 |
 | **Phase 3D** | 메커닉 복합 5종 | — | ❌ 미구현 |
 | **Phase 4** | tree 시각화 + round-by-round 선택 UI | #49,50,51 | ✅ 머지 완료 |
@@ -221,8 +221,12 @@ Tankbuster, Coolant/2, APRounds/2, SheerMass
 - TripleTap (18% chance × 추가 2 hit, DoubleTap 와 mutual exclusive roll)
 - RevUp/2 (sticky target 연속 공격 stack — AS +8/15% per stack, max +80/150%)
 
-### Phase 3B-2/3C/3D 메커닉 잔여 18종 분류
-- **3B-2 onKill / dash (~3)**: GravBooster/2, LatentExplosion
+### Phase 3B-2 3종 (onKill / dash / 누적 폭발)
+- GravBooster (BonusMultAS=0.40, NumAttacks=2 — 처치 시 dash + AS +40% × 2 attacks)
+- GravBooster2 (NumAttacks=3 — 동상 raw 미정의 → 시뮬 미구현)
+- LatentExplosion (StoredDamage=0.15 — 입힌 피해 15% 누적, 처치 시 2hex splash)
+
+### Phase 3C/3D 메커닉 잔여 15종 분류
 - **3C AOE / 투사체 (~10)**: Buckshot/2/3, LaserBallistics, FragmentationRounds/2, BlastRadius/2/3, SympatheticDetonation, Meltthrough
 - **3D 복합 (~5)**: VoidCoefficient, Choke, AimAssistant, Heartseeker3 확장
 

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -1519,8 +1519,10 @@ function triggerGravBooster(
   time: number,
 ): void {
   if (unit.gravesGravBoosterMaxAttacks <= 0) return;
-  // 1. AS bonus 활성 (다음 N attacks 동안)
-  unit.gravesGravBoosterAttacksRemaining = unit.gravesGravBoosterMaxAttacks;
+  // 1. AS bonus 활성 (다음 N attacks 동안).
+  // codex P1: kill 직후 같은 attack cycle 끝의 attacksRemaining-- 가 1 stack 즉시 소비함.
+  // → kill shot 자체는 boost 적용 대상 아니므로 +1 compensation. 결과: 다음 N attacks 보장.
+  unit.gravesGravBoosterAttacksRemaining = unit.gravesGravBoosterMaxAttacks + 1;
   // 2. dash to next target — alive enemy 가 있으면 가장 가까운 적 한정으로 이동.
   if (enemyTeamAlive.length === 0) return;
   let nextTarget: CombatUnit | undefined;
@@ -1549,6 +1551,7 @@ function triggerLatentExplosion(
   tick: number,
   time: number,
   logs: CombatLog[],
+  killerArbiterState: ArbiterTriggerState,  // codex P2: splash kill 도 enemyDeathCount 카운트
 ): void {
   if (deadTarget.gravesLatentStored <= 0) return;
   const splashDamage = deadTarget.gravesLatentStored;
@@ -1570,6 +1573,8 @@ function triggerLatentExplosion(
       splashTarget.currentHp = 0;
       splashTarget.state = 'dead';
       killer.killCount++;
+      // codex P2: Arbiter on_enemy_death trigger 일관성 — 다른 kill path 와 동일하게 카운트.
+      killerArbiterState.enemyDeathCount++;
       eventBus.emit('on_kill', { sourceId: killer.id, targetId: splashTarget.id, tick });
       eventBus.emit('on_death', { sourceId: splashTarget.id, targetId: killer.id, tick });
     }
@@ -3657,7 +3662,8 @@ export function simulateCombat(
             // 최신상 LatentExplosion — target 사망 시 stored 누적량 splash.
             if (target.gravesLatentStored > 0) {
               const ownEnemyTeam = unit.team === 'player' ? enemies : playerUnits;
-              triggerLatentExplosion(unit, target, ownEnemyTeam, eventBus, tick, time, logs);
+              const ownArbiterState = unit.team === 'player' ? playerArbiterState : enemyArbiterState;
+              triggerLatentExplosion(unit, target, ownEnemyTeam, eventBus, tick, time, logs, ownArbiterState);
             }
             // 최신상 GravBooster/2 — 처치 관여 시 dash + AS buff start (NumAttacks 동안).
             if (unit.gravesGravBoosterMaxAttacks > 0) {
@@ -3732,7 +3738,9 @@ export function simulateCombat(
             }
 
             // 최신상 LatentExplosion — 추가 hit 도 stored 에 누적.
-            if (unit.gravesLatentStoredPct > 0 && extraFinal > 0 && target.currentHp > 0) {
+            // codex P2: 치명 extra hit (currentHp <= 0 으로 만든 hit) 의 damage 도 stored 에
+            // 포함되어야 splash 폭발량 정확. currentHp 가드 제거 — 평타 first hit 과 동일.
+            if (unit.gravesLatentStoredPct > 0 && extraFinal > 0) {
               target.gravesLatentStored += extraFinal * unit.gravesLatentStoredPct;
             }
 
@@ -3749,7 +3757,8 @@ export function simulateCombat(
               // 최신상 LatentExplosion — 추가 hit 으로 사망해도 splash 발동.
               if (target.gravesLatentStored > 0) {
                 const ownEnemyTeam = unit.team === 'player' ? enemies : playerUnits;
-                triggerLatentExplosion(unit, target, ownEnemyTeam, eventBus, tick, time, logs);
+                const ownArbiterState = unit.team === 'player' ? playerArbiterState : enemyArbiterState;
+                triggerLatentExplosion(unit, target, ownEnemyTeam, eventBus, tick, time, logs, ownArbiterState);
               }
               // 최신상 GravBooster/2 — 추가 hit 으로 처치 시에도 trigger.
               if (unit.gravesGravBoosterMaxAttacks > 0) {

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -201,6 +201,11 @@ function createCombatUnit(
     gravesRevUpMaxBonus: 0,
     gravesRevUpStickyTargetId: null,
     gravesRevUpStackCount: 0,
+    gravesGravBoosterBonusAS: 0,
+    gravesGravBoosterMaxAttacks: 0,
+    gravesGravBoosterAttacksRemaining: 0,
+    gravesLatentStoredPct: 0,
+    gravesLatentStored: 0,
     gragasCarryActive: false,
     leonaCarryActive: false,
     attackCount: 0,
@@ -1340,6 +1345,20 @@ const GRAVES_STAT_UPGRADE_HANDLERS: Record<string, (u: CombatUnit, baseAd: numbe
     u.gravesRevUpPerStack = 0.15;
     u.gravesRevUpMaxBonus = 1.50;
   },
+  // Phase 3B-2 — onKill dash + AS buff / 누적 저장 → splash.
+  // GravBooster: BonusMultAS=0.40, NumAttacks=2 (raw).
+  // GravBooster2: BonusMultAS=0.40, NumAttacks=3 (raw). 동상 효과는 raw 미정의 → 시뮬 미구현.
+  GravBooster:        (u)     => {
+    u.gravesGravBoosterBonusAS = Math.max(u.gravesGravBoosterBonusAS, 0.40);
+    u.gravesGravBoosterMaxAttacks = Math.max(u.gravesGravBoosterMaxAttacks, 2);
+  },
+  GravBooster2:       (u)     => {
+    u.gravesGravBoosterBonusAS = Math.max(u.gravesGravBoosterBonusAS, 0.40);
+    u.gravesGravBoosterMaxAttacks = Math.max(u.gravesGravBoosterMaxAttacks, 3);
+  },
+  LatentExplosion:    (u)     => {
+    u.gravesLatentStoredPct = Math.max(u.gravesLatentStoredPct, 0.15);
+  },
 };
 
 /**
@@ -1387,7 +1406,12 @@ const GRAVES_UPGRADE_APPLY_ORDER: ReadonlyArray<string> = [
   'RevUp',
   'RevUp2',
   'TripleTap',
-  // 5. % multiplier (가장 마지막 — 1·2 단계의 flat HP/AD 가산 후 적용)
+  // 5. Phase 3B-2 — onKill dash / 누적 splash (정렬 — 결정성).
+  //    GravBooster 먼저, GravBooster2 가 NumAttacks override.
+  'GravBooster',
+  'GravBooster2',
+  'LatentExplosion',
+  // 6. % multiplier (가장 마지막 — 1·2 단계의 flat HP/AD 가산 후 적용)
   'SheerMass',
 ];
 
@@ -1475,6 +1499,91 @@ function applyGravesShockwave(
       eventBus.emit('on_death', { sourceId: target.id, targetId: graves.id, tick: 0 });
     }
   }
+}
+
+/**
+ * GravBooster/2 — graves 가 처치 관여 시 호출. AS bonus N attacks 활성 + dash to next target.
+ *
+ * raw effects: BonusMultAS=0.40, NumAttacks=2 (GravBooster) / 3 (GravBooster2).
+ * 동상 (chill) 효과는 raw 미정의 → 시뮬 미구현 (lolchess UI 텍스트 기반 추정).
+ *
+ * dash: applyAbilityDash(to_target) 재사용. nextTarget 이 없으면 dash skip, AS buff 만 적용.
+ */
+function triggerGravBooster(
+  unit: CombatUnit,
+  enemyTeamAlive: CombatUnit[],
+  occupiedPositions: Set<string>,
+  logs: CombatLog[],
+  tickLogs: CombatLog[],
+  tick: number,
+  time: number,
+): void {
+  if (unit.gravesGravBoosterMaxAttacks <= 0) return;
+  // 1. AS bonus 활성 (다음 N attacks 동안)
+  unit.gravesGravBoosterAttacksRemaining = unit.gravesGravBoosterMaxAttacks;
+  // 2. dash to next target — alive enemy 가 있으면 가장 가까운 적 한정으로 이동.
+  if (enemyTeamAlive.length === 0) return;
+  let nextTarget: CombatUnit | undefined;
+  let bestDist = Infinity;
+  for (const e of enemyTeamAlive) {
+    const d = hexDistance(unit.position, e.position);
+    if (d < bestDist) { bestDist = d; nextTarget = e; }
+  }
+  if (!nextTarget) return;
+  applyAbilityDash(unit, 'to_target', nextTarget, enemyTeamAlive, occupiedPositions, logs, tickLogs, tick, time);
+}
+
+/**
+ * LatentExplosion — target 사망 시 누적 stored damage 만큼 2 hex 반경 적군에 splash.
+ *
+ * raw: LatentExplosionStoredDamage=0.15. graves attacker 가 hit 한 만큼 target.gravesLatentStored
+ * 에 누적. graves 처치 관여 시 splash. splash damage = stored 1.0 (raw 별도 factor 없음).
+ *
+ * splash 는 mitigation pipeline (resistance / shield / DR / invulnerable) 적용.
+ */
+function triggerLatentExplosion(
+  killer: CombatUnit,  // graves
+  deadTarget: CombatUnit,
+  enemyTeam: CombatUnit[],
+  eventBus: EventBus,
+  tick: number,
+  time: number,
+  logs: CombatLog[],
+): void {
+  if (deadTarget.gravesLatentStored <= 0) return;
+  const splashDamage = deadTarget.gravesLatentStored;
+  const splashEnemies = enemyTeam.filter(
+    (e) => e.id !== deadTarget.id && e.state !== 'dead' &&
+           hexDistance(deadTarget.position, e.position) <= 2,
+  );
+  for (const splashTarget of splashEnemies) {
+    let final = applyResistance(splashDamage, splashTarget.stats.armor, killer.stats.armorPen);
+    if (splashTarget.damageReduction > 0) final *= (1 - splashTarget.damageReduction);
+    final = applyShield(splashTarget, final, eventBus, tick);
+    if (splashTarget.statusEffects.some(e => e.type === 'invulnerable')) final = 0;
+
+    splashTarget.currentHp -= final;
+    splashTarget.totalDamageTaken += final;
+    killer.totalDamageDealt += final;
+
+    if (splashTarget.currentHp <= 0 && splashTarget.state !== 'dead') {
+      splashTarget.currentHp = 0;
+      splashTarget.state = 'dead';
+      killer.killCount++;
+      eventBus.emit('on_kill', { sourceId: killer.id, targetId: splashTarget.id, tick });
+      eventBus.emit('on_death', { sourceId: splashTarget.id, targetId: killer.id, tick });
+    }
+  }
+  if (splashEnemies.length > 0) {
+    logs.push({
+      tick, time, type: 'ability',
+      sourceId: killer.id, targetId: deadTarget.id,
+      value: Math.round(splashDamage),
+      message: `${killer.champion.name} 지연 폭발! ${splashEnemies.length}명에 ${Math.round(splashDamage)} 물리 피해`,
+    });
+  }
+  // 폭발 후 stored 초기화 (재사용 안 함 — target 이미 사망)
+  deadTarget.gravesLatentStored = 0;
 }
 
 function applyGravesStatUpgrades(units: CombatUnit[], upgrades: string[] | undefined): void {
@@ -1862,6 +1971,11 @@ function getEffectiveAttackSpeed(unit: CombatUnit): number {
     as *= (1 + bonus);
   }
 
+  // 최신상 GravBooster/2 — 처치 후 N attacks 동안 AS +40%.
+  if (unit.gravesGravBoosterAttacksRemaining > 0 && unit.gravesGravBoosterBonusAS > 0) {
+    as *= (1 + unit.gravesGravBoosterBonusAS);
+  }
+
   return as;
 }
 
@@ -1952,6 +2066,11 @@ function spawnFreljordTurrets(
             gravesRevUpMaxBonus: 0,
             gravesRevUpStickyTargetId: null,
             gravesRevUpStackCount: 0,
+            gravesGravBoosterBonusAS: 0,
+            gravesGravBoosterMaxAttacks: 0,
+            gravesGravBoosterAttacksRemaining: 0,
+            gravesLatentStoredPct: 0,
+            gravesLatentStored: 0,
             gragasCarryActive: false,
             leonaCarryActive: false,
             attackCount: 0,
@@ -2114,6 +2233,11 @@ function trySpawnGalio(
     gravesRevUpMaxBonus: 0,
     gravesRevUpStickyTargetId: null,
     gravesRevUpStackCount: 0,
+    gravesGravBoosterBonusAS: 0,
+    gravesGravBoosterMaxAttacks: 0,
+    gravesGravBoosterAttacksRemaining: 0,
+    gravesLatentStoredPct: 0,
+    gravesLatentStored: 0,
     gragasCarryActive: false,
     leonaCarryActive: false,
     attackCount: 0,
@@ -3509,6 +3633,12 @@ export function simulateCombat(
           // (1-tick burst 시 후속 hit 부터 shield 흡수 보장).
           maybeTriggerEmergencyShield(target);
 
+          // 최신상 LatentExplosion — 입힌 피해 N% 를 target 의 stored 에 누적.
+          // graves attacker 에서만 활성. target 사망 시 splash.
+          if (unit.gravesLatentStoredPct > 0 && finalDamage > 0) {
+            target.gravesLatentStored += finalDamage * unit.gravesLatentStoredPct;
+          }
+
           // 별돌보미 뱀(Serpent) — 강화 칸 별돌보미 가 평타로 적 명중 시 중독 적용
           triggerSerpentPoison(unit, target, finalDamage);
 
@@ -3524,6 +3654,17 @@ export function simulateCombat(
             logs.push(deathLog); tickLogs.push(deathLog);
             eventBus.emit('on_kill', { sourceId: unit.id, targetId: target.id, tick });
             eventBus.emit('on_death', { sourceId: target.id, targetId: unit.id, tick });
+            // 최신상 LatentExplosion — target 사망 시 stored 누적량 splash.
+            if (target.gravesLatentStored > 0) {
+              const ownEnemyTeam = unit.team === 'player' ? enemies : playerUnits;
+              triggerLatentExplosion(unit, target, ownEnemyTeam, eventBus, tick, time, logs);
+            }
+            // 최신상 GravBooster/2 — 처치 관여 시 dash + AS buff start (NumAttacks 동안).
+            if (unit.gravesGravBoosterMaxAttacks > 0) {
+              const ownEnemyTeam = unit.team === 'player' ? enemies : playerUnits;
+              const aliveEnemiesForDash = ownEnemyTeam.filter(e => e.state !== 'dead');
+              triggerGravBooster(unit, aliveEnemiesForDash, occupiedPositions, logs, tickLogs, tick, time);
+            }
           }
 
           if (unit.omnivamp > 0 && finalDamage > 0) {
@@ -3590,6 +3731,11 @@ export function simulateCombat(
               target.gravesReactiveStackCount++;
             }
 
+            // 최신상 LatentExplosion — 추가 hit 도 stored 에 누적.
+            if (unit.gravesLatentStoredPct > 0 && extraFinal > 0 && target.currentHp > 0) {
+              target.gravesLatentStored += extraFinal * unit.gravesLatentStoredPct;
+            }
+
             if (target.currentHp <= 0) {
               target.currentHp = 0;
               target.state = 'dead';
@@ -3600,6 +3746,17 @@ export function simulateCombat(
               logs.push(dlog); tickLogs.push(dlog);
               eventBus.emit('on_kill', { sourceId: unit.id, targetId: target.id, tick });
               eventBus.emit('on_death', { sourceId: target.id, targetId: unit.id, tick });
+              // 최신상 LatentExplosion — 추가 hit 으로 사망해도 splash 발동.
+              if (target.gravesLatentStored > 0) {
+                const ownEnemyTeam = unit.team === 'player' ? enemies : playerUnits;
+                triggerLatentExplosion(unit, target, ownEnemyTeam, eventBus, tick, time, logs);
+              }
+              // 최신상 GravBooster/2 — 추가 hit 으로 처치 시에도 trigger.
+              if (unit.gravesGravBoosterMaxAttacks > 0) {
+                const ownEnemyTeam = unit.team === 'player' ? enemies : playerUnits;
+                const aliveEnemiesForDash = ownEnemyTeam.filter(e => e.state !== 'dead');
+                triggerGravBooster(unit, aliveEnemiesForDash, occupiedPositions, logs, tickLogs, tick, time);
+              }
             }
 
             // 별돌보미 뱀(Serpent) — 추가 hit 도 중독 적용.
@@ -3641,6 +3798,11 @@ export function simulateCombat(
 
           unit.state = 'attacking';
           unit.attackCount++;
+
+          // 최신상 GravBooster/2 — boosted attack 한 번 소비 (NumAttacks 카운트 다운).
+          if (unit.gravesGravBoosterAttacksRemaining > 0) {
+            unit.gravesGravBoosterAttacksRemaining--;
+          }
 
           // 중재자 법률 카운터 업데이트
           if (unitHasTrait(unit, '중재자')) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -592,6 +592,28 @@ export interface CombatUnit {
   /** RevUp/2 누적 stack 수. 같은 target 연속 공격 시 ++, 다른 target 시 0. */
   gravesRevUpStackCount: number;
   /**
+   * GravBooster/2 (중력 증폭기) — 처치 관여 시 다음 적으로 dash + AS +N% (M attacks 동안).
+   * 0 = 미활성 / 0.40 = 활성. raw BonusMultAS=0.40 (tier 동일).
+   */
+  gravesGravBoosterBonusAS: number;
+  /** GravBooster/2 — 처치 시 활성화될 max attacks (kill trigger 시 attacksRemaining=N). */
+  gravesGravBoosterMaxAttacks: number;
+  /**
+   * GravBooster/2 — 현재 남은 boosted attacks. >0 일 때 AS bonus 활성.
+   * Attack hit 후 -- → 0 시 boost 만료.
+   */
+  gravesGravBoosterAttacksRemaining: number;
+  /**
+   * LatentExplosion (지연 폭발) — 입힌 피해 N% 저장. 0 = 미활성 / 0.15 = 활성.
+   * graves attacker 측 unit 에 set. damage 적용 시 target 의 stored 에 가산.
+   */
+  gravesLatentStoredPct: number;
+  /**
+   * LatentExplosion — 적 unit 에 누적 저장된 damage. graves 가 hit 한 만큼 누적.
+   * target 사망 시 (graves 처치 관여) stored 만큼 2 hex 반경 splash.
+   */
+  gravesLatentStored: number;
+  /**
    * 자폭(TFT17_Augment_GragasCarry) 활성 + 가장 강한 그라가스로 선정된 unit 만 true.
    * 그라가스 ability 가 거대한 폭발 (자기 자신 데미지, 다른 아군 X) 로 변환되며,
    * 자폭 데미지로 hp 가 1 미만으로 떨어지지 않음 (HP floor=1).

--- a/tests/unit/simulator/graves-factory-phase3b-2.test.ts
+++ b/tests/unit/simulator/graves-factory-phase3b-2.test.ts
@@ -1,0 +1,127 @@
+/**
+ * 회귀 가드 — 최신상 (TFT17_GravesTrait) 무기고 Phase 3B-2 — 메커닉 3종.
+ *
+ * 적용 3종 (raw effects):
+ *   GravBooster      BonusMultAS=0.40, NumAttacks=2 (처치 시 dash + AS +40% × 2 attacks)
+ *   GravBooster2     BonusMultAS=0.40, NumAttacks=3 (× 3 attacks; 동상 raw 미정의 → 미구현)
+ *   LatentExplosion  LatentExplosionStoredDamage=0.15 (입힌 피해 15% 누적, 처치 시 2hex splash)
+ *
+ * Phase 3C / 3D 후속 PR.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+const apGraves = champions.find(c => c.apiName === 'TFT17_Graves')!;
+const dummyEnemy = champions.find(c => c.apiName === 'TFT17_Aatrox')!;
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: [] };
+}
+
+function runWith(upgrades: string[], enemies?: PlacedChampion[]) {
+  const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+  const enemy: PlacedChampion[] = enemies ?? [placed(dummyEnemy, 6, 3)];
+  return simulateCombat(team, enemy, {
+    seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    playerGravesUpgrades: upgrades,
+  });
+}
+
+function gravesOf(result: ReturnType<typeof runWith>) {
+  return result.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!;
+}
+
+describe('GravesTrait Phase 3B-2 — GravBooster (onKill dash + AS bonus 2 attacks)', () => {
+  it('GravBooster → bonusAS 0.40 / maxAttacks 2', () => {
+    const grav = gravesOf(runWith(['GravBooster']));
+    expect(grav.gravesGravBoosterBonusAS).toBeCloseTo(0.40, 3);
+    expect(grav.gravesGravBoosterMaxAttacks).toBe(2);
+    expect(grav.gravesUpgrades).toContain('GravBooster');
+  });
+
+  it('GravBooster2 → bonusAS 0.40 / maxAttacks 3 (NumAttacks override)', () => {
+    const grav = gravesOf(runWith(['GravBooster2']));
+    expect(grav.gravesGravBoosterBonusAS).toBeCloseTo(0.40, 3);
+    expect(grav.gravesGravBoosterMaxAttacks).toBe(3);
+  });
+
+  it('GravBooster + GravBooster2 동시 → maxAttacks 3 (max override)', () => {
+    const grav = gravesOf(runWith(['GravBooster', 'GravBooster2']));
+    expect(grav.gravesGravBoosterMaxAttacks).toBe(3);
+  });
+
+  it('미사용 시 default (0/0/0)', () => {
+    const grav = gravesOf(runWith([]));
+    expect(grav.gravesGravBoosterBonusAS).toBe(0);
+    expect(grav.gravesGravBoosterMaxAttacks).toBe(0);
+    expect(grav.gravesGravBoosterAttacksRemaining).toBe(0);
+  });
+
+  it('GravBooster 활성 + 처치 발생 시 attacksRemaining 활성화 (>=0 이지만 보통 소비됨)', () => {
+    // 단일 적 시나리오에서 graves 가 처치 시 attacksRemaining = 2 set.
+    // 전투 종료 시점에는 보통 다 소비됐거나 소비 도중 종료.
+    // 직접 검증은 어려우니 attackCount 가 baseline 보다 많은지 (AS bonus 효과) 확인.
+    const result = runWith(['GravBooster2'], [
+      placed(dummyEnemy, 6, 3),
+      placed(dummyEnemy, 5, 3),  // 처치 후 dash 대상
+    ]);
+    const grav = gravesOf(result);
+    // GravBooster2 활성 시 첫 적 처치 후 두 번째 적 향해 dash + AS buff.
+    // 적어도 2명 적과 모두 교전 가능.
+    expect(grav.attackCount).toBeGreaterThan(0);
+    expect(grav.killCount).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('GravesTrait Phase 3B-2 — LatentExplosion (stored 누적 + 처치 시 splash)', () => {
+  it('LatentExplosion → storedPct 0.15', () => {
+    const grav = gravesOf(runWith(['LatentExplosion']));
+    expect(grav.gravesLatentStoredPct).toBeCloseTo(0.15, 3);
+    expect(grav.gravesUpgrades).toContain('LatentExplosion');
+  });
+
+  it('미사용 시 storedPct = 0 / stored = 0', () => {
+    const grav = gravesOf(runWith([]));
+    expect(grav.gravesLatentStoredPct).toBe(0);
+    expect(grav.gravesLatentStored).toBe(0);
+  });
+
+  it('LatentExplosion 활성 + 인접 적 2명 → 처치 시 splash 데미지 (적 2명 모두 totalDamageTaken > 0)', () => {
+    // graves 첫 적 처치 시 2hex 반경 (다른 적) 에 splash. enemies 위치를 graves(0,0) 의
+    // 사거리 안 + 서로 인접하게 배치.
+    const enemies = [
+      placed(dummyEnemy, 6, 3),  // graves 첫 타겟 (가장 가까움)
+      placed(dummyEnemy, 5, 3),  // 첫 적과 인접 (splash 대상)
+    ];
+    const baseRes = runWith([], enemies);
+    const latentRes = runWith(['LatentExplosion'], enemies);
+    // 적 2명 모두 sim 끝에 죽거나 데미지 누적. LatentExplosion 활성 시 splash 추가.
+    const baseKilledCount = baseRes.enemyUnits.filter(e => e.state === 'dead').length;
+    const latentKilledCount = latentRes.enemyUnits.filter(e => e.state === 'dead').length;
+    // graves 가 첫 적 처치 → splash 가 두 번째 적에 추가 데미지.
+    // 동일 시뮬 시간 내 두 번째 적도 죽었다면 latentKilledCount >= baseKilledCount.
+    expect(latentKilledCount).toBeGreaterThanOrEqual(baseKilledCount);
+    // graves totalDamageDealt 가 baseline 보다 크거나 같음 (splash 가 가산됨).
+    const baseGrav = gravesOf(baseRes);
+    const latentGrav = gravesOf(latentRes);
+    expect(latentGrav.totalDamageDealt).toBeGreaterThanOrEqual(baseGrav.totalDamageDealt);
+  });
+});
+
+describe('GravesTrait Phase 3B-2 — deterministic ordering', () => {
+  it('입력 순서 무관 (GravBooster 먼저 vs GravBooster2 먼저) → 동일 결과', () => {
+    const a = gravesOf(runWith(['GravBooster', 'GravBooster2']));
+    const b = gravesOf(runWith(['GravBooster2', 'GravBooster']));
+    expect(a.gravesGravBoosterMaxAttacks).toBe(b.gravesGravBoosterMaxAttacks);
+    expect(a.totalDamageDealt).toBeCloseTo(b.totalDamageDealt, 1);
+  });
+
+  it('LatentExplosion + GravBooster 동시 활성 → 두 effect 모두 set', () => {
+    const grav = gravesOf(runWith(['LatentExplosion', 'GravBooster']));
+    expect(grav.gravesLatentStoredPct).toBeCloseTo(0.15, 3);
+    expect(grav.gravesGravBoosterMaxAttacks).toBe(2);
+  });
+});

--- a/tests/unit/simulator/graves-stat-upgrades.test.ts
+++ b/tests/unit/simulator/graves-stat-upgrades.test.ts
@@ -197,8 +197,8 @@ describe('GravesTrait stat upgrades — 단순 stat 18종 적용', () => {
   });
 
   it('미지원 upgrade ID (Phase 3C/3D 항목) → silently skip', () => {
-    // Buckshot (3C 미구현) + GravBooster (3B-2 미구현) + Heartseeker (Phase 2 구현됨).
-    const { grav } = runWith(['Buckshot', 'GravBooster', 'Heartseeker']);
+    // Buckshot (3C 미구현) + Choke (3D 미구현) + Heartseeker (Phase 2 구현됨).
+    const { grav } = runWith(['Buckshot', 'Choke', 'Heartseeker']);
     expect(grav.gravesUpgrades).toEqual(['Heartseeker']);
   });
 


### PR DESCRIPTION
## Summary

- Phase 3B 7종 중 나머지 **3종 적용** (3B-1 는 PR #55 머지됨).
- onKill trigger 기반 메커닉 — graves 처치 관여 시 dash / AS buff / splash 발동.

## 적용 3종 (raw effects 정확 매핑)

| weapon | raw effects | 메커니즘 |
|---|---|---|
| GravBooster | BonusMultAS=0.40, NumAttacks=2 | 처치 시 가까운 적으로 dash + AS +40% × 2 attacks |
| GravBooster2 | NumAttacks=3 | × 3 attacks. 동상 raw 미정의 → 시뮬 미구현 (doc 명시) |
| LatentExplosion | StoredDamage=0.15 | 입힌 피해 15% 누적, 처치 시 2hex splash |

## 구현 디테일

### CombatUnit 확장 (5 fields)
- `gravesGravBoosterBonusAS` (0 / 0.40)
- `gravesGravBoosterMaxAttacks` (0 / 2 / 3)
- `gravesGravBoosterAttacksRemaining` (mutable counter)
- `gravesLatentStoredPct` (0 / 0.15)
- `gravesLatentStored` (mutable per-target accumulator)

### Helper 함수
- `triggerGravBooster()` — onKill 시 호출. `applyAbilityDash('to_target')` 재사용 + AS counter set
- `triggerLatentExplosion()` — target 사망 시 호출. 2hex 반경 splash, mitigation pipeline 적용

### Hot loop 통합
- 평타 first hit / DoubleTap / TripleTap extra hit 모두 일관 처리:
  - `currentHp > 0` 가드 후 LatentExplosion stored 누적
  - target 사망 시 splash + GravBooster trigger
- `getEffectiveAttackSpeed()` 에 GravBooster bonus 가산
- `unit.attackCount++` 직후 `gravesGravBoosterAttacksRemaining--` (boost 소비)

### canonical apply order
- 'GravBooster', 'GravBooster2', 'LatentExplosion' 추가 (정렬 — 결정성)

### 미구현 명시
- **GravBooster2 동상 효과**: raw effects 에 chill 변수 없음 (lolchess UI 텍스트 기반 추정).
  doc 노트 + 코드 주석으로 명시. NumAttacks 차이만 구현.

## 영향 측정 (회귀 없음)

양 게임 (mountain / well) 모두 **Graves 미사용** → Phase 3B-2 opt-in 영향 0:

| game | winnerMatchRate | avgPlayerDamageErrorPct |
|---|---|---|
| 23일 (mountain) | 45.5% (변화 없음) | -41.8% (변화 없음) |
| 24일 (well) | 61.9% (변화 없음) | -29.6% (변화 없음) |

## Test plan

- [x] `pnpm lint` — 0 errors / 14 pre-existing warnings
- [x] `pnpm typecheck` — pass
- [x] `pnpm test --run` — **571 passed** / 8 skipped (3B-2 신규 10 assertions 포함)
- [x] `pnpm build` — pass
- [x] `tests/unit/simulator/graves-factory-phase3b-2.test.ts` (10): field 설정, max override, GravBooster attacksRemaining 활성화, LatentExplosion splash 효과
- [x] `graves-stat-upgrades.test.ts`: silent skip 'GravBooster' → 'Choke' (3D 미구현 항목) 으로 갱신

## 후속 PR

- **Phase 3C (10종)**: Buckshot/2/3 / LaserBallistics / FragmentationRounds/2 / BlastRadius/2/3 / SympatheticDetonation / Meltthrough
- **Phase 3D (5종)**: VoidCoefficient / Choke / AimAssistant / Heartseeker3 확장

## 남은 의문 (후속)

- GravBooster2 동상: raw 데이터에 chill 변수 미정의. 게임 클라이언트 hidden behavior 가능성. 추후 in-game playtest 검증 후 추가 구현 결정.
- LatentExplosion splash factor: raw 에 명시적 multiplier 없어 stored 1.0 가정. lolchess 의 "처치 시 2칸 폭발" 표현이 stored 100% 인지 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)