### PR TITLE
feat(hero-augment): Hero Augment stat/abilityData 시스템 + 17.2b 반영 (PR3)

### DIFF
--- a/docs/meta/set17-hero-augments.md
+++ b/docs/meta/set17-hero-augments.md
@@ -1,0 +1,206 @@
+# Set 17 영웅 증강 (Hero Augment) — 시뮬 구현 도메인 지식
+
+> 작성일: 2026-04-30 (17.2b 패치 시점)
+> 출처: 사용자 인게임 데이터 (2026-04-30 직접 측정/스샷)
+> 적용 PR: PR3 (`feature/hero-augment-stat-system`)
+> 17.2b 변경 표시: ⚠️
+
+## 핵심 개념
+
+**영웅 증강 (Hero Augment)** = 보드 위 가장 강한 (`findStrongestUnitByApi`) 특정 챔프 1명을 augment-specific 빌드로 변환:
+
+1. **역할군 변경** — Tank/Marksman 등 → "공격력 전사" / "주문력 전사" (Fighter / APFighter)
+2. **stat 변경** — HP/Armor/MR/AS/range/mana 등 augment 기준으로 재산정
+3. **ability 변경** — augment 전용 mana cost / damage / shield / 메커니즘
+4. **마나 재생 / 공격 속도 / 타게팅** — 변경된 역할군 룰을 따름 (`mana.ts:ROLE_MANA_CONFIG`)
+
+stat 데이터는 사용자 인게임 측정 후 `statOverrides` 슬롯에 채움. 본 도큐먼트는 **damage/shield/메커니즘 변수** 정리 (사용자 제공분).
+
+## 8 영웅 증강
+
+### 1. 그라가스 — 자폭 (Self-Destruct) `TFT17_Augment_GragasCarry`
+
+| 변수 | 값 |
+|---|---|
+| 마나 | 30 / 80 |
+| 패턴 | aoe_circle, radius 3 |
+| 변환 후 역할 | 주문력 전사 (APFighter / Fighter) |
+| ⚠️ healthCost (체력 비용) | 0.30 → **0.20** (maxHp 비율) |
+| ⚠️ hexReduction (헥스당 감소) | 0.55 → **0.45** |
+| baseDamageHpFrac (체력 비율 damage) | 0.10 |
+| damage [1성/2성/3성] (AP) | 280 / 420 / 630 |
+| tankBonusMultiplier (탱커 추가) | 0.60 (+60%) |
+| HP floor | 1 (자기 스킬로 죽지 않음) |
+
+**메커니즘**: 자폭 시 자기 maxHp × 0.20 만큼 self-damage (HP floor 1). 반경 3칸 magic damage = `maxHp × 0.10 + AP × (280|420|630/100)`. 중심에서 1칸 멀어질 때마다 55% → 45% 감소. 탱커 상대 +60%.
+
+**3성 예시 표기**: 285 = maxHp × 30%(이전), 938 = 10% maxHp + 630 AP
+
+---
+
+### 2. 모데카이저 — 뜨거운 죽음 (Heat Death) `TFT17_Augment_MordekaiserCarry`
+
+| 변수 | 값 |
+|---|---|
+| 마나 | 40 / 100 |
+| 패턴 | aoe_circle (오라), 시작 radius 1 |
+| 변환 후 역할 | 주문력 전사 (APFighter / Fighter) |
+| 패시브 damage [1/2/3] (AP) | 20 / 30 / 45 |
+| 오라 확장 주기 | 6초마다 +1칸 |
+| ⚠️ shield [1/2/3] (AP) | 175/200/250 → **225/250/300** |
+| 사용 시 damage [1/2/3] (AP) | 50 / 75 / 115 |
+| 사용 시 지속시간 | 4초 |
+
+**메커니즘**:
+- 패시브: 매초 본인 주변 반경 N칸 (시작 1, 6초마다 +1) 에 magic damage `20|30|45`
+- 사용 시: `225|250|300` AP 보호막 + 4초 동안 오라 damage 가 `50|75|115` 로 증가
+
+---
+
+### 3. 파이크 — 청부 살인마 `TFT17_Augment_PykeCarry`
+
+| 변수 | 값 |
+|---|---|
+| 마나 | 0 / 40 |
+| 패턴 | single, dash to_lowest_hp (2칸 내) |
+| 변환 후 역할 | 공격력 전사 (Fighter) |
+| damage [1/2/3] (AD) | 220 / 330 / 500 |
+| secondaryDamage [1/2/3] (AD) | 60 / 90 / 135 |
+| tankBonusMultiplier | 0.60 (+60%) |
+| onKillRecast (처치 재시전) | 0.70 (70% damage) |
+| killGoldChance (마지막 일격) | 0.40 / 0.50 / 1.00 |
+
+**메커니즘**: 2칸 내 lowest HP 적에 dash. X 모양으로 베어 대상 + 주변 모든 적 타격. 대상 = AD damage (탱커 +60%), 주변 = secondaryDamage. 처치 시 70% damage 즉시 재시전 (1회 한정 추정 — 사용자 검증 필요).
+
+---
+
+### 4. 잭스 — 저 별을 향해 `TFT17_Augment_JaxCarry`
+
+| 변수 | 값 |
+|---|---|
+| 마나 | 20 / 80 |
+| 패턴 | self_buff |
+| 변환 후 역할 | 주문력 전사 (APFighter / Fighter) |
+| 패시브 onAttackBonus [1/2/3] (AP) | 45 / 70 / 105 |
+| cast damage [1/2/3] (AP) | 155 / 230 / 375 |
+| asGain [1/2/3] (영구) | 0.15 / 0.15 / 0.20 |
+| moveSpeedGain | 동일 비율 (15/15/20%) |
+
+**메커니즘**: 패시브 — 기본 공격당 추가 magic damage. 사용 — 대상 magic damage + 영구 AS/MS +15%/15%/20% (전투 종료까지 누적).
+
+---
+
+### 5. 꼬마정령 (Ivern Minion) — 빅뱅 `TFT17_Augment_IvernMinionCarry`
+
+| 변수 | 값 |
+|---|---|
+| 마나 | 50 / 100 |
+| 패턴 | aoe_circle, radius 3, dash to_largest_cluster (2칸 내) |
+| 변환 후 역할 | 주문력 전사 (APFighter / Fighter) |
+| 패시브 onAttackBonus [1/2/3] (AP, 미프) | 40 / 60 / 90 |
+| cast damage [1/2/3] (AP) | 240 / 360 / 560 |
+| hexReduction (헥스당 감소) | 0.45 |
+| stunDuration [1/2/3] | 1.25 / 1.5 / 1.75 (가장 가까운 3명) |
+
+**메커니즘**: 패시브 onAttack 추가 magic (미프 시너지 잠재력 스케일 — 정령족 잠재력 변수). 사용 — 2칸 내 가장 큰 적 무리에 dash, 반경 3칸 magic damage (1칸당 45% 감소), 가장 가까운 3명 1.25/1.5/1.75초 공중 띄움 (stun + knockup).
+
+---
+
+### 6. 아트록스 — 별빛 연계 `TFT17_Augment_AatroxCarry`
+
+| 변수 | 값 |
+|---|---|
+| 마나 | 30 / 90 |
+| 변환 후 역할 | 공격력 전사 (Fighter) |
+| 3-skill cycle | 타격 → 휩쓸기 → 찍기 (반복) |
+| 타격 damage [1/2/3] (AD) | 140 / 210 / 315 |
+| 휩쓸기 damage [1/2/3] (AD) | 100 / 150 / 225 |
+| 휩쓸기 패턴 | 원뿔 |
+| 휩쓸기 armorReduction (AP) | 10 (방어력 감소) |
+| 찍기 damage [1/2/3] (AD) | 160 / 240 / 360 |
+| 찍기 패턴 | 반경 1칸 (대상 주변) + 공중 띄움 |
+| 찍기 single-target multiplier | 2.50 (단일 적중 시 250%) |
+| N.O.V.A. 타격 damage [1/2/3] (AD) | 120 / 180 / 270 |
+| N.O.V.A. 효과 | 전장 가르고 모든 적 공중 띄움 |
+
+**메커니즘**: 3가지 스킬을 마나 풀 때마다 번갈아 사용 (cycle counter 필요). 시너지 (4) N.O.V.A. 활성 시 cycle 진입 전 N.O.V.A. 타격 (별도 ability). **본 PR 시뮬 미구현 — abilityData 만 정의.** 후속 PR 로 cycle counter + 패턴 분기.
+
+---
+
+### 7. 뽀삐 — 정령단 속도 `TFT17_Augment_PoppyCarry`
+
+| 변수 | 값 |
+|---|---|
+| 마나 | 30 / 100 |
+| 패턴 | projectile, single, range 4 (이미 rangeOverride) |
+| 변환 후 역할 | 원거리 공격력 마법사 (단순화 → Fighter / Marksman, 사용자 결정 필요) |
+| baseDamage [1/2/3] (AD) | 340 / 510 / 850 |
+| armorScale | 1.00 (100% armor 가산) |
+| spiritBounceOnKill | true (처치 시 가장 가까운 적에 튕김, 잔여 damage) |
+| spiritEffectPerStack (미프 정령족 스케일) | 0.15 |
+
+**예시**: 1성 damage 표기 385 = 340 AD + 100% armor + 미프 효과. **미프 (정령족 잠재력) 시너지 의존이라 본 PR 시뮬 미구현.** abilityData 만 정의.
+
+---
+
+### 8. 레오나 — 방패 여전사 (Shieldmaiden) `TFT17_Augment_LeonaCarry`
+
+| 변수 | 값 |
+|---|---|
+| 마나 | 50 / 110 |
+| 패턴 | line, dash to_target (최대 3칸), tank-priority |
+| 변환 후 역할 | 공격력 전사 (Fighter) |
+| pre-dash shield [1/2/3] (AP) | 200 / 240 / 280 |
+| pre-dash shield duration | 2초 |
+| ⚠️ primary damage [1/2/3] (AD) | 110/165/250 → **90/135/225** |
+| primary damage hp scale | 0.28 (+ maxHp × 28%) |
+| stunDuration [1/2/3] | 1.0 / 1.25 / 1.5 |
+| secondaryDamage [1/2/3] (AD) | 180 / 270 / 405 |
+
+**메커니즘**: 2초 보호막 → 최대 3칸 dash (적이 가장 많은 일직선, 탱커 우선) → 첫 적중 적: AD damage + maxHp 28% + stun. 추가 대상: secondaryDamage AD.
+
+**예시**: 1성 primary damage 306 = 90 AD + 28% maxHp.
+
+---
+
+## 시뮬 구현 우선순위 (PR3 본 범위)
+
+### ✅ 본 PR 적용
+
+| 챔프 | 적용 항목 |
+|---|---|
+| 그라가스 | healthCost 0.20, hexReduction 0.45 (17.2b), abilityData damage |
+| 모데카이저 | shield 225/250/300 (17.2b), abilityData passive damage / cast damage |
+| 잭스 | abilityData damage / asGain / passive onAttack damage |
+| 레오나 | primary damage 90/135/225 (17.2b), abilityData secondaryDamage / shield |
+
+### ⏭️ 후속 PR (메커니즘 복잡성)
+
+| 챔프 | 미구현 항목 |
+|---|---|
+| 파이크 | X-shape 멀티 타겟 + onKill 재시전 + killGold |
+| 꼬마정령 | dash to_largest_cluster + multi-stun + 미프 스케일 |
+| 아트록스 | 3-skill cycle + N.O.V.A. 분기 |
+| 뽀삐 | bouncing projectile + 미프 스케일 |
+
+abilityData 슬롯은 모두 채워두되 시뮬 cast 로직만 후속 진행.
+
+### ⏭️ 사용자 인게임 측정 후 채울 항목
+
+`statOverrides` 슬롯 — HP/Armor/MR/AS/range. 사용자가 게임 내에서 augment 활성 vs 비활성 stat 비교 후 PR 추가.
+
+## 17.2b 패치 변경 (본 PR 처리)
+
+| 챔프 | 변수 | 이전 | 17.2b |
+|---|---|---|---|
+| 그라가스 (자폭) | healthCost | 0.30 | **0.20** |
+| 그라가스 (자폭) | hexReduction | 0.55 | **0.45** |
+| 모데카이저 (뜨거운 죽음) | shield AP | 175/200/250 | **225/250/300** |
+| 레오나 (방패 여전사) | primary damage AD | 110/165/250 | **90/135/225** |
+
+## 참고
+
+- 시뮬 적용 위치: `src/data/carryAugments.ts`, `src/lib/simulator/engine/combatLoop.ts:applyHeroCarryTransforms`
+- 마나 재생 룰: `src/lib/simulator/systems/mana.ts:ROLE_MANA_CONFIG`
+- 17.2b 패치 계획: [`set17-patch-17-2b-plan.md`](./set17-patch-17-2b-plan.md)
+- 17.2b 출처 URL: <https://teamfighttactics.leagueoflegends.com/en-us/news/game-updates/teamfight-tactics-patch-17-2/>

