### PR TITLE
fix(simulator): DarkStar (6) — 소형 블랙홀 maxHp 보정

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -1288,10 +1288,15 @@ function applyBrawlerEffects(activeTraits: ActiveTrait[], units: CombatUnit[]): 
  *   (2) tier (style 1)  : 블랙홀 execute — currentHp/maxHp ≤ 0.08 적 즉사
  *   (4) tier (style 3)  : (2) + ADAP 45% AD/AP 가산
  *   (6) tier (style 5)  : (4) + 가장 강한 darkStar unit Supermassive
- *                          (ADAP × (1 + 0.85), maxHp × (1 + 0.30))
+ *                          (ADAP × (1 + 0.85), ExecuteHPPercent × (1 + 0.85))
+ *                          + 소형 블랙홀 maxHp = (아군 darkStar maxHp 합) × 0.30
  *   (9) tier (style 6)  : 프리즘 — 별도 prism handler 처리 (10레벨 즉시 승리)
  *
  * 암흑의 별 챔프 (6명): Kaisa, Karma, Jhin, Chogath, Lissandra, Mordekaiser.
+ *
+ * PercentHealth=0.30 변수는 FakeUnit (소형 블랙홀) ability desc 에서 사용:
+ *   "아군 암흑의 별 체력의 30% 만큼 최대 체력을 얻습니다."
+ *   raw hp=1 base 만으로는 첫 공격에 즉사 → 합산 보정 필수.
  */
 function applyDarkStarEffects(activeTraits: ActiveTrait[], units: CombatUnit[]): void {
   const trait = activeTraits.find(t => t.trait.apiName === 'TFT17_DarkStar');
@@ -1300,7 +1305,7 @@ function applyDarkStarEffects(activeTraits: ActiveTrait[], units: CombatUnit[]):
   const adap = (v.ADAP ?? 0) as number;
   const executePct = (v.ExecuteHPPercent ?? 0) as number;
   const supermassiveBonus = (v.SupermassivePercentBonus ?? 0) as number;
-  // PercentHealth=0.30 raw 변수는 desc 에 미사용 → 적용 안 함 (codex 후속 검토).
+  const blackholeHpFrac = (v.PercentHealth ?? 0) as number;
 
   // darkStar unit 식별 (FakeUnit 소형 블랙홀 은 traits=[] 라서 자연 제외됨)
   const darkStarUnits = units.filter(u => unitHasTrait(u, '암흑의 별'));
@@ -1337,6 +1342,22 @@ function applyDarkStarEffects(activeTraits: ActiveTrait[], units: CombatUnit[]):
       // ExecuteHPPercent 도 +85% 강화 — base 0.08 × 1.85 ≈ 0.148 (codex P1 회귀 가드).
       if (executePct > 0) {
         strongest.darkStarExecuteThreshold = executePct * (1 + supermassiveBonus);
+      }
+    }
+  }
+
+  // (6)+ tier 소형 블랙홀 maxHp 보정 (FakeUnit ability desc):
+  //   "아군 암흑의 별 체력의 30% 만큼 최대 체력을 얻습니다."
+  //   합산 시점 — Brawler/Astronaut/Stargazer HP buff 모두 적용 후 (호출 순서 보장).
+  //   미보정 시 hp=1 base 그대로 첫 공격에 즉사 (사용자 보고 회귀 가드).
+  if (trait.style >= 5 && blackholeHpFrac > 0) {
+    const blackholes = units.filter(u => u.champion.apiName === 'TFT17_DarkStar_FakeUnit');
+    if (blackholes.length > 0) {
+      const totalDarkStarHp = darkStarUnits.reduce((sum, u) => sum + u.maxHp, 0);
+      const bonusHp = Math.round(totalDarkStarHp * blackholeHpFrac);
+      for (const bh of blackholes) {
+        bh.maxHp = bh.maxHp + bonusHp;
+        bh.currentHp = bh.maxHp;
       }
     }
   }

--- a/tests/unit/simulator/darkstar-execute-supermassive.test.ts
+++ b/tests/unit/simulator/darkstar-execute-supermassive.test.ts
@@ -7,11 +7,13 @@
  *   (2) tier (style 1)  : 블랙홀 execute (HP ≤ 8% 적 즉사)
  *   (4) tier (style 3)  : (2) + ADAP 45% 가산
  *   (6) tier (style 5)  : (4) + 가장 강한 darkStar unit Supermassive
- *                          (ADAP × 1.85, maxHp × 1.30)
+ *                          (ADAP × 1.85, ExecuteHPPercent × 1.85)
+ *                          + 소형 블랙홀 maxHp = (아군 darkStar maxHp 합) × 0.30
  */
 import { describe, it, expect } from 'vitest';
 import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
 import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import { DARKSTAR_BLACKHOLE_CHAMPION } from '@/data/specialUnits';
 import type { PlacedChampion, RawChampion, RawItem } from '@/types';
 
 const { champions, traits } = loadServerCatalogs();
@@ -131,9 +133,6 @@ describe('G3 — DarkStar (6) tier Supermassive', () => {
     expect(mord.stats.ap - karma.stats.ap).toBeCloseTo(45 * 0.85, 0);
   });
 
