### PR TITLE
G2 Phase 3C-1 — 최신상 무기고 평타 base AOE 7종

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-30T01:39:30.651Z",
+  "computedAt": "2026-04-30T01:50:33.211Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "c76ddfadf481b86ee863d1b9b28538a674bfbd82",
+  "engineSha": "2d850088f48edb09ea60b0150eb48ea9a225ca23",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-04-30T01:50:33.211Z",
+  "computedAt": "2026-04-30T02:07:08.427Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "2d850088f48edb09ea60b0150eb48ea9a225ca23",
+  "engineSha": "a83bbbcb6f5c0256c99dd4df8ae1e2f713236551",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-04-30T01:39:31.884Z",
+  "computedAt": "2026-04-30T01:50:34.472Z",
   "sourceGameMtime": 1777278310429,
-  "engineSha": "c76ddfadf481b86ee863d1b9b28538a674bfbd82",
+  "engineSha": "2d850088f48edb09ea60b0150eb48ea9a225ca23",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-04-30T01:50:34.472Z",
+  "computedAt": "2026-04-30T02:07:09.707Z",
   "sourceGameMtime": 1777278310429,
-  "engineSha": "2d850088f48edb09ea60b0150eb48ea9a225ca23",
+  "engineSha": "a83bbbcb6f5c0256c99dd4df8ae1e2f713236551",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/docs/meta/set17-graves-factory-tree.md
+++ b/docs/meta/set17-graves-factory-tree.md
@@ -201,8 +201,9 @@ Set 17 그레이브즈 전용 시너지 **`최신상`(GravesTrait)** 의 핵심 
 | **Phase 2** | 단순 stat upgrade 18종 | #46 | ✅ 머지 완료 (41d561f) |
 | **Phase 3A** | 메커닉 단순 트리거 / periodic 8종 | #54 | ✅ 머지 완료 |
 | **Phase 3B-1** | 공격 횟수 변종 + sticky stack 4종 | #55 | ✅ 머지 완료 |
-| **Phase 3B-2** | onKill / dash / 누적 폭발 3종 | (본 PR) | 🟢 작업 중 |
-| **Phase 3C** | 메커닉 AOE / 투사체 10종 | — | ❌ 미구현 |
+| **Phase 3B-2** | onKill / dash / 누적 폭발 3종 | #56 | ✅ 머지 완료 |
+| **Phase 3C-1** | 평타 base AOE 7종 | (본 PR) | 🟢 작업 중 |
+| **Phase 3C-2** | ability AOE 4종 | — | ❌ 미구현 |
 | **Phase 3D** | 메커닉 복합 5종 | — | ❌ 미구현 |
 | **Phase 4** | tree 시각화 + round-by-round 선택 UI | #49,50,51 | ✅ 머지 완료 |
 
@@ -226,8 +227,14 @@ Tankbuster, Coolant/2, APRounds/2, SheerMass
 - GravBooster2 (NumAttacks=3 — 동상 raw 미정의 → 시뮬 미구현)
 - LatentExplosion (StoredDamage=0.15 — 입힌 피해 15% 누적, 처치 시 2hex splash)
 