--- a/docs/meta/set17-patch-17-2b-plan.md
+++ b/docs/meta/set17-patch-17-2b-plan.md
@@ -5,6 +5,81 @@
 > 라이브 출시: 2026-04-29
 > 출처 URL: <https://teamfighttactics.leagueoflegends.com/en-us/news/game-updates/teamfight-tactics-patch-17-2/>
 
+---
+
+## 🚀 다음 세션 시작 가이드 (Session Handoff)
+
+> **마지막 작업일**: 2026-04-30
+> **새 세션 시작 시 첫 명령**: `docs/meta/set17-patch-17-2b-plan.md` + `docs/meta/set17-hero-augments.md` 읽고 컨텍스트 회복
+
+### 현재 상태 스냅샷
+
+| PR | 상태 | 내용 | 머지 후 다음 |
+|---|---|---|---|
+| **PR #67** | ✅ 머지 완료 (2026-04-30) | 17.2b 직접 수치 변경 (브라이어/레오나/잭스 ability variable + 군체의 심장 disabled) | — |
+| **PR #68** | 🟡 **OPEN** — 사용자 검토/머지 대기 | Hero Augment stat/abilityData 시스템 + 17.2b 데이터 반영 (그라가스 healthCost / 모데 shield / 레오나 damage) | codex 리뷰 응답 후 머지 |
+| **PR2 (신병 추가)** | ⏸️ 미시작 | CDragon 에서 신병 augment fetch → raw JSON 추가 | PR #68 머지 후 진행 |
+
+### 새 세션 첫 액션 결정 트리
+
+1. **PR #68 codex 리뷰 결과 확인** — `gh pr view 68 --comments`
+   - codex P1/P2 있으면 → 수정 → push → 멘션 reply
+   - 리뷰 OK 또는 무시 가능 → 사용자에게 머지 가능 알림
+2. **PR #68 머지된 후** → 아래 후속 작업 중 사용자 우선순위 확인:
+
+### 사용자 결정 대기 중인 항목 (PR #68 머지 후)
+
+| 우선순위 후보 | 작업 양 | 의존성 |
+|---|---|---|
+| **PR2 — 신병 augment 추가** | 1시간 | CDragon fetch + raw JSON 부분 추가 |
+| **PR4 — 자폭 적군 damage 시뮬 적용** | 2-3시간 | 자폭이 현재 적군 damage flow skip — 큰 리팩토링. healthCost 0.20 + 적군 magic damage (baseDamageHpFrac × maxHp + AP) + hexReduction 0.45 + 탱커 +60% |
+| **PR5 — augment-specific damage 시뮬 분기** | 2시간 | 레오나/잭스/모데 등이 carry augment 활성 시 abilityData.damage 사용하도록 getAbilityDamage 분기 |
+| **PR6 — 사용자 stat 측정 후 statOverrides 채우기** | 30분 + 사용자 데이터 | 사용자가 인게임에서 augment 활성/비활성 챔프 stat 비교 측정 후 carryAugments.ts 의 statOverrides 채움 |
+| **PR7+ — 복잡 메커니즘 5종** | 각 1-3시간 | X-shape (Pyke) / multi-stun (꼬마정령) / 3-skill cycle (Aatrox) / bouncing (Poppy) / 미프 (정령족 잠재력) |
+
+### 핵심 결정 사항 (이전 세션에서 확정)
+
+- **데이터 수정 원칙**: raw JSON 전체 덮어쓰기 절대 금지. 변경 필드만 부분 Edit. (메모리 `feedback_data_edit.md`)
+- **PR 분리 전략**: 큰 작업은 항상 PR 단위 분리, 각 PR 머지 후 다음 진행
+- **영웅 증강 시뮬 단순화**: "주문력 전사" / "공격력 전사" → 시뮬 내부 `'Fighter'` 단일 role. 차별화는 ability config 로
+- **statOverrides 채움 정책**: 사용자가 게임에서 직접 측정한 데이터로만 채움. 추측 금지
+- **17.2b 정확 반영분** (PR #67 + #68 합산):
+  - 브라이어 ADDamage [120, 180, 285] (raw)
+  - 레오나 ShieldAmount [..., 480, 620, 870] (raw 일반 ability)
+  - 잭스 ShieldAP [..., 470, 550, 850] (raw)
+  - 군체의 심장 disabled
+  - 그라가스 자폭: `healthCost 0.20`, `hexReduction 0.45` (carryAugments)
+  - 모데카이저 뜨거운 죽음: `shield [225, 250, 300]` (carryAugments)
+  - 레오나 방패 여전사: `damage [90, 135, 225]` (carryAugments)
+
+### 빠른 명령어 cheat sheet
+
+```bash
+# 현재 PR 상태 확인
+gh pr list
+gh pr view 68 --comments
+
+# dev 동기화 (이전 세션에서 이미 dev 정리됨)
+git checkout dev && git pull origin dev
+
+# PR2 시작 시 (신병 augment)
+git checkout -b feature/patch-17-2b-new-recruit
+# CDragon fetch → public/data/tft_set17_augments.json 부분 추가
+
+# 검증 명령
+pnpm lint && pnpm typecheck && pnpm build
+pnpm exec vitest run
+```
+
+### 세션 컨텍스트 빨리 회복하기
+
+1. 본 문서 (PR 분리 전략 + 변경 내역 + 후속 작업)
+2. `docs/meta/set17-hero-augments.md` (8 영웅 증강 도메인 지식)
+3. 메모리 `feedback_data_edit.md` (데이터 수정 원칙 — **반드시 준수**)
+4. PR #67, #68 본문 (코드 변경 요약)
+
+---
+
 ## 17.2b 변경 내역 (전체)
 
 ### 신의 제안 (Market Offerings)

--- a/docs/meta/set17-patch-17-2b-plan.md
+++ b/docs/meta/set17-patch-17-2b-plan.md
@@ -205,12 +205,35 @@ PR1 본문이 아닌 **별도 분석 코멘트** 로 정리:
 
 ## 작업 순서 (다른 세션 인계용)
 
-1. **PR1 부터 시작** — 가장 명확하고 빠름. 머지까지 30분.
-2. PR1 머지 후 **PR2** — 신병 CDragon fetch 후 추가
-3. PR2 머지 후 **PR3** — Hero Augment 시스템 리팩토링
-4. PR3 머지 후 — 모데카이저 등 잔여 영웅 증강 데이터 (사용자 제공 후) 후속 PR
+1. ~~**PR1 부터 시작**~~ ✅ **머지 완료** (PR #67) — 직접 수치 변경 + 군체의 심장 disabled
+2. ~~PR1 머지 후 **PR3 (Hero Augment 시스템)** 먼저 진행~~ — **본 PR 진행 중** (PR2 신병 추가는 후순위로 미룸 — 사용자 결정)
+3. **PR3 머지 후 PR2** — 신병 CDragon fetch 후 추가
+4. **후속 PR** — 사용자 인게임 stat 측정 결과로 statOverrides 채우기 + 복잡 메커니즘 (3-skill cycle / X-shape / bouncing / 미프) 시뮬 적용
 
 각 PR 별로 codex 리뷰 결과 확인 → 수정 → 멘션 → 머지.
+
+## PR3 본 PR 적용 항목 (2026-04-30 작업)
+
+✅ **본 PR 적용**:
+- `CarryAugmentConfig.statOverrides` 슬롯 (사용자 추후 채움)
+- `CarryAbilityData` 확장 (shield/healthCost/hexReduction/asGain/secondaryDamage 등 27 변수)
+- 8 영웅 증강 모두 `abilityData` 채움 (사용자 인게임 데이터 기반)
+- 17.2b 변경분 정확 반영:
+  - 그라가스 자폭 `healthCost: 0.20`, `hexReduction: 0.45`
+  - 모데카이저 뜨거운 죽음 `shield: [225, 250, 300]`
+  - 레오나 방패 여전사 `damage: [90, 135, 225]`
+- `applyHeroCarryTransforms` generic 화 (CARRY_AUGMENTS iterate, statOverrides 적용)
+- 자폭 self-damage 가 `maxHp × healthCost` 정확 적용
+- 회귀 가드 19 tests 신규
+
+⏭️ **후속 PR (구현 미완)**:
+- 자폭 적군 damage / hexReduction / 탱커 +60% 시뮬 적용 (현재 적군 damage flow skip 구조)
+- augment-specific damage 시뮬 분기 (레오나 90/135/225, 잭스 starLevel asGain, 모데 shield 등)
+- 파이크 X-shape 멀티 타겟 + onKill 재시전
+- 꼬마정령 multi-stun + 미프 스케일
+- 아트록스 3-skill cycle + N.O.V.A.
+- 뽀삐 bouncing projectile + 미프
+- `statOverrides` 슬롯 사용자 인게임 측정 후 채움
 
 ## 참고 문서
 

--- a/src/data/carryAugments.ts
+++ b/src/data/carryAugments.ts
@@ -1,4 +1,5 @@
 import type { AbilityConfig } from '@/lib/simulator/systems/ability';
+import type { UnitRole } from '@/types';
 
 export interface CarryScalingInput {
   label: string;
@@ -7,14 +8,89 @@ export interface CarryScalingInput {
   effectPerStack: string;
 }
 
+/**
+ * Hero Augment 활성 시 챔프의 stat override.
+ *
+ * 사용자가 게임 내에서 augment 활성 vs 비활성 stat 차이를 측정 후 채워넣는 슬롯.
+ * undefined 필드는 기존 stat 유지 (안전 default).
+ *
+ * `applyHeroCarryTransforms` 가 augment 활성 시 적용 (중첩 가능 — 다른 buff 와 합산).
+ */
+export interface HeroAugmentStatOverrides {
+  hp?: number;
+  armor?: number;
+  magicResist?: number;
+  damage?: number;
+  attackSpeed?: number;
+  range?: number;
+  mana?: number;
+  initialMana?: number;
+  /** 변환 후 역할군. 마나 재생 / 공격 속도 / 타게팅 룰을 따라감. */
+  role?: UnitRole;
+}
+
+/**
+ * Hero Augment ability data.
+ *
+ * 모든 변수는 [1성, 2성, 3성] tuple. `damage` 는 cast primary damage.
+ * 추가 변수는 augment 별 메커니즘 (shield / hex reduction / self-damage 등) 에 사용.
+ */
 export interface CarryAbilityData {
   name: string;
   desc: string;
   mana: string;
+  /** Cast primary damage [1성, 2성, 3성]. 일부 augment 는 hp/armor 스케일도 포함 → 별도 필드. */
   damage: [number, number, number];
   damageType: 'physical' | 'magic';
   /** 처치당 영구 추가 피해 [1성, 2성, 3성] */
   bonusPerKill?: [number, number, number];
+
+  // ── augment 전용 변수 (옵셔널) ──
+
+  /** Cast 시 자기 보호막 [1성, 2성, 3성] (Mordekaiser/Leona 등). */
+  shield?: [number, number, number];
+  /** 보호막 지속시간 (초). */
+  shieldDuration?: number;
+  /** 패시브 onAttack 추가 damage [1성, 2성, 3성] (Jax/꼬마정령 등). */
+  onAttackBonus?: [number, number, number];
+  /** 패시브 오라 damage [1성, 2성, 3성] (Mordekaiser). */
+  passiveDamage?: [number, number, number];
+  /** 사용 시 강화된 오라 damage [1성, 2성, 3성] (Mordekaiser cast). */
+  empoweredAuraDamage?: [number, number, number];
+  /** 강화 오라 지속시간 (초). */
+  empoweredDuration?: number;
+  /** 추가 대상 damage [1성, 2성, 3성] (Pyke X-shape, Leona line secondary). */
+  secondaryDamage?: [number, number, number];
+  /** 자기 maxHp 비율 self-damage (Gragas healthCost). */
+  healthCost?: number;
+  /** Self-damage HP floor (자기 스킬로 죽지 않음 보장). */
+  selfDamageHpFloor?: number;
+  /** 헥스 거리당 damage 감소 비율 (Gragas hexReduction, 꼬마정령). */
+  hexReduction?: number;
+  /** maxHp 비율 base damage (Gragas: 0.10 = 최대체력 10%). */
+  baseDamageHpFrac?: number;
+  /** 탱커 상대 추가 damage 배율 (Gragas/Pyke: 0.60 = +60%). */
+  tankBonusMultiplier?: number;
+  /** Cast 시 영구 AS 가산 [1성, 2성, 3성] (Jax). */
+  asGain?: [number, number, number];
+  /** Stun/공중 띄움 지속시간 [1성, 2성, 3성] (Leona / 꼬마정령). */
+  stunDuration?: [number, number, number];
+  /** 처치 시 재시전 damage 배율 (Pyke onKill: 0.70 = 70% damage 재시전). */
+  onKillRecastMultiplier?: number;
+  /** 단일 적중 시 damage 배율 (Aatrox 찍기: 2.50). */
+  singleTargetMultiplier?: number;
+  /** Armor 비율 추가 damage (Poppy: 1.00 = 100% armor 가산). */
+  armorScale?: number;
+  /** 정령족 잠재력 (미프) 스케일 — 챔프별 onAttack 또는 cast damage 에 가산. */
+  spiritEffectPerStack?: number;
+  /** 처치 시 가장 가까운 적에게 잔여 damage 튕김 (Poppy). */
+  spiritBounceOnKill?: boolean;
+  /** Aatrox 휩쓸기 armor 감소 (AP 스케일). */
+  armorReduction?: number;
+  /** Aatrox N.O.V.A. 타격 damage [1성, 2성, 3성] (4-NOVA 시너지 활성 시). */
+  novaDamage?: [number, number, number];
+  /** Aatrox 3-skill cycle 패턴 라벨 — 후속 PR 에서 cycle counter 분기. */
+  skillCycleLabels?: readonly string[];
 }
 
 export interface CarryAugmentConfig {
@@ -25,6 +101,8 @@ export interface CarryAugmentConfig {
   damageTypeOverride?: 'physical' | 'magic';
   scalingInput?: CarryScalingInput;
   abilityData?: CarryAbilityData;
+  /** Augment 활성 시 stat 변경 (사용자 인게임 데이터 기반 채움). */
+  statOverrides?: HeroAugmentStatOverrides;
 }
 
 export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
@@ -50,31 +128,51 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
     damageTypeOverride: 'physical',
     abilityData: {
       name: '별빛 연계',
-      desc: '세 가지 스킬을 번갈아 사용합니다.\n타격: 물리 피해\n휩쓸기: 원뿔 범위 물리 피해 + 방어력 감소\n찍기: 반경 1칸 피해 + 공중 띄움 (단독 적중 시 250%)',
+      desc: '세 가지 스킬을 번갈아 사용합니다.\n타격: 물리 피해\n휩쓸기: 원뿔 범위 물리 피해 + 방어력 감소\n찍기: 반경 1칸 피해 + 공중 띄움 (단독 적중 시 250%)\nN.O.V.A. 활성 시: 전장 가르고 모든 적 공중 띄움 + 추가 타격',
       mana: '30/90',
-      damage: [140, 210, 315],
+      damage: [140, 210, 315], // 타격
+      secondaryDamage: [100, 150, 225], // 휩쓸기
+      armorReduction: 10, // 휩쓸기 armor 감소 (AP 스케일)
+      novaDamage: [120, 180, 270], // N.O.V.A. 타격
+      singleTargetMultiplier: 2.5, // 찍기 단독 적중 시 250%
       damageType: 'physical',
+      skillCycleLabels: ['타격', '휩쓸기', '찍기'] as const,
     },
   },
   {
     augmentApiName: 'TFT17_Augment_PoppyCarry',
     targetChampionApiName: 'TFT17_Poppy',
-    abilityOverride: { pattern: 'multi', maxTargets: 3 },
+    abilityOverride: { pattern: 'single', dash: 'to_target' },
     rangeOverride: 4,
     damageTypeOverride: 'physical',
     abilityData: {
       name: '정령단 속도',
-      desc: '원거리 공격력 마법사로 변하며 대상에게 고속 정령을 발사합니다.',
-      mana: '0/40',
-      damage: [100, 150, 240],
+      desc: '거대한 정령을 소환하여 대상에게 발사. 적중한 적에게 AD + 100% 방어력 + 미프 정령족 잠재력 가산. 처치 시 가장 가까운 적에게 잔여 damage 튕김.',
+      mana: '30/100',
+      damage: [340, 510, 850],
+      armorScale: 1.0, // 100% armor 가산
+      spiritEffectPerStack: 0.15,
+      spiritBounceOnKill: true,
       damageType: 'physical',
     },
   },
   {
     augmentApiName: 'TFT17_Augment_LeonaCarry',
     targetChampionApiName: 'TFT17_Leona',
-    abilityOverride: { pattern: 'line', dash: 'to_target', stun: 1.0 },
+    abilityOverride: { pattern: 'line', maxTargets: 4, dash: 'to_target', stun: 1.0, firstHitOnlyStun: true },
     damageTypeOverride: 'physical',
+    abilityData: {
+      name: '방패 여전사',
+      desc: '2초 동안 보호막. 최대 3칸 돌진해 적이 가장 많은 일직선 타격 (탱커 우선). 첫 적중: AD + 28% 최대체력 + 기절. 추가 대상: AD damage. (17.2b 너프)',
+      mana: '50/110',
+      damage: [90, 135, 225], // 17.2b: 110/165/250 → 90/135/225
+      shield: [200, 240, 280],
+      shieldDuration: 2,
+      baseDamageHpFrac: 0.28, // primary damage 에 maxHp 28% 가산
+      stunDuration: [1.0, 1.25, 1.5],
+      secondaryDamage: [180, 270, 405],
+      damageType: 'physical',
+    },
   },
   {
     augmentApiName: 'TFT17_Augment_IvernMinionCarry',
@@ -82,47 +180,79 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
     abilityOverride: { pattern: 'aoe_circle', radius: 3, dash: 'to_farthest' },
     abilityData: {
       name: '빅뱅',
-      desc: '주문력 전사로 변하며 주변 칸으로 도약하여 넓은 반경에 마법 피해를 입힙니다.',
-      mana: '40/100',
-      damage: [200, 300, 480],
+      desc: '주문력 전사로 변환. 패시브: 기본 공격당 추가 magic damage (미프 시너지 잠재력 스케일). 사용: 2칸 내 가장 큰 적 무리에 도약, 반경 3칸 magic damage (1칸당 45% 감소), 가장 가까운 3명 1.25/1.5/1.75초 공중 띄움.',
+      mana: '50/100',
+      damage: [240, 360, 560],
+      onAttackBonus: [40, 60, 90],
+      hexReduction: 0.45,
+      stunDuration: [1.25, 1.5, 1.75],
+      spiritEffectPerStack: 0,
       damageType: 'magic',
     },
   },
   {
     augmentApiName: 'TFT17_Augment_JaxCarry',
     targetChampionApiName: 'TFT17_Jax',
-    abilityOverride: { pattern: 'self_buff', selfBuff: { attackSpeed: 0.3, duration: 999 } },
+    abilityOverride: { pattern: 'self_buff', selfBuff: { attackSpeed: 0.15, duration: 999 } },
     abilityData: {
       name: '저 별을 향해',
-      desc: '주문력 전사로 변하며 기본 공격 시 추가 마법 피해를 입히고 스킬 사용 시 중첩되는 공격 속도를 얻습니다.',
-      mana: '20/60',
-      damage: [60, 90, 140],
+      desc: '주문력 전사로 변환. 패시브: 기본 공격당 추가 magic damage. 사용: 대상 magic damage + 영구 AS/MS +15/15/20% (전투 종료까지 누적).',
+      mana: '20/80',
+      damage: [155, 230, 375],
+      onAttackBonus: [45, 70, 105],
+      asGain: [0.15, 0.15, 0.20],
       damageType: 'magic',
     },
   },
   {
     augmentApiName: 'TFT17_Augment_PykeCarry',
     targetChampionApiName: 'TFT17_Pyke',
-    abilityOverride: { pattern: 'single', dash: 'to_target' },
+    abilityOverride: { pattern: 'single', dash: 'to_lowest_hp' },
     damageTypeOverride: 'physical',
     scalingInput: { label: '처치 수', unit: '회', max: 999, effectPerStack: '골드 +1' },
     abilityData: {
       name: '청부 살인마',
-      desc: '공격력 전사로 변하고, 아군 처치 관여 시 골드를 생성하며, 적 처치 시 초기화되는 스킬을 얻습니다.',
-      mana: '0/50',
-      damage: [200, 300, 480],
+      desc: '공격력 전사로 변환. 2칸 내 lowest HP 적에 dash 후 X 모양 베기. 대상 AD damage (탱커 +60%) + 주변 모든 적 secondaryDamage. 처치 시 70% damage 즉시 재시전.',
+      mana: '0/40',
+      damage: [220, 330, 500],
+      secondaryDamage: [60, 90, 135],
+      tankBonusMultiplier: 0.60,
+      onKillRecastMultiplier: 0.70,
       damageType: 'physical',
     },
   },
   {
     augmentApiName: 'TFT17_Augment_MordekaiserCarry',
     targetChampionApiName: 'TFT17_Mordekaiser',
-    abilityOverride: { pattern: 'aoe_circle', radius: 2 },
+    abilityOverride: { pattern: 'aoe_circle', radius: 1 },
+    abilityData: {
+      name: '뜨거운 죽음',
+      desc: '주문력 전사로 변환. 패시브: 매초 반경 N칸 magic damage (시작 1, 6초마다 +1). 사용: 보호막 + 4초 동안 오라 damage 강화. (17.2b: shield 175/200/250 → 225/250/300)',
+      mana: '40/100',
+      damage: [50, 75, 115], // 사용 시 오라 damage
+      passiveDamage: [20, 30, 45], // 패시브 오라
+      empoweredAuraDamage: [50, 75, 115],
+      empoweredDuration: 4,
+      shield: [225, 250, 300], // 17.2b: 175/200/250 → 225/250/300
+      damageType: 'magic',
+    },
   },
   {
     augmentApiName: 'TFT17_Augment_GragasCarry',
     targetChampionApiName: 'TFT17_Gragas',
-    abilityOverride: { pattern: 'aoe_circle', radius: 3 },
+    abilityOverride: { pattern: 'aoe_circle', radius: 3, selfDamage: true, selfDamageHpFloor: 1 },
+    abilityData: {
+      name: '자폭',
+      desc: '주문력 전사로 변환. 자폭하여 maxHp 20% 희생 + 반경 3칸 magic damage (10% 최대체력 + AP). 1칸당 45% 감소. 탱커 상대 +60%. (17.2b: healthCost 30%→20%, hexReduction 55%→45%)',
+      mana: '30/80',
+      damage: [280, 420, 630], // AP 스케일 base
+      healthCost: 0.20, // 17.2b: 0.30 → 0.20
+      hexReduction: 0.45, // 17.2b: 0.55 → 0.45
+      baseDamageHpFrac: 0.10, // 10% maxHp
+      tankBonusMultiplier: 0.60,
+      selfDamageHpFloor: 1,
+      damageType: 'magic',
+    },
   },
   {
     augmentApiName: 'TFT17_Augment_InvaderZed',

--- a/src/data/carryAugments.ts
+++ b/src/data/carryAugments.ts
@@ -142,12 +142,13 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
   {
     augmentApiName: 'TFT17_Augment_PoppyCarry',
     targetChampionApiName: 'TFT17_Poppy',
-    abilityOverride: { pattern: 'single', dash: 'to_target' },
+    // 정령단 속도: ranged projectile (rangeOverride=4). dash 없음 — 사거리 증가가 핵심.
+    abilityOverride: { pattern: 'single' },
     rangeOverride: 4,
     damageTypeOverride: 'physical',
     abilityData: {
       name: '정령단 속도',
-      desc: '거대한 정령을 소환하여 대상에게 발사. 적중한 적에게 AD + 100% 방어력 + 미프 정령족 잠재력 가산. 처치 시 가장 가까운 적에게 잔여 damage 튕김.',
+      desc: '원거리 공격력 마법사로 변환 (사거리 +N칸). 거대한 정령을 발사. 적중한 적에게 AD + 100% 방어력 + 미프 정령족 잠재력 가산. 처치 시 가장 가까운 적에게 잔여 damage 튕김.',
       mana: '30/100',
       damage: [340, 510, 850],
       armorScale: 1.0, // 100% armor 가산

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -5,7 +5,7 @@ import {
   MF_MODE_CONFIG, ArbiterLaw, STAR_SCALING,
 } from '@/types';
 import arbiterLawsData from '../../../../public/data/arbiter_laws.json';
-import { findCarryAugment } from '@/data/carryAugments';
+import { findCarryAugment, CARRY_AUGMENTS } from '@/data/carryAugments';
 import type { StatusEffectType } from '@/types';
 import { calculateStats, getItemEffects } from '@/lib/simulator/systems/stat';
 import { getAbilityDamage, getAbilityShield, findAbilityTargets, CHAMPION_ABILITY_PATTERNS, getChampionScaling, starValue, getSynergyScaling } from '@/lib/simulator/systems/ability';
@@ -1497,37 +1497,46 @@ function findStrongestUnitByApi(units: CombatUnit[], apiName: string): CombatUni
 }
 
 /**
- * Hero carry augment 변환 — 자폭(GragasCarry) / 방패 여전사(LeonaCarry).
+ * Hero carry augment 변환 — 영웅 증강 활성 시 가장 강한 챔프 1명을 augment-specific
+ * 빌드로 변환:
+ *   1. 역할군 변경 (사용자 명세 "주문력 전사" / "공격력 전사" → 시뮬 내부 'Fighter')
+ *   2. statOverrides 적용 (HP/AS/range 등 — 사용자 인게임 측정 기반 채워넣기)
+ *   3. ability override 는 getAbilityConfigForUnit (carry augment lookup) 에서 처리
  *
- * 자폭 (TFT17_Augment_GragasCarry):
- *   - 가장 강한 그라가스 → "주문력 전사" 변환 (role='APFighter').
- *   - ability 가 거대한 폭발 (자기 자신 데미지, 다른 아군 X) 로 변환.
- *   - 자폭 self-damage 로 hp 가 1 미만으로 떨어지지 않음 (HP floor=1).
+ * 변환 후 마나 재생 / 공격 속도 / 타게팅은 변경된 role 룰 자동 적용 (mana.ts 등).
  *
- * 방패 여전사 (TFT17_Augment_LeonaCarry):
- *   - 가장 강한 레오나 → "공격력 전사" 변환 (role='ADFighter').
- *   - ability 가 적 가로질러 dash + 첫 적중 대상 기절 (CC) 로 변환.
- *
- * 변환 결과 unit 만 gragasCarryActive / leonaCarryActive 가 true. 일반 그라가스/레오나
- * (carry 미선정) 는 기존 ability 그대로.
+ * gragasCarryActive / leonaCarryActive 는 ability 분기용 flag 로 유지 (기존 호출 경로 호환).
+ * 다른 carry augment (Nasus/Aatrox/Poppy/Pyke/IvernMinion/Jax/Mordekaiser) 는
+ * findCarryAugment 에서 ability 가져오므로 별도 flag 불필요.
  */
 function applyHeroCarryTransforms(augmentApiNames: string[], units: CombatUnit[]): void {
   const augSet = new Set(augmentApiNames);
-  // 사용자 명세 "주문력 전사" / "공격력 전사" 는 raw GameRole 표기.
-  // 시뮬 내부 UnitRole 은 단순화 ('Fighter' 단일) — 마나 획득/타게팅 룰 동일하게 처리됨.
-  // 차별화 (AP vs AD) 는 ability config (selfDamage/firstHitOnlyStun) 로 표현.
-  if (augSet.has('TFT17_Augment_GragasCarry')) {
-    const target = findStrongestUnitByApi(units, 'TFT17_Gragas');
-    if (target) {
-      target.gragasCarryActive = true;
-      target.role = 'Fighter';
+  for (const cfg of CARRY_AUGMENTS) {
+    if (!augSet.has(cfg.augmentApiName)) continue;
+    const target = findStrongestUnitByApi(units, cfg.targetChampionApiName);
+    if (!target) continue;
+    // role 변환: statOverrides.role 우선, 없으면 default 'Fighter' (사용자 명세 단순화)
+    target.role = cfg.statOverrides?.role ?? 'Fighter';
+    // statOverrides 적용 — undefined 필드는 기존 stat 유지 (안전 default)
+    const so = cfg.statOverrides;
+    if (so) {
+      if (so.hp !== undefined) {
+        target.maxHp = so.hp;
+        target.currentHp = so.hp;
+      }
+      if (so.armor !== undefined) target.stats.armor = so.armor;
+      if (so.magicResist !== undefined) target.stats.magicResist = so.magicResist;
+      if (so.damage !== undefined) target.stats.damage = so.damage;
+      if (so.attackSpeed !== undefined) target.stats.attackSpeed = so.attackSpeed;
+      if (so.range !== undefined) target.stats.range = so.range;
+      if (so.mana !== undefined) target.maxMana = so.mana;
+      if (so.initialMana !== undefined) target.currentMana = so.initialMana;
     }
-  }
-  if (augSet.has('TFT17_Augment_LeonaCarry')) {
-    const target = findStrongestUnitByApi(units, 'TFT17_Leona');
-    if (target) {
+    // ability 분기용 flag (기존 호출 경로 호환)
+    if (cfg.augmentApiName === 'TFT17_Augment_GragasCarry') {
+      target.gragasCarryActive = true;
+    } else if (cfg.augmentApiName === 'TFT17_Augment_LeonaCarry') {
       target.leonaCarryActive = true;
-      target.role = 'Fighter';
     }
   }
 }
@@ -4882,23 +4891,32 @@ export function simulateCombat(
 
             // 자폭 (GragasCarry) — 일반 ability target 흐름 skip + self 에 데미지 + HP floor.
             // 사용자 명세: 그라가스 본인 데미지, 다른 아군 X, 자기 스킬로 죽지 않음 (HP >= 1).
+            // 17.2b: self-damage 는 maxHp × healthCost (0.20). 기존 raw ability damage 사용 시
+            //   AP 스케일이 그대로 self 에 가해져 부정확 — abilityData.healthCost 우선 사용.
+            //   적군 damage / hexReduction / 탱커 보너스 적용은 후속 PR (자폭이 현재 적군 flow skip 구조).
             if (config.selfDamage) {
               const hpFloor = config.selfDamageHpFloor ?? 0;
+              // 영웅 증강 abilityData.healthCost 가 있으면 maxHp × healthCost, 없으면 raw ability damage.
+              const carryCfg = findCarryAugment(unit.champion.apiName, augNames);
+              const healthCost = carryCfg?.abilityData?.healthCost;
+              const selfDamageRaw = healthCost !== undefined
+                ? unit.maxHp * healthCost
+                : rawAbilityDmg;
               const beforeHp = unit.currentHp;
-              const dmgApplied = Math.max(0, Math.min(rawAbilityDmg, beforeHp - hpFloor));
-              unit.currentHp = Math.max(hpFloor, beforeHp - rawAbilityDmg);
+              const dmgApplied = Math.max(0, Math.min(selfDamageRaw, beforeHp - hpFloor));
+              unit.currentHp = Math.max(hpFloor, beforeHp - selfDamageRaw);
               unit.totalDamageTaken += dmgApplied;
               const selfLog: CombatLog = {
                 tick, time, type: 'ability',
                 sourceId: unit.id, targetId: unit.id,
                 value: Math.round(dmgApplied),
-                message: `${unit.champion.name}이(가) 자폭! 자기 자신에게 ${Math.round(dmgApplied)} 피해 (HP floor=${hpFloor})`,
+                message: `${unit.champion.name}이(가) 자폭! 자기 자신에게 ${Math.round(dmgApplied)} 피해 (HP floor=${hpFloor}${healthCost !== undefined ? `, ${Math.round(healthCost * 100)}% maxHp` : ''})`,
               };
               logs.push(selfLog);
               tickLogs.push(selfLog);
               // on_cast 이벤트 emit — PsyOps 등 cast event subscriber 호환 (codex P2 회귀 가드).
               // targetId 는 self (적군 X). value 는 실제 입은 self damage. rawValue 는 동일 (no resistance for self).
-              eventBus.emit('on_cast', { sourceId: unit.id, targetId: unit.id, value: dmgApplied, rawValue: rawAbilityDmg, tick });
+              eventBus.emit('on_cast', { sourceId: unit.id, targetId: unit.id, value: dmgApplied, rawValue: selfDamageRaw, tick });
               continue; // 일반 ability 흐름 skip — 적군/아군 데미지 없음
             }
 

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -3686,16 +3686,11 @@ export function simulateCombat(
   applySet17SynergyBuffs(enemyActiveTraits, enemies);
 
   // === 전사 AS 패시브 (스테이지 비례 5~30%) ===
+  // codex P2 (PR #68): hero carry augment 가 챔프 role 을 'Fighter' 로 변환할 수 있어
+  // applyHeroCarryTransforms 직후로 호출 위치 이동 (변환된 carry 도 AS bonus 수령).
+  // stageNumber 만 여기서 미리 계산해두고 실제 적용은 transform 이후로 연기.
   const stageNumber = options.stageNumber ?? 4;
   const fighterASBonus = getFighterASBonus(stageNumber);
-  if (fighterASBonus > 0) {
-    for (const u of playerUnits) {
-      if (u.role === 'Fighter') u.stats.attackSpeed *= (1 + fighterASBonus);
-    }
-    for (const u of enemies) {
-      if (u.role === 'Fighter') u.stats.attackSpeed *= (1 + fighterASBonus);
-    }
-  }
 
   // === 칸 버프 증강 ===
   if (options.playerHexBuffs?.length) applyHexBuffs(playerUnits, options.playerHexBuffs);
@@ -3769,6 +3764,17 @@ export function simulateCombat(
   // hero augment carry 변환 — 자폭(그라가스) / 방패 여전사(레오나).
   applyHeroCarryTransforms(playerAugApiNames, playerUnits);
   applyHeroCarryTransforms(enemyAugApiNames, enemies);
+  // 전사 AS 패시브 — carry 변환 후 적용 (codex P2 PR #68).
+  // role='Fighter' 로 변환된 carry (Jax/Pyke/Poppy/Aatrox/Gragas/Leona/Mordekaiser)
+  // 도 stage-based AS bonus 수령. 일반 'Fighter' role 챔프와 동일 처리.
+  if (fighterASBonus > 0) {
+    for (const u of playerUnits) {
+      if (u.role === 'Fighter') u.stats.attackSpeed *= (1 + fighterASBonus);
+    }
+    for (const u of enemies) {
+      if (u.role === 'Fighter') u.stats.attackSpeed *= (1 + fighterASBonus);
+    }
+  }
   // 최신상 (GravesTrait) Frame — 가장 강한 그레이브즈 1명에 stat/메커닉 적용.
   applyGravesFrameEffects(playerUnits, options.playerGravesFrame);
   applyGravesFrameEffects(enemies, options.enemyGravesFrame);

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -98,6 +98,15 @@ describe('CARRY_AUGMENTS 카탈로그 — 8 영웅 증강 abilityData 정의', (
     expect(ivern?.abilityData?.stunDuration).toEqual([1.25, 1.5, 1.75]);
     expect(ivern?.abilityData?.onAttackBonus).toEqual([40, 60, 90]);
   });
+
+  it('뽀삐 정령단 속도: ranged projectile (dash 없음, rangeOverride=4) — codex P1 회귀 가드', () => {
+    // 정령단 속도는 ranged projectile augment. dash 추가 시 매 cast 마다 melee 점프 →
+    // 의도된 ranged behavior 깨짐. abilityOverride 에 dash 없는지 검증.
+    const poppy = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_PoppyCarry');
+    expect(poppy).toBeDefined();
+    expect(poppy!.abilityOverride.dash).toBeUndefined();
+    expect(poppy!.rangeOverride).toBe(4);
+  });
 });
 
 describe('applyHeroCarryTransforms — 8 영웅 증강 모두 처리', () => {

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -19,6 +19,7 @@ import { describe, it, expect } from 'vitest';
 import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
 import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
 import { CARRY_AUGMENTS, findCarryAugment } from '@/data/carryAugments';
+import { getFighterASBonus } from '@/lib/simulator/models/unit';
 import type { PlacedChampion, RawChampion } from '@/types';
 
 const { champions, traits, augments } = loadServerCatalogs();
@@ -138,6 +139,40 @@ describe('applyHeroCarryTransforms — 8 영웅 증강 모두 처리', () => {
     if (u) {
       expect(u.role).toBe('Fighter');
     }
+  });
+
+  // codex P2 (PR #68) 회귀 가드 — hero carry 변환된 unit 도 stage-based Fighter AS bonus 수령.
+  // 변환 전 호출 순서로 인해 AS bonus 누락되는 회귀 방지.
+  it('PoppyCarry 변환 unit 이 stage-based Fighter AS bonus 수령 (codex P2 회귀 가드)', () => {
+    const poppy = champions.find(c => c.apiName === 'TFT17_Poppy');
+    const enemy = champions.find(c => c.apiName === 'TFT17_Briar');
+    const carryAug = augments.find(a => a.apiName === 'TFT17_Augment_PoppyCarry');
+    if (!poppy || !enemy || !carryAug) return;
+    const stage = 5;
+    const expectedBonus = getFighterASBonus(stage);
+    expect(expectedBonus).toBeGreaterThan(0); // sanity
+
+    // baseline — carry augment 없이 run (Poppy 본래 role 은 'Fighter' 가 아님)
+    const baseline = simulateCombat([placed(poppy, 0, 0)], [placed(enemy, 6, 3)], {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: stage,
+    });
+    const baseUnit = baseline.playerUnits.find(u => u.champion.apiName === 'TFT17_Poppy');
+    if (!baseUnit) return;
+    const baseAS = baseUnit.stats.attackSpeed;
+
+    // carry augment 적용 — role='Fighter' 로 변환 + AS bonus 수령 기대
+    const transformed = simulateCombat([placed(poppy, 0, 0)], [placed(enemy, 6, 3)], {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: stage,
+      playerAugments: [carryAug],
+    });
+    const tUnit = transformed.playerUnits.find(u => u.champion.apiName === 'TFT17_Poppy');
+    if (!tUnit) return;
+    expect(tUnit.role).toBe('Fighter');
+
+    // AS ratio 가 (1 + fighterASBonus) 만큼 증가했는지 검증.
+    // carry 변환은 attackSpeed 자체를 건드리지 않으므로 (statOverrides 비어있음) 순수 fighterAS 효과만 측정.
+    const ratio = tUnit.stats.attackSpeed / baseAS;
+    expect(ratio).toBeCloseTo(1 + expectedBonus, 3);
   });
 });
 

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -1,0 +1,169 @@
+/**
+ * 회귀 가드 — 영웅 증강 (Hero Augment) stat/abilityData 시스템 (PR3).
+ *
+ * 본 PR 적용 범위:
+ *   - CarryAugmentConfig.statOverrides 슬롯 (사용자 추후 채움)
+ *   - CarryAbilityData 확장 변수 (shield/healthCost/hexReduction/asGain 등)
+ *   - applyHeroCarryTransforms 가 8개 영웅 증강 모두 처리 (기존 2개 hardcoded → CARRY_AUGMENTS iter)
+ *   - 자폭 self-damage 가 abilityData.healthCost (maxHp × 0.20) 정확 적용 (17.2b)
+ *
+ * 후속 PR 범위:
+ *   - augment-specific damage 시뮬 적용 (레오나 90/135/225 AD, 잭스 starLevel asGain 등)
+ *   - 자폭 적군 damage / hexReduction / 탱커 보너스
+ *   - 복잡 메커니즘 (3-skill cycle / X-shape / bouncing / 미프)
+ *   - 사용자 인게임 stat 측정 후 statOverrides 채우기
+ *
+ * 17.2b 변경 출처: docs/meta/set17-hero-augments.md
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import { CARRY_AUGMENTS, findCarryAugment } from '@/data/carryAugments';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits, augments } = loadServerCatalogs();
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: [] };
+}
+
+describe('CARRY_AUGMENTS 카탈로그 — 8 영웅 증강 abilityData 정의', () => {
+  it('8개 영웅 증강 모두 abilityData 정의됨', () => {
+    const heroAugmentApis = [
+      'TFT17_Augment_GragasCarry',
+      'TFT17_Augment_MordekaiserCarry',
+      'TFT17_Augment_PykeCarry',
+      'TFT17_Augment_JaxCarry',
+      'TFT17_Augment_IvernMinionCarry',
+      'TFT17_Augment_AatroxCarry',
+      'TFT17_Augment_PoppyCarry',
+      'TFT17_Augment_LeonaCarry',
+    ];
+    for (const api of heroAugmentApis) {
+      const cfg = CARRY_AUGMENTS.find(c => c.augmentApiName === api);
+      expect(cfg, `${api} 누락`).toBeDefined();
+      expect(cfg!.abilityData, `${api} abilityData 누락`).toBeDefined();
+    }
+  });
+
+  it('17.2b — 그라가스 자폭: healthCost=0.20, hexReduction=0.45', () => {
+    const gragas = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_GragasCarry');
+    expect(gragas?.abilityData?.healthCost).toBe(0.20);
+    expect(gragas?.abilityData?.hexReduction).toBe(0.45);
+  });
+
+  it('17.2b — 모데카이저 뜨거운 죽음: shield = [225, 250, 300]', () => {
+    const morde = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_MordekaiserCarry');
+    expect(morde?.abilityData?.shield).toEqual([225, 250, 300]);
+  });
+
+  it('17.2b — 레오나 방패 여전사: damage = [90, 135, 225]', () => {
+    const leona = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_LeonaCarry');
+    expect(leona?.abilityData?.damage).toEqual([90, 135, 225]);
+    expect(leona?.abilityData?.shield).toEqual([200, 240, 280]);
+    expect(leona?.abilityData?.baseDamageHpFrac).toBeCloseTo(0.28, 2);
+  });
+
+  it('잭스 저 별을 향해: asGain starLevel 별 [0.15, 0.15, 0.20]', () => {
+    const jax = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_JaxCarry');
+    expect(jax?.abilityData?.asGain).toEqual([0.15, 0.15, 0.20]);
+    expect(jax?.abilityData?.onAttackBonus).toEqual([45, 70, 105]);
+    expect(jax?.abilityData?.damage).toEqual([155, 230, 375]);
+  });
+
+  it('파이크 청부 살인마: tankBonus 0.60 + onKillRecast 0.70', () => {
+    const pyke = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_PykeCarry');
+    expect(pyke?.abilityData?.tankBonusMultiplier).toBe(0.60);
+    expect(pyke?.abilityData?.onKillRecastMultiplier).toBe(0.70);
+    expect(pyke?.abilityData?.secondaryDamage).toEqual([60, 90, 135]);
+  });
+
+  it('아트록스 별빛 연계: 3-skill cycle + N.O.V.A. 변수', () => {
+    const aatrox = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_AatroxCarry');
+    expect(aatrox?.abilityData?.skillCycleLabels).toEqual(['타격', '휩쓸기', '찍기']);
+    expect(aatrox?.abilityData?.novaDamage).toEqual([120, 180, 270]);
+    expect(aatrox?.abilityData?.singleTargetMultiplier).toBe(2.5);
+  });
+
+  it('뽀삐 정령단 속도: armorScale 1.0 + spiritBounceOnKill', () => {
+    const poppy = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_PoppyCarry');
+    expect(poppy?.abilityData?.armorScale).toBe(1.0);
+    expect(poppy?.abilityData?.spiritBounceOnKill).toBe(true);
+    expect(poppy?.abilityData?.damage).toEqual([340, 510, 850]);
+  });
+
+  it('꼬마정령 빅뱅: hexReduction + stunDuration', () => {
+    const ivern = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_IvernMinionCarry');
+    expect(ivern?.abilityData?.hexReduction).toBe(0.45);
+    expect(ivern?.abilityData?.stunDuration).toEqual([1.25, 1.5, 1.75]);
+    expect(ivern?.abilityData?.onAttackBonus).toEqual([40, 60, 90]);
+  });
+});
+
+describe('applyHeroCarryTransforms — 8 영웅 증강 모두 처리', () => {
+  // 각 영웅 증강 활성 시 가장 강한 챔프가 role='Fighter' 로 변환되는지 검증.
+  // statOverrides 비어있어도 기존 stat 유지 (안전 default).
+  function runWithCarry(carryApi: string, championApi: string) {
+    const champ = champions.find(c => c.apiName === championApi);
+    const enemy = champions.find(c => c.apiName === 'TFT17_Aatrox' && c.apiName !== championApi)
+      ?? champions.find(c => c.apiName === 'TFT17_Briar')!;
+    const carryAug = augments.find(a => a.apiName === carryApi);
+    if (!champ || !carryAug) return null;
+    const result = simulateCombat([placed(champ, 0, 0)], [placed(enemy, 6, 3)], {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerAugments: [carryAug],
+    });
+    return result.playerUnits.find(u => u.champion.apiName === championApi);
+  }
+
+  it.each([
+    ['TFT17_Augment_GragasCarry', 'TFT17_Gragas'],
+    ['TFT17_Augment_MordekaiserCarry', 'TFT17_Mordekaiser'],
+    ['TFT17_Augment_LeonaCarry', 'TFT17_Leona'],
+    ['TFT17_Augment_JaxCarry', 'TFT17_Jax'],
+    ['TFT17_Augment_PykeCarry', 'TFT17_Pyke'],
+    ['TFT17_Augment_PoppyCarry', 'TFT17_Poppy'],
+    ['TFT17_Augment_AatroxCarry', 'TFT17_Aatrox'],
+  ])('%s 활성 → 챔프 role = Fighter (변환됨)', (carryApi, championApi) => {
+    const u = runWithCarry(carryApi, championApi);
+    if (u) {
+      expect(u.role).toBe('Fighter');
+    }
+  });
+});
+
+describe('자폭 (GragasCarry) — 17.2b healthCost 적용', () => {
+  it('GragasCarry 활성 시 gragasCarryActive=true + role=Fighter', () => {
+    const gragas = champions.find(c => c.apiName === 'TFT17_Gragas');
+    const enemy = champions.find(c => c.apiName === 'TFT17_Aatrox')!;
+    const carryAug = augments.find(a => a.apiName === 'TFT17_Augment_GragasCarry');
+    if (!gragas || !carryAug) return;
+    const result = simulateCombat([placed(gragas, 0, 0, 2)], [placed(enemy, 6, 3, 2)], {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerAugments: [carryAug],
+    });
+    const g = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Gragas');
+    if (!g) return;
+    expect(g.gragasCarryActive).toBe(true);
+    expect(g.role).toBe('Fighter');
+    // 자폭이 maxHp 를 stat으로 변경하지는 않음 — base HP 보존
+    expect(g.maxHp).toBeGreaterThan(0);
+  });
+
+  it('findCarryAugment 가 그라가스 carry 정상 lookup', () => {
+    const cfg = findCarryAugment('TFT17_Gragas', ['TFT17_Augment_GragasCarry']);
+    expect(cfg).toBeDefined();
+    expect(cfg!.abilityData?.healthCost).toBe(0.20);
+  });
+});
+
+describe('CarryAugmentConfig.statOverrides — 슬롯 추후 채움 가드', () => {
+  it('현재는 모든 augment 의 statOverrides 가 미정의 (사용자 추후 인게임 측정 후 채움)', () => {
+    // 본 PR 은 슬롯만 추가. 사용자가 인게임 stat 측정 후 채울 예정.
+    // 미정의 = augment 활성 시 기존 챔프 stat 그대로 (회귀 없음).
+    for (const cfg of CARRY_AUGMENTS) {
+      // statOverrides 슬롯 자체는 옵셔널 — 정의 안 되어있어야 정상 (현재).
+      expect(cfg.statOverrides ?? null).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

영웅 증강 (Hero Augment) 시뮬 시스템 확장 — 사용자 인게임 데이터 기반 + 17.2b 변경분 반영.

### 변경 핵심

**`CarryAugmentConfig` 타입 확장**
- `statOverrides` 슬롯 추가 (HP/Armor/MR/AS/range/role 등 — 사용자 추후 채움)
- `CarryAbilityData` 확장 27 변수 (shield, healthCost, hexReduction, asGain, secondaryDamage, tankBonusMultiplier, onKillRecastMultiplier, spiritBounceOnKill, novaDamage, skillCycleLabels 등)

**8 영웅 증강 `abilityData` 채움** (사용자 인게임 데이터 출처)
| 챔프 | 17.2b 변경 | 정의 변수 |
|---|---|---|
| 그라가스 (자폭) | `healthCost: 0.20`, `hexReduction: 0.45` | damage / baseDamageHpFrac / tankBonus / hpFloor |
| 모데카이저 (뜨거운 죽음) | `shield: [225, 250, 300]` | passiveDamage / empoweredAuraDamage / empoweredDuration |
| 레오나 (방패 여전사) | `damage: [90, 135, 225]` | shield / baseDamageHpFrac / stunDuration / secondaryDamage |
| 잭스 | — | onAttackBonus / asGain |
| 파이크 | — | secondaryDamage / tankBonus / onKillRecast |
| 꼬마정령 | — | hexReduction / stunDuration / onAttackBonus |
| 아트록스 | — | secondaryDamage / armorReduction / novaDamage / singleTargetMultiplier / skillCycleLabels |
| 뽀삐 | — | armorScale / spiritEffectPerStack / spiritBounceOnKill |

**`applyHeroCarryTransforms` generic 화**
- 기존 2 hardcoded (Gragas/Leona) → `CARRY_AUGMENTS` 전체 iterate
- `statOverrides` 적용 (undefined 시 기존 stat 유지 — 안전 default)
- role 변경 후 마나 재생 / 공격 속도 / 타게팅 자동 적용 (mana.ts 룰)

**시뮬 적용**
- 자폭 self-damage = `maxHp × healthCost` 정확 적용 (HP floor 1 보존)
- 기존 raw ability damage 사용 → augment 전용 healthCost 변수 사용으로 17.2b 정확 반영

## 본 PR 범위 외 (후속 PR)

⏭️ 자폭 적군 damage / hexReduction / 탱커 +60% 시뮬 적용 (현재 적군 damage flow skip 구조)
⏭️ augment-specific damage 시뮬 분기 (레오나 90/135/225 시뮬 적용, 잭스 starLevel asGain, 모데 shield)
⏭️ 파이크 X-shape 멀티 타겟 + onKill 재시전
⏭️ 꼬마정령 multi-stun + 미프 스케일
⏭️ 아트록스 3-skill cycle + N.O.V.A.
⏭️ 뽀삐 bouncing projectile + 미프
⏭️ `statOverrides` 슬롯 — 사용자 인게임 측정 후 채움

## 도메인 문서

- `docs/meta/set17-hero-augments.md` — 8 영웅 증강 메커니즘 + 변수 정리 (다른 세션 인계용)
- `docs/meta/set17-patch-17-2b-plan.md` — PR3 진행 상황 갱신 + 후속 작업 명시

## Test plan

- [x] `tests/unit/simulator/hero-augment-stat-system.test.ts` — 19 신규 회귀 가드
  - 8 augment abilityData 정의 검증
  - 17.2b 변경분 (그라가스/모데카이저/레오나) 검증
  - 7 augment 변환 시 role=Fighter 검증 (it.each)
  - 자폭 gragasCarryActive + maxHp 보존
  - statOverrides 슬롯 미정의 회귀 가드 (사용자 채움 전)
- [x] 전체 664 tests passed
- [x] `pnpm lint` 0 errors
- [x] `pnpm typecheck` pass
- [x] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)