-  // PercentHealth=0.30 raw 변수는 trait desc 에 미사용 → maxHp 효과 미적용
-  // (codex P2 후속 검토 결과). desc 명시 효과만 시뮬에 반영.
-
   it('Supermassive unit 의 ExecuteHPPercent 도 +85% 강화 (codex P1 회귀 가드)', () => {
     // desc: "암흑의 별 효과 +85% 증가" → ADAP + ExecuteHPPercent 둘 다 +85%.
     // base 0.08 × 1.85 ≈ 0.148. 일반 darkStar unit 은 그대로 0.08.
@@ -155,5 +154,85 @@ describe('G3 — DarkStar (6) tier Supermassive', () => {
     expect(mord.darkStarExecuteThreshold).toBeCloseTo(0.08 * 1.85, 3);
     // 일반 (Karma): 0.08
     expect(karma.darkStarExecuteThreshold).toBeCloseTo(0.08, 3);
+  });
+});
+
+describe('G3 — 소형 블랙홀 maxHp 보정 (PercentHealth=0.30, FakeUnit ability desc)', () => {
+  function placedBlackhole(q: number, r: number): PlacedChampion {
+    return { champion: DARKSTAR_BLACKHOLE_CHAMPION, starLevel: 1, position: { q, r }, items: [], isSummon: true };
+  }
+
+  it('(6) DarkStar 활성 + 소형 블랙홀 2개 → maxHp = 아군 darkStar 합 × 30%', () => {
+    const team: PlacedChampion[] = [
+      placed(apKaisa, 0, 0),
+      placed(apKarma, 1, 0),
+      placed(apJhin, 2, 0),
+      placed(apChogath, 3, 0),
+      placed(apLissandra, 4, 0),
+      placed(apMordekaiser, 5, 0),
+      placedBlackhole(0, 1),
+      placedBlackhole(1, 1),
+    ];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const blackholes = result.playerUnits.filter(u => u.champion.apiName === 'TFT17_DarkStar_FakeUnit');
+    expect(blackholes).toHaveLength(2);
+
+    // 아군 darkStar maxHp 합산 (Brawler/Astronaut 등 buff 적용 후)
+    const darkStarUnits = result.playerUnits.filter(u =>
+      ['TFT17_Kaisa', 'TFT17_Karma', 'TFT17_Jhin', 'TFT17_Chogath', 'TFT17_Lissandra', 'TFT17_Mordekaiser']
+        .includes(u.champion.apiName)
+    );
+    const totalHp = darkStarUnits.reduce((s, u) => s + u.maxHp, 0);
+    const expectedBlackholeMax = 1 + Math.round(totalHp * 0.30);
+
+    for (const bh of blackholes) {
+      expect(bh.maxHp).toBe(expectedBlackholeMax);
+      expect(bh.currentHp).toBe(bh.maxHp);
+    }
+  });
+
+  it('(6) DarkStar 미활성 ((4) tier) → 블랙홀 maxHp 보정 없음 (raw hp=1 그대로)', () => {
+    const team: PlacedChampion[] = [
+      placed(apKaisa, 0, 0),
+      placed(apKarma, 1, 0),
+      placed(apJhin, 2, 0),
+      placed(apChogath, 3, 0),
+      // 4명 only — (4) tier, supermassive 미발동
+      placedBlackhole(0, 1),  // 비정상적이나 가드 목적
+    ];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const bh = result.playerUnits.find(u => u.champion.apiName === 'TFT17_DarkStar_FakeUnit');
+    if (bh) {
+      // (4) tier — supermassive 비활성 → 블랙홀 hp 보정 안 됨 (base 1)
+      expect(bh.maxHp).toBe(1);
+    }
+  });
+
+  it('블랙홀 maxHp 가 1보다 충분히 커서 첫 공격에 즉사하지 않음 (사용자 보고 회귀 가드)', () => {
+    const team: PlacedChampion[] = [
+      placed(apKaisa, 0, 0),
+      placed(apKarma, 1, 0),
+      placed(apJhin, 2, 0),
+      placed(apChogath, 3, 0),
+      placed(apLissandra, 4, 0),
+      placed(apMordekaiser, 5, 0),
+      placedBlackhole(0, 1),
+      placedBlackhole(1, 1),
+    ];
+    const enemy = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const blackholes = result.playerUnits.filter(u => u.champion.apiName === 'TFT17_DarkStar_FakeUnit');
+    // base hp=1 였으면 합산 30% 보정 안 됐다는 신호 — 최소 100 이상 (실제론 darkStar hp 합 30% 라 수천대)
+    for (const bh of blackholes) {
+      expect(bh.maxHp).toBeGreaterThan(100);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **원인**: `applyDarkStarEffects` 가 `PercentHealth=0.30` raw 변수를 "trait desc 미사용" 으로 잘못 판단해 무시 → 소형 블랙홀이 raw `hp=1` base 그대로 전투 진입 → 첫 공격에 즉사 ("갑자기 사라지는" 사용자 보고)
- **실제 용도**: `TFT17_DarkStar_FakeUnit` ability desc 에서 사용 — "아군 암흑의 별 체력의 30% 만큼 최대 체력을 얻습니다."
- **수정**: (6) tier 활성 시 아군 darkStar 챔프 maxHp 합산 × 30% 만큼 블랙홀 maxHp/currentHp 보정. Brawler/Astronaut/Stargazer HP buff 적용 후 합산되도록 호출 순서 보장

## Test plan

- [x] `darkstar-execute-supermassive.test.ts` 10/10 pass (기존 7 + 신규 3)
  - 블랙홀 maxHp = darkStar 합산 × 0.30 + base 1
  - (4) tier 비활성 시 hp=1 유지 (보정 안 됨)
  - 블랙홀 hp > 100 보장 (즉사 방지 회귀 가드)
- [x] `pnpm lint` 0 errors
- [x] `pnpm typecheck` pass
- [x] `pnpm build` 성공
- [x] 사용자 게임 데이터 실측 검증 (블랙홀 maxHp 비교)

🤖 Generated with [Claude Code](https://claude.com/claude-code)