-### Phase 3C/3D 메커닉 잔여 15종 분류
-- **3C AOE / 투사체 (~10)**: Buckshot/2/3, LaserBallistics, FragmentationRounds/2, BlastRadius/2/3, SympatheticDetonation, Meltthrough
+### Phase 3C-1 7종 (평타 base AOE)
+- Buckshot/2/3 (NumBonusProjectiles 2/4/6, SpreadIncrease 0.20/0.30/0.40 — 타겟+주변 혼합 multi-hit)
+- LaserBallistics (BonusHexes=1, DamageReductionPerTarget=0.5 — 관통 1명)
+- FragmentationRounds/2 (FragmentDamage 0.15/0.20, Projectiles 2/3 — 평타 시 주변 파편)
+- Meltthrough (ArmorMRReduction=4 — 매초 graves 주변 2hex 적 armor/MR -4)
+
+### Phase 3C-2/3D 메커닉 잔여 8종 분류
+- **3C-2 ability AOE (~4)**: BlastRadius/2/3, SympatheticDetonation
 - **3D 복합 (~5)**: VoidCoefficient, Choke, AimAssistant, Heartseeker3 확장
 
 ---

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -206,6 +206,13 @@ function createCombatUnit(
     gravesGravBoosterAttacksRemaining: 0,
     gravesLatentStoredPct: 0,
     gravesLatentStored: 0,
+    gravesBuckshotProjectiles: 0,
+    gravesBuckshotSpread: 0,
+    gravesLaserPenetrationHexes: 0,
+    gravesLaserDmgReductionPerTarget: 0,
+    gravesFragDamage: 0,
+    gravesFragProjectiles: 0,
+    gravesMeltthroughArmorMR: 0,
     gragasCarryActive: false,
     leonaCarryActive: false,
     attackCount: 0,
@@ -1359,6 +1366,38 @@ const GRAVES_STAT_UPGRADE_HANDLERS: Record<string, (u: CombatUnit, baseAd: numbe
   LatentExplosion:    (u)     => {
     u.gravesLatentStoredPct = Math.max(u.gravesLatentStoredPct, 0.15);
   },
+  // Phase 3C-1 — 평타 base AOE (Buckshot/Laser/Frag/Melt).
+  // Buckshot: NumBonusProjectiles 2/4/6, SpreadIncrease 0.20/0.30/0.40.
+  Buckshot:           (u)     => {
+    u.gravesBuckshotProjectiles = Math.max(u.gravesBuckshotProjectiles, 2);
+    u.gravesBuckshotSpread = Math.max(u.gravesBuckshotSpread, 0.20);
+  },
+  Buckshot2:          (u)     => {
+    u.gravesBuckshotProjectiles = Math.max(u.gravesBuckshotProjectiles, 4);
+    u.gravesBuckshotSpread = Math.max(u.gravesBuckshotSpread, 0.30);
+  },
+  Buckshot3:          (u)     => {
+    u.gravesBuckshotProjectiles = Math.max(u.gravesBuckshotProjectiles, 6);
+    u.gravesBuckshotSpread = Math.max(u.gravesBuckshotSpread, 0.40);
+  },
+  // LaserBallistics: BonusHexes=1, DamageReductionPerTarget=0.5.
+  LaserBallistics:    (u)     => {
+    u.gravesLaserPenetrationHexes = Math.max(u.gravesLaserPenetrationHexes, 1);
+    u.gravesLaserDmgReductionPerTarget = Math.max(u.gravesLaserDmgReductionPerTarget, 0.5);
+  },
+  // FragmentationRounds: FragmentDamage 0.15/0.20, FragmentProjectiles 2/3.
+  FragmentationRounds: (u)    => {
+    u.gravesFragDamage = Math.max(u.gravesFragDamage, 0.15);
+    u.gravesFragProjectiles = Math.max(u.gravesFragProjectiles, 2);
+  },
+  FragmentationRounds2: (u)   => {
+    u.gravesFragDamage = Math.max(u.gravesFragDamage, 0.20);
+    u.gravesFragProjectiles = Math.max(u.gravesFragProjectiles, 3);
+  },
+  // Meltthrough: ArmorMRReduction=4 (매초 graves 주변 2hex 적군 armor/MR -4).
+  Meltthrough:        (u)     => {
+    u.gravesMeltthroughArmorMR = Math.max(u.gravesMeltthroughArmorMR, 4);
+  },
 };
 
 /**
@@ -1411,7 +1450,16 @@ const GRAVES_UPGRADE_APPLY_ORDER: ReadonlyArray<string> = [
   'GravBooster',
   'GravBooster2',
   'LatentExplosion',
-  // 6. % multiplier (가장 마지막 — 1·2 단계의 flat HP/AD 가산 후 적용)
+  // 6. Phase 3C-1 — 평타 base AOE (정렬 — 결정성).
+  //    Buckshot 1→2→3 순서, Frag 1→2 순서로 max() override.
+  'Buckshot',
+  'Buckshot2',
+  'Buckshot3',
+  'FragmentationRounds',
+  'FragmentationRounds2',
+  'LaserBallistics',
+  'Meltthrough',
+  // 7. % multiplier (가장 마지막 — 1·2 단계의 flat HP/AD 가산 후 적용)
   'SheerMass',
 ];
 
@@ -1589,6 +1637,131 @@ function triggerLatentExplosion(
   }
   // 폭발 후 stored 초기화 (재사용 안 함 — target 이미 사망)
   deadTarget.gravesLatentStored = 0;
+}
+
+/**
+ * Buckshot/2/3 — 평타 명중 시 추가 (N-1) projectile 을 nearby 적군에 분산.
+ * 사용자 결정: "타겟 + 주변 혼합" — 첫 hit 은 target (이미 처리됨), 추가 (N-1) 은
+ * graves 주변 가까운 적 N-1 명에 finalDmg 만큼 추가 hit. SpreadIncrease 는 nearby radius
+ * 결정 (1 + round(spread × 2.5) → 0.20→1, 0.30→2, 0.40→2 hex).
+ *
+ * raw: NumBonusProjectiles=2/4/6, SpreadIncrease=0.20/0.30/0.40.
+ * mitigation pipeline 적용 (resistance / DR / shield / invulnerable).
+ */
+function triggerBuckshot(
+  attacker: CombatUnit,
+  primaryTarget: CombatUnit,
+  finalDamage: number,
+  enemyTeam: CombatUnit[],
+  eventBus: EventBus,
+  tick: number,
+): void {
+  if (attacker.gravesBuckshotProjectiles <= 0) return;
+  const extraProjectiles = attacker.gravesBuckshotProjectiles;
+  const spreadRadius = 1 + Math.round(attacker.gravesBuckshotSpread * 2.5);
+  // primaryTarget 제외, attacker 주변 spread radius 안 가까운 적 (정렬 — distance asc).
+  const candidates = enemyTeam
+    .filter((e) => e.id !== primaryTarget.id && e.state !== 'dead')
+    .map((e) => ({ enemy: e, dist: hexDistance(attacker.position, e.position) }))
+    .filter((x) => x.dist <= spreadRadius)
+    .sort((a, b) => a.dist - b.dist)
+    .slice(0, extraProjectiles);
+  for (const { enemy } of candidates) {
+    let dmg = applyResistance(finalDamage, enemy.stats.armor, attacker.stats.armorPen);
+    if (enemy.damageReduction > 0) dmg *= (1 - enemy.damageReduction);
+    dmg = applyShield(enemy, dmg, eventBus, tick);
+    if (enemy.statusEffects.some(e => e.type === 'invulnerable')) dmg = 0;
+    enemy.currentHp -= dmg;
+    enemy.totalDamageTaken += dmg;
+    attacker.totalDamageDealt += dmg;
+    if (enemy.currentHp <= 0 && enemy.state !== 'dead') {
+      enemy.currentHp = 0;
+      enemy.state = 'dead';
+      attacker.killCount++;
+      eventBus.emit('on_kill', { sourceId: attacker.id, targetId: enemy.id, tick });
+      eventBus.emit('on_death', { sourceId: enemy.id, targetId: attacker.id, tick });
+    }
+  }
+}
+
+/**
+ * LaserBallistics — 평타 hit 후 다음 가까운 적 1명에 추가 hit (감소 50%).
+ * 단일화: BonusHexes=1 의미는 1 칸 너머 추가 비행. 시뮬은 단일 타겟 모델 → 가까운 적 next 1명.
+ * raw: BonusHexes=1, DamageReductionPerTarget=0.5.
+ */
+function triggerLaserBallistics(
+  attacker: CombatUnit,
+  primaryTarget: CombatUnit,
+  finalDamage: number,
+  enemyTeam: CombatUnit[],
+  eventBus: EventBus,
+  tick: number,
+): void {
+  if (attacker.gravesLaserPenetrationHexes <= 0) return;
+  // primaryTarget 제외 가장 가까운 적 (관통 다음 적).
+  const candidates = enemyTeam.filter((e) => e.id !== primaryTarget.id && e.state !== 'dead');
+  if (candidates.length === 0) return;
+  let nextEnemy: CombatUnit | undefined;
+  let bestDist = Infinity;
+  for (const e of candidates) {
+    const d = hexDistance(primaryTarget.position, e.position);
+    if (d < bestDist) { bestDist = d; nextEnemy = e; }
+  }
+  if (!nextEnemy) return;
+  const reducedDmg = finalDamage * (1 - attacker.gravesLaserDmgReductionPerTarget);
+  let dmg = applyResistance(reducedDmg, nextEnemy.stats.armor, attacker.stats.armorPen);
+  if (nextEnemy.damageReduction > 0) dmg *= (1 - nextEnemy.damageReduction);
+  dmg = applyShield(nextEnemy, dmg, eventBus, tick);
+  if (nextEnemy.statusEffects.some(e => e.type === 'invulnerable')) dmg = 0;
+  nextEnemy.currentHp -= dmg;
+  nextEnemy.totalDamageTaken += dmg;
+  attacker.totalDamageDealt += dmg;
+  if (nextEnemy.currentHp <= 0 && nextEnemy.state !== 'dead') {
+    nextEnemy.currentHp = 0;
+    nextEnemy.state = 'dead';
+    attacker.killCount++;
+    eventBus.emit('on_kill', { sourceId: attacker.id, targetId: nextEnemy.id, tick });
+    eventBus.emit('on_death', { sourceId: nextEnemy.id, targetId: attacker.id, tick });
+  }
+}
+
+/**
+ * FragmentationRounds/2 — 평타 hit 시 primaryTarget 주변 N hex 적군 N명에 magic damage.
+ * raw: FragmentDamage=0.15/0.20, FragmentProjectiles=2/3.
+ * splash radius = 1 hex (close fragments).
+ */
+function triggerFragmentation(
+  attacker: CombatUnit,
+  primaryTarget: CombatUnit,
+  finalDamage: number,
+  enemyTeam: CombatUnit[],
+  eventBus: EventBus,
+  tick: number,
+): void {
+  if (attacker.gravesFragDamage <= 0 || attacker.gravesFragProjectiles <= 0) return;
+  const fragDmg = finalDamage * attacker.gravesFragDamage;
+  const candidates = enemyTeam
+    .filter((e) => e.id !== primaryTarget.id && e.state !== 'dead')
+    .map((e) => ({ enemy: e, dist: hexDistance(primaryTarget.position, e.position) }))
+    .filter((x) => x.dist <= 1)
+    .sort((a, b) => a.dist - b.dist)
+    .slice(0, attacker.gravesFragProjectiles);
+  for (const { enemy } of candidates) {
+    let dmg = applyResistance(fragDmg, enemy.stats.magicResist, attacker.stats.magicPen);
+    if (enemy.damageReduction > 0) dmg *= (1 - enemy.damageReduction);
+    dmg = applyShield(enemy, dmg, eventBus, tick);
+    if (enemy.statusEffects.some(e => e.type === 'invulnerable')) dmg = 0;
+    enemy.currentHp -= dmg;
+    enemy.totalDamageTaken += dmg;
+    attacker.totalDamageDealt += dmg;
+    if (enemy.currentHp <= 0 && enemy.state !== 'dead') {
+      enemy.currentHp = 0;
+      enemy.state = 'dead';
+      attacker.killCount++;
+      eventBus.emit('on_kill', { sourceId: attacker.id, targetId: enemy.id, tick });
+      eventBus.emit('on_death', { sourceId: enemy.id, targetId: attacker.id, tick });
+    }
+  }
 }
 
 function applyGravesStatUpgrades(units: CombatUnit[], upgrades: string[] | undefined): void {
@@ -2076,6 +2249,13 @@ function spawnFreljordTurrets(
             gravesGravBoosterAttacksRemaining: 0,
             gravesLatentStoredPct: 0,
             gravesLatentStored: 0,
+            gravesBuckshotProjectiles: 0,
+            gravesBuckshotSpread: 0,
+            gravesLaserPenetrationHexes: 0,
+            gravesLaserDmgReductionPerTarget: 0,
+            gravesFragDamage: 0,
+            gravesFragProjectiles: 0,
+            gravesMeltthroughArmorMR: 0,
             gragasCarryActive: false,
             leonaCarryActive: false,
             attackCount: 0,
@@ -2243,6 +2423,13 @@ function trySpawnGalio(
     gravesGravBoosterAttacksRemaining: 0,
     gravesLatentStoredPct: 0,
     gravesLatentStored: 0,
+    gravesBuckshotProjectiles: 0,
+    gravesBuckshotSpread: 0,
+    gravesLaserPenetrationHexes: 0,
+    gravesLaserDmgReductionPerTarget: 0,
+    gravesFragDamage: 0,
+    gravesFragProjectiles: 0,
+    gravesMeltthroughArmorMR: 0,
     gragasCarryActive: false,
     leonaCarryActive: false,
     attackCount: 0,
@@ -3471,6 +3658,21 @@ export function simulateCombat(
       }
     }
 
+    // 최신상 Meltthrough — 매 1초 graves 주변 2hex 적군 armor/MR -N (영구 누적, floor 0).
+    if (tick > 0 && tick % TICKS_PER_SECOND === 0) {
+      for (const u of allUnits) {
+        if (u.state === 'dead') continue;
+        if (u.gravesMeltthroughArmorMR <= 0) continue;
+        const enemyTeam = u.team === 'player' ? enemies : playerUnits;
+        for (const e of enemyTeam) {
+          if (e.state === 'dead') continue;
+          if (hexDistance(u.position, e.position) > 2) continue;
+          e.stats.armor = Math.max(0, e.stats.armor - u.gravesMeltthroughArmorMR);
+          e.stats.magicResist = Math.max(0, e.stats.magicResist - u.gravesMeltthroughArmorMR);
+        }
+      }
+    }
+
     // 최신상 EmergencyShielding/2 — tick pre-check (safety net).
     // codex P1 fix: damage application 직후 maybeTriggerEmergencyShield() 호출이
     // primary path (평타/DoubleTap inline). 본 tick pre-check 는 비-attack
@@ -3644,6 +3846,15 @@ export function simulateCombat(
             target.gravesLatentStored += finalDamage * unit.gravesLatentStoredPct;
           }
 
+          // 최신상 Phase 3C-1 — 평타 base AOE (Buckshot/Laser/Frag).
+          // 모든 helper 가 mitigation pipeline 적용 + on_kill/on_death emit (kill 시).
+          {
+            const ownEnemyTeam = unit.team === 'player' ? enemies : playerUnits;
+            triggerBuckshot(unit, target, finalDamage, ownEnemyTeam, eventBus, tick);
+            triggerLaserBallistics(unit, target, finalDamage, ownEnemyTeam, eventBus, tick);
+            triggerFragmentation(unit, target, finalDamage, ownEnemyTeam, eventBus, tick);
+          }
+
           // 별돌보미 뱀(Serpent) — 강화 칸 별돌보미 가 평타로 적 명중 시 중독 적용
           triggerSerpentPoison(unit, target, finalDamage);
 
@@ -3742,6 +3953,14 @@ export function simulateCombat(
             // 포함되어야 splash 폭발량 정확. currentHp 가드 제거 — 평타 first hit 과 동일.
             if (unit.gravesLatentStoredPct > 0 && extraFinal > 0) {
               target.gravesLatentStored += extraFinal * unit.gravesLatentStoredPct;
+            }
+
+            // 최신상 Phase 3C-1 — 추가 hit 도 base AOE (Buckshot/Laser/Frag) 트리거.
+            {
+              const ownEnemyTeam = unit.team === 'player' ? enemies : playerUnits;
+              triggerBuckshot(unit, target, extraFinal, ownEnemyTeam, eventBus, tick);
+              triggerLaserBallistics(unit, target, extraFinal, ownEnemyTeam, eventBus, tick);
+              triggerFragmentation(unit, target, extraFinal, ownEnemyTeam, eventBus, tick);
             }
 
             if (target.currentHp <= 0) {

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -1648,13 +1648,47 @@ function triggerLatentExplosion(
  * raw: NumBonusProjectiles=2/4/6, SpreadIncrease=0.20/0.30/0.40.
  * mitigation pipeline 적용 (resistance / DR / shield / invulnerable).
  */
+/**
+ * 공통 helper-hit kill follow-up — codex P2 (PR #57):
+ *  1. arbiter enemyDeathCount++ (Arbiter on_enemy_death trigger 일관성)
+ *  2. LatentExplosion splash (해당 enemy 의 stored > 0 일 때)
+ *  3. GravBooster trigger (attacker 활성 시)
+ * 평타 first hit / extra hit kill 사이트와 동일한 후속 처리 보장.
+ */
+function applyGravesHelperKill(
+  attacker: CombatUnit,
+  deadEnemy: CombatUnit,
+  enemyTeam: CombatUnit[],
+  occupiedPositions: Set<string>,
+  killerArbiterState: ArbiterTriggerState,
+  eventBus: EventBus,
+  tick: number,
+  time: number,
+  logs: CombatLog[],
+  tickLogs: CombatLog[],
+): void {
+  killerArbiterState.enemyDeathCount++;
+  if (deadEnemy.gravesLatentStored > 0) {
+    triggerLatentExplosion(attacker, deadEnemy, enemyTeam, eventBus, tick, time, logs, killerArbiterState);
+  }
+  if (attacker.gravesGravBoosterMaxAttacks > 0) {
+    const aliveEnemies = enemyTeam.filter(e => e.state !== 'dead');
+    triggerGravBooster(attacker, aliveEnemies, occupiedPositions, logs, tickLogs, tick, time);
+  }
+}
+
 function triggerBuckshot(
   attacker: CombatUnit,
   primaryTarget: CombatUnit,
   finalDamage: number,
   enemyTeam: CombatUnit[],
+  occupiedPositions: Set<string>,
+  killerArbiterState: ArbiterTriggerState,
   eventBus: EventBus,
   tick: number,
+  time: number,
+  logs: CombatLog[],
+  tickLogs: CombatLog[],
 ): void {
   if (attacker.gravesBuckshotProjectiles <= 0) return;
   const extraProjectiles = attacker.gravesBuckshotProjectiles;
@@ -1674,12 +1708,17 @@ function triggerBuckshot(
     enemy.currentHp -= dmg;
     enemy.totalDamageTaken += dmg;
     attacker.totalDamageDealt += dmg;
+    // codex P2: helper hit 도 LatentExplosion stored 누적 (graves 가 입힌 모든 피해).
+    if (attacker.gravesLatentStoredPct > 0 && dmg > 0) {
+      enemy.gravesLatentStored += dmg * attacker.gravesLatentStoredPct;
+    }
     if (enemy.currentHp <= 0 && enemy.state !== 'dead') {
       enemy.currentHp = 0;
       enemy.state = 'dead';
       attacker.killCount++;
       eventBus.emit('on_kill', { sourceId: attacker.id, targetId: enemy.id, tick });
       eventBus.emit('on_death', { sourceId: enemy.id, targetId: attacker.id, tick });
+      applyGravesHelperKill(attacker, enemy, enemyTeam, occupiedPositions, killerArbiterState, eventBus, tick, time, logs, tickLogs);
     }
   }
 }
@@ -1694,8 +1733,13 @@ function triggerLaserBallistics(
   primaryTarget: CombatUnit,
   finalDamage: number,
   enemyTeam: CombatUnit[],
+  occupiedPositions: Set<string>,
+  killerArbiterState: ArbiterTriggerState,
   eventBus: EventBus,
   tick: number,
+  time: number,
+  logs: CombatLog[],
+  tickLogs: CombatLog[],
 ): void {
   if (attacker.gravesLaserPenetrationHexes <= 0) return;
   // primaryTarget 제외 가장 가까운 적 (관통 다음 적).
@@ -1716,12 +1760,17 @@ function triggerLaserBallistics(
   nextEnemy.currentHp -= dmg;
   nextEnemy.totalDamageTaken += dmg;
   attacker.totalDamageDealt += dmg;
+  // codex P2: helper hit 도 LatentExplosion stored 누적.
+  if (attacker.gravesLatentStoredPct > 0 && dmg > 0) {
+    nextEnemy.gravesLatentStored += dmg * attacker.gravesLatentStoredPct;
+  }
   if (nextEnemy.currentHp <= 0 && nextEnemy.state !== 'dead') {
     nextEnemy.currentHp = 0;
     nextEnemy.state = 'dead';
     attacker.killCount++;
     eventBus.emit('on_kill', { sourceId: attacker.id, targetId: nextEnemy.id, tick });
     eventBus.emit('on_death', { sourceId: nextEnemy.id, targetId: attacker.id, tick });
+    applyGravesHelperKill(attacker, nextEnemy, enemyTeam, occupiedPositions, killerArbiterState, eventBus, tick, time, logs, tickLogs);
   }
 }
 
@@ -1735,8 +1784,13 @@ function triggerFragmentation(
   primaryTarget: CombatUnit,
   finalDamage: number,
   enemyTeam: CombatUnit[],
+  occupiedPositions: Set<string>,
+  killerArbiterState: ArbiterTriggerState,
   eventBus: EventBus,
   tick: number,
+  time: number,
+  logs: CombatLog[],
+  tickLogs: CombatLog[],
 ): void {
   if (attacker.gravesFragDamage <= 0 || attacker.gravesFragProjectiles <= 0) return;
   const fragDmg = finalDamage * attacker.gravesFragDamage;
@@ -1754,12 +1808,17 @@ function triggerFragmentation(
     enemy.currentHp -= dmg;
     enemy.totalDamageTaken += dmg;
     attacker.totalDamageDealt += dmg;
+    // codex P2: helper hit 도 LatentExplosion stored 누적.
+    if (attacker.gravesLatentStoredPct > 0 && dmg > 0) {
+      enemy.gravesLatentStored += dmg * attacker.gravesLatentStoredPct;
+    }
     if (enemy.currentHp <= 0 && enemy.state !== 'dead') {
       enemy.currentHp = 0;
       enemy.state = 'dead';
       attacker.killCount++;
       eventBus.emit('on_kill', { sourceId: attacker.id, targetId: enemy.id, tick });
       eventBus.emit('on_death', { sourceId: enemy.id, targetId: attacker.id, tick });
+      applyGravesHelperKill(attacker, enemy, enemyTeam, occupiedPositions, killerArbiterState, eventBus, tick, time, logs, tickLogs);
     }
   }
 }
@@ -3848,11 +3907,14 @@ export function simulateCombat(
 
           // 최신상 Phase 3C-1 — 평타 base AOE (Buckshot/Laser/Frag).
           // 모든 helper 가 mitigation pipeline 적용 + on_kill/on_death emit (kill 시).
+          // codex P2 (PR #57): kill 시 arbiter death count + LatentExplosion + GravBooster
+          // follow-up 일관성 위해 occupiedPositions/arbiterState/tickLogs/time 전달.
           {
             const ownEnemyTeam = unit.team === 'player' ? enemies : playerUnits;
-            triggerBuckshot(unit, target, finalDamage, ownEnemyTeam, eventBus, tick);
-            triggerLaserBallistics(unit, target, finalDamage, ownEnemyTeam, eventBus, tick);
-            triggerFragmentation(unit, target, finalDamage, ownEnemyTeam, eventBus, tick);
+            const ownArbiterState = unit.team === 'player' ? playerArbiterState : enemyArbiterState;
+            triggerBuckshot(unit, target, finalDamage, ownEnemyTeam, occupiedPositions, ownArbiterState, eventBus, tick, time, logs, tickLogs);
+            triggerLaserBallistics(unit, target, finalDamage, ownEnemyTeam, occupiedPositions, ownArbiterState, eventBus, tick, time, logs, tickLogs);
+            triggerFragmentation(unit, target, finalDamage, ownEnemyTeam, occupiedPositions, ownArbiterState, eventBus, tick, time, logs, tickLogs);
           }
 
           // 별돌보미 뱀(Serpent) — 강화 칸 별돌보미 가 평타로 적 명중 시 중독 적용
@@ -3956,11 +4018,13 @@ export function simulateCombat(
             }
 
             // 최신상 Phase 3C-1 — 추가 hit 도 base AOE (Buckshot/Laser/Frag) 트리거.
+            // codex P2 (PR #57): helper kill follow-up 일관성 (arbiter / LatentExplosion / GravBooster).
             {
               const ownEnemyTeam = unit.team === 'player' ? enemies : playerUnits;
-              triggerBuckshot(unit, target, extraFinal, ownEnemyTeam, eventBus, tick);
-              triggerLaserBallistics(unit, target, extraFinal, ownEnemyTeam, eventBus, tick);
-              triggerFragmentation(unit, target, extraFinal, ownEnemyTeam, eventBus, tick);
+              const ownArbiterState = unit.team === 'player' ? playerArbiterState : enemyArbiterState;
+              triggerBuckshot(unit, target, extraFinal, ownEnemyTeam, occupiedPositions, ownArbiterState, eventBus, tick, time, logs, tickLogs);
+              triggerLaserBallistics(unit, target, extraFinal, ownEnemyTeam, occupiedPositions, ownArbiterState, eventBus, tick, time, logs, tickLogs);
+              triggerFragmentation(unit, target, extraFinal, ownEnemyTeam, occupiedPositions, ownArbiterState, eventBus, tick, time, logs, tickLogs);
             }
 
             if (target.currentHp <= 0) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -614,6 +614,35 @@ export interface CombatUnit {
    */
   gravesLatentStored: number;
   /**
+   * Buckshot/2/3 — 평타 시 추가 발사 projectile 수 (N-1 nearby hits).
+   * 0 = 미활성 / 2 / 4 / 6. raw NumBonusProjectiles.
+   */
+  gravesBuckshotProjectiles: number;
+  /**
+   * Buckshot/2/3 — spread 정도 (nearby radius 영향). 0 / 0.20 / 0.30 / 0.40.
+   * radius = 1 + round(spread × 2.5) → 1 / 2 / 2 / 2 hex (단순화).
+   */
+  gravesBuckshotSpread: number;
+  /**
+   * LaserBallistics — 관통 hex 수 (다음 적까지 1칸). 0 / 1.
+   * 단일 tier 만 존재 (LaserBallistics2/3 raw 는 tree 미표시 — Riot 미구현).
+   */
+  gravesLaserPenetrationHexes: number;
+  /** LaserBallistics — 관통 적당 damage reduction. 0 / 0.5. */
+  gravesLaserDmgReductionPerTarget: number;
+  /**
+   * FragmentationRounds/2 — 평타 시 주변 파편 fraction. 0 / 0.15 / 0.20.
+   * raw FragmentDamage. magic damage type.
+   */
+  gravesFragDamage: number;
+  /** FragmentationRounds/2 — 파편 개수 (nearby targets). 0 / 2 / 3. */
+  gravesFragProjectiles: number;
+  /**
+   * Meltthrough — 매 1초 graves 주변 2 hex 적군 armor/MR -N (영구 누적, floor 0).
+   * 0 = 미활성 / 4 = 활성. raw ArmorMRReduction.
+   */
+  gravesMeltthroughArmorMR: number;
+  /**
    * 자폭(TFT17_Augment_GragasCarry) 활성 + 가장 강한 그라가스로 선정된 unit 만 true.
    * 그라가스 ability 가 거대한 폭발 (자기 자신 데미지, 다른 아군 X) 로 변환되며,
    * 자폭 데미지로 hp 가 1 미만으로 떨어지지 않음 (HP floor=1).

--- a/tests/unit/simulator/graves-factory-phase3c-1.test.ts
+++ b/tests/unit/simulator/graves-factory-phase3c-1.test.ts
@@ -1,0 +1,178 @@
+/**
+ * 회귀 가드 — 최신상 (TFT17_GravesTrait) 무기고 Phase 3C-1 — 평타 base AOE 7종.
+ *
+ * 적용 7종 (raw effects):
+ *   Buckshot       NumBonusProjectiles=2, SpreadIncrease=0.20 (타겟+주변 혼합)
+ *   Buckshot2      4 / 0.30
+ *   Buckshot3      6 / 0.40
+ *   LaserBallistics BonusHexes=1, DamageReductionPerTarget=0.5 (관통 1명)
+ *   FragmentationRounds  FragmentDamage=0.15, Projectiles=2 (평타 시 주변 파편)
+ *   FragmentationRounds2 FragmentDamage=0.20, Projectiles=3
+ *   Meltthrough    ArmorMRReduction=4 (매초 주변 2hex 적 armor/MR -4)
+ *
+ * Phase 3C-2 (BlastRadius/2/3 + SympatheticDetonation) 는 후속 PR.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+const apGraves = champions.find(c => c.apiName === 'TFT17_Graves')!;
+const dummyEnemy = champions.find(c => c.apiName === 'TFT17_Aatrox')!;
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: [] };
+}
+
+function runWith(upgrades: string[], enemies?: PlacedChampion[]) {
+  const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+  const enemy: PlacedChampion[] = enemies ?? [placed(dummyEnemy, 6, 3)];
+  return simulateCombat(team, enemy, {
+    seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    playerGravesUpgrades: upgrades,
+  });
+}
+
+function gravesOf(result: ReturnType<typeof runWith>) {
+  return result.playerUnits.find(u => u.champion.apiName === 'TFT17_Graves')!;
+}
+
+describe('GravesTrait Phase 3C-1 — Buckshot/2/3 (multi-hit)', () => {
+  it('Buckshot → projectiles=2 / spread=0.20', () => {
+    const grav = gravesOf(runWith(['Buckshot']));
+    expect(grav.gravesBuckshotProjectiles).toBe(2);
+    expect(grav.gravesBuckshotSpread).toBeCloseTo(0.20, 3);
+  });
+
+  it('Buckshot2 → projectiles=4 / spread=0.30', () => {
+    const grav = gravesOf(runWith(['Buckshot2']));
+    expect(grav.gravesBuckshotProjectiles).toBe(4);
+    expect(grav.gravesBuckshotSpread).toBeCloseTo(0.30, 3);
+  });
+
+  it('Buckshot3 → projectiles=6 / spread=0.40', () => {
+    const grav = gravesOf(runWith(['Buckshot3']));
+    expect(grav.gravesBuckshotProjectiles).toBe(6);
+    expect(grav.gravesBuckshotSpread).toBeCloseTo(0.40, 3);
+  });
+
+  it('Buckshot 활성 + 다수 적 → 추가 hits 로 totalDamageDealt 증가', () => {
+    // graves 주변에 3명 배치 (target + 2명 nearby spread radius 안)
+    const enemies = [
+      placed(dummyEnemy, 6, 3),  // primary target
+      placed(dummyEnemy, 1, 1),  // nearby
+      placed(dummyEnemy, 1, 0),  // nearby
+    ];
+    const baseDmg = gravesOf(runWith([], enemies)).totalDamageDealt;
+    const buckDmg = gravesOf(runWith(['Buckshot3'], enemies)).totalDamageDealt;
+    expect(buckDmg).toBeGreaterThan(baseDmg);
+  });
+});
+
+describe('GravesTrait Phase 3C-1 — LaserBallistics (관통)', () => {
+  it('LaserBallistics → penetrationHexes=1 / dmgReduction=0.5', () => {
+    const grav = gravesOf(runWith(['LaserBallistics']));
+    expect(grav.gravesLaserPenetrationHexes).toBe(1);
+    expect(grav.gravesLaserDmgReductionPerTarget).toBeCloseTo(0.5, 3);
+  });
+
+  it('LaserBallistics 활성 + 다수 적 → 관통으로 추가 hit', () => {
+    const enemies = [
+      placed(dummyEnemy, 6, 3),
+      placed(dummyEnemy, 5, 3),  // primary target 1칸 너머
+    ];
+    const baseDmg = gravesOf(runWith([], enemies)).totalDamageDealt;
+    const laserDmg = gravesOf(runWith(['LaserBallistics'], enemies)).totalDamageDealt;
+    expect(laserDmg).toBeGreaterThan(baseDmg);
+  });
+});
+
+describe('GravesTrait Phase 3C-1 — FragmentationRounds/2 (주변 파편)', () => {
+  it('FragmentationRounds → fragDamage=0.15 / projectiles=2', () => {
+    const grav = gravesOf(runWith(['FragmentationRounds']));
+    expect(grav.gravesFragDamage).toBeCloseTo(0.15, 3);
+    expect(grav.gravesFragProjectiles).toBe(2);
+  });
+
+  it('FragmentationRounds2 → fragDamage=0.20 / projectiles=3 (override)', () => {
+    const grav = gravesOf(runWith(['FragmentationRounds', 'FragmentationRounds2']));
+    expect(grav.gravesFragDamage).toBeCloseTo(0.20, 3);
+    expect(grav.gravesFragProjectiles).toBe(3);
+  });
+
+  it('FragmentationRounds 활성 + 인접 적 → 파편 splash 데미지', () => {
+    const enemies = [
+      placed(dummyEnemy, 6, 3),  // primary target
+      placed(dummyEnemy, 5, 3),  // primary 인접 (frag splash 대상)
+    ];
+    const baseDmg = gravesOf(runWith([], enemies)).totalDamageDealt;
+    const fragDmg = gravesOf(runWith(['FragmentationRounds2'], enemies)).totalDamageDealt;
+    expect(fragDmg).toBeGreaterThan(baseDmg);
+  });
+});
+
+describe('GravesTrait Phase 3C-1 — Meltthrough (periodic armor shred)', () => {
+  it('Meltthrough → armorMR reduction=4', () => {
+    const grav = gravesOf(runWith(['Meltthrough']));
+    expect(grav.gravesMeltthroughArmorMR).toBe(4);
+  });
+
+  it('미사용 시 default 0', () => {
+    const grav = gravesOf(runWith([]));
+    expect(grav.gravesMeltthroughArmorMR).toBe(0);
+  });
+
+  it('Meltthrough 활성 시 인접 적 armor/MR 감소 (매초 누적, floor 0)', () => {
+    // graves 주변 2hex 안 적 → 매초 -4 누적. 1초 이상 sim 진행 필요.
+    const enemies = [
+      placed(dummyEnemy, 1, 1),  // graves(0,0) 와 1hex 거리
+    ];
+    const baseEnemy = runWith([], enemies).enemyUnits[0];
+    const meltEnemy = runWith(['Meltthrough'], enemies).enemyUnits[0];
+    // baseline 대비 armor 감소.
+    expect(meltEnemy.stats.armor).toBeLessThan(baseEnemy.stats.armor);
+    expect(meltEnemy.stats.magicResist).toBeLessThan(baseEnemy.stats.magicResist);
+    // floor 0 보장
+    expect(meltEnemy.stats.armor).toBeGreaterThanOrEqual(0);
+    expect(meltEnemy.stats.magicResist).toBeGreaterThanOrEqual(0);
+  });
+
+  it('Meltthrough — 멀리 있는 적은 영향 없음 (radius 2hex)', () => {
+    const farEnemy = placed(dummyEnemy, 6, 3);  // graves(0,0)과 9hex
+    const baseEnemy = runWith([], [farEnemy]).enemyUnits[0];
+    const meltEnemy = runWith(['Meltthrough'], [farEnemy]).enemyUnits[0];
+    // graves 가 적에게 가까이 가지 않으면 melt 영향 없을 가능성. graves 가 적에 인접하면 영향.
+    // 실제 graves 가 attack range 안으로 이동하면 인접 — 시뮬 종료 시 거리 변동 가능.
+    // 본 test 는 melt 가 항상 작동한다는 보장보다는 set 확인 + min 0 floor.
+    expect(meltEnemy.stats.armor).toBeGreaterThanOrEqual(0);
+    expect(meltEnemy.stats.magicResist).toBeGreaterThanOrEqual(0);
+    // 일관성: 적의 armor 가 baseline 보다 같거나 작음.
+    expect(meltEnemy.stats.armor).toBeLessThanOrEqual(baseEnemy.stats.armor);
+  });
+});
+
+describe('GravesTrait Phase 3C-1 — deterministic ordering', () => {
+  it('Buckshot + Buckshot3 동시 → max override (projectiles=6, spread=0.40)', () => {
+    const grav = gravesOf(runWith(['Buckshot', 'Buckshot3']));
+    expect(grav.gravesBuckshotProjectiles).toBe(6);
+    expect(grav.gravesBuckshotSpread).toBeCloseTo(0.40, 3);
+  });
+
+  it('입력 순서 무관 (Buckshot 먼저 vs Buckshot3 먼저) → 동일 결과', () => {
+    const a = gravesOf(runWith(['Buckshot', 'Buckshot3']));
+    const b = gravesOf(runWith(['Buckshot3', 'Buckshot']));
+    expect(a.gravesBuckshotProjectiles).toBe(b.gravesBuckshotProjectiles);
+    expect(a.gravesBuckshotSpread).toBe(b.gravesBuckshotSpread);
+    expect(a.totalDamageDealt).toBeCloseTo(b.totalDamageDealt, 1);
+  });
+
+  it('7종 모두 입력 시 gravesUpgrades 에 모두 포함', () => {
+    const all = ['Buckshot', 'Buckshot2', 'Buckshot3', 'LaserBallistics',
+                 'FragmentationRounds', 'FragmentationRounds2', 'Meltthrough'];
+    const grav = gravesOf(runWith(all));
+    for (const id of all) {
+      expect(grav.gravesUpgrades).toContain(id);
+    }
+  });
+});

--- a/tests/unit/simulator/graves-stat-upgrades.test.ts
+++ b/tests/unit/simulator/graves-stat-upgrades.test.ts
@@ -196,9 +196,9 @@ describe('GravesTrait stat upgrades — 단순 stat 18종 적용', () => {
     expect(grav.gravesTankDamageAmp).toBe(0);
   });
 
-  it('미지원 upgrade ID (Phase 3C/3D 항목) → silently skip', () => {
-    // Buckshot (3C 미구현) + Choke (3D 미구현) + Heartseeker (Phase 2 구현됨).
-    const { grav } = runWith(['Buckshot', 'Choke', 'Heartseeker']);
+  it('미지원 upgrade ID (Phase 3D 항목) → silently skip', () => {
+    // Choke (3D 미구현) + AimAssistant (3D 미구현) + Heartseeker (Phase 2 구현됨).
+    const { grav } = runWith(['Choke', 'AimAssistant', 'Heartseeker']);
     expect(grav.gravesUpgrades).toEqual(['Heartseeker']);
   });
 


### PR DESCRIPTION
## Summary

- Phase 3C 11종 중 **평타 base 7종** 적용 (3C-2 BlastRadius/SympatheticDetonation 4종은 후속 PR).
- 평타 hit 시 multi-target / AOE / periodic debuff 메커닉.

## 적용 7종 (raw effects 정확 매핑)

| weapon | raw effects | 메커니즘 |
|---|---|---|
| Buckshot | NumBonusProjectiles=2, SpreadIncrease=0.20 | 타겟+주변 혼합: primary 외 (N-1) 추가 hit (가까운 적) |
| Buckshot2 | 4 / 0.30 | 동일 패턴 |
| Buckshot3 | 6 / 0.40 | 동일 패턴 |
| LaserBallistics | BonusHexes=1, DamageReductionPerTarget=0.5 | 관통 1명 (finalDmg×0.5) |
| FragmentationRounds | FragmentDamage=0.15, Projectiles=2 | 평타 시 primary 인접 1hex 적 N명에 magic |
| FragmentationRounds2 | 0.20 / 3 | 동일 패턴 |
| Meltthrough | ArmorMRReduction=4 | 매초 graves 주변 2hex 적 armor/MR -4 |

## 사용자 결정 사항

- **Buckshot 모델링**: "타겟 + 주변 혼합" 선택 — 첫 hit primary, 추가 (N-1) 은 graves 주변 spread radius 안 가까운 적 N-1 명 분산. SpreadIncrease 도 nearby radius 결정에 반영.
- spread radius = `1 + round(spread × 2.5)` → 0.20→1, 0.30→2, 0.40→2 hex.

## 구현 디테일

### CombatUnit 확장 (7 fields)
- `gravesBuckshotProjectiles`, `gravesBuckshotSpread`
- `gravesLaserPenetrationHexes`, `gravesLaserDmgReductionPerTarget`
- `gravesFragDamage`, `gravesFragProjectiles`
- `gravesMeltthroughArmorMR`

### Helper 함수 3개
- `triggerBuckshot(attacker, primary, finalDmg, enemyTeam, eventBus, tick)` — N-1 nearby hits
- `triggerLaserBallistics(attacker, primary, finalDmg, ...)` — 다음 가까운 적 50% reduced hit
- `triggerFragmentation(attacker, primary, finalDmg, ...)` — primary 인접 1hex N명 magic splash

모두 mitigation pipeline (resistance / DR / shield / invulnerable) 적용 + on_kill/on_death emit.

### Hot loop 통합
- 평타 first hit + DoubleTap/TripleTap extra hit 양 사이트에서 일관 호출
- Meltthrough: main loop tick % TICKS_PER_SECOND === 0 inline (graves 주변 2hex 적 armor/MR --)

### canonical apply order
- 'Buckshot', 'Buckshot2', 'Buckshot3' / 'FragmentationRounds', 'FragmentationRounds2' / 'LaserBallistics' / 'Meltthrough' 추가 (정렬 — 결정성)

## 영향 측정 (회귀 없음)

양 게임 (mountain / well) 모두 **Graves 미사용** → Phase 3C-1 opt-in 영향 0:

| game | winnerMatchRate | avgPlayerDamageErrorPct |
|---|---|---|
| 23일 (mountain) | 45.5% (변화 없음) | -41.8% (변화 없음) |
| 24일 (well) | 61.9% (변화 없음) | -29.6% (변화 없음) |

## Test plan

- [x] `pnpm lint` — 0 errors / 14 pre-existing warnings
- [x] `pnpm typecheck` — pass
- [x] `pnpm test --run` — **587 passed** / 8 skipped (3C-1 신규 16 assertions 포함)
- [x] `pnpm build` — pass
- [x] `tests/unit/simulator/graves-factory-phase3c-1.test.ts` (16): field 설정, max override, AOE multi-target damage 증가, Meltthrough armor 감소 + floor 0
- [x] `graves-stat-upgrades.test.ts`: silent skip 'Buckshot' → 'Choke/AimAssistant' (3D 미구현) 갱신

## 후속 PR

- **Phase 3C-2 (4종)**: BlastRadius/2/3 (스킬 폭발 반경) + SympatheticDetonation (가까운 적 2nd 폭발)
- **Phase 3D (5종)**: VoidCoefficient / Choke / AimAssistant / Heartseeker3 확장

🤖 Generated with [Claude Code](https://claude.com/claude-code)