### PR TITLE
feat(patch-17-2b): 신병 augment 추가 (PR2) + Stargazer Fountain 비활성 표기

### DIFF
--- a/docs/superpowers/plans/2026-04-27-stargazer-system-handoff.md
+++ b/docs/superpowers/plans/2026-04-27-stargazer-system-handoff.md
@@ -37,14 +37,14 @@
 
 | 옵션 | 후보 | 영향 게임 | 사이즈 |
 |---|---|---|---|
-| **A** | Fountain 스킬 힐 (`Fountain_HealPercent`) | 24일 직접 | 작음 |
+| ~~**A**~~ | ~~Fountain 스킬 힐 (`Fountain_HealPercent`)~~ ⚠️ **17.2 LIVE 비활성** (Riot patch note: "룰루와 자야 효과 찾는 중") — 진행 금지. Riot patch 17.3+ 효과 확정 시 재고. 메모리 `stargazer_fountain_inactive.md` 참조 | ~~24일 직접~~ | ~~작음~~ |
 | **B** | Huntress 표식 + Serpent 중독 (statusEffect 시스템) | 양 게임 잠재 | 중간 |
 | **C** | Shield cashout (사망 카운트 → 강화 칸 별돌보미 buff) | (현재 게임 영향 적음) | 중간 |
 | **D** | Mountain emblem 누적 (RoundsPerEmblem) | 23일 잠재 | 작음 |
 | **E** | 강화 칸 player level 점진 추가 (revealedTiles) | 양 게임 정확도 | 중간 |
-| **F** | 통합 PR (A+B+C+D+E 한 번에) | 측정 베이스 한 번에 | 크게 |
+| **F** | 통합 PR (B+C+D+E 한 번에) | 측정 베이스 한 번에 | 크게 |
 
-**추천 순서**: A (Fountain — 24일 직접 영향, 단일 메커니즘) → B → C → D → E.
+**추천 순서**: B → C → D → E. (옵션 A Fountain 은 17.2 LIVE 비활성으로 제외)
 
 ## 다음 세션 시작 가이드
 
@@ -58,8 +58,8 @@ pnpm test --run       # baseline 306 pass 확인
 ```
 
 ### 1. PR-4 시작 결정
-- 사용자에게 옵션 (A~F) 중 선택 받기
-- 옵션 A (Fountain) 추천 — 작고 측정 가능
+- 사용자에게 옵션 (B~F) 중 선택 받기 (옵션 A Fountain 은 17.2 LIVE 비활성으로 제외)
+- 옵션 B (Huntress 표식 + Serpent 중독) 또는 D (Mountain emblem 누적) 추천 — 측정 가능 + 활성 메커니즘
 
 ### 2. 작업 패턴 (이전 세션 표준)
 1. 새 feature 브랜치 (`feature/stargazer-...`)

--- a/public/data/tft_set17_augments.json
+++ b/public/data/tft_set17_augments.json
@@ -3,7 +3,7 @@
     "set": 17,
     "source": "CommunityDragon TFT ko_kr.json",
     "extractedAt": "2026-04-29T00:27:54.652Z",
-    "totalAugments": 435
+    "totalAugments": 436
   },
   "augments": [
     {
@@ -8371,6 +8371,23 @@
       "icon": "ASSETS/Maps/TFT/Icons/Augments/Hexcore/ConstructaCompanion_III.TFT_Set16.tex",
       "associatedTraits": [],
       "tags": [],
+      "disable": false
+    },
+    {
+      "name": "신병",
+      "apiName": "TFT6_Augment_ForceOfNature",
+      "desc": "최대 팀 규모가 +@MaxArmySizeIncrease@ 증가하고 4단계 챔피언 @NumUnits@명을 획득합니다.",
+      "effects": {
+        "MaxArmySizeIncrease": 1,
+        "NumUnits": 3
+      },
+      "icon": "ASSETS/Maps/TFT/Icons/Augments/Hexcore/NewRecruit3.tex",
+      "associatedTraits": [],
+      "tags": [
+        "{cf1fd3af}",
+        "{b72bd3bf}",
+        "{d02ae323}"
+      ],
       "disable": false
     }
   ]

--- a/tests/unit/data/augments-disable-filter.test.ts
+++ b/tests/unit/data/augments-disable-filter.test.ts
@@ -17,7 +17,10 @@ import * as path from 'node:path';
 const { augments: filteredAugments } = loadServerCatalogs();
 const rawJson = JSON.parse(
   fs.readFileSync(path.join(process.cwd(), 'public/data/tft_set17_augments.json'), 'utf8'),
-) as { augments: Array<{ apiName: string; disable?: boolean }> };
+) as {
+  meta: { totalAugments: number };
+  augments: Array<{ apiName: string; disable?: boolean; name?: string }>;
+};
 const rawAugments = rawJson.augments;
 
 describe('Augment Set17 풀 필터링 — disable + DISABLED 양쪽 검증', () => {
@@ -74,5 +77,23 @@ describe('Augment Set17 풀 필터링 — disable + DISABLED 양쪽 검증', () 
     for (const api of hidden) {
       expect(filteredAugments.find(a => a.apiName === api)).toBeUndefined();
     }
+  });
+
+  // PR2 (17.2b) — 신병 augment 추가. CDragon raw 그대로 (NumUnits=3 라이브에서는 1로 너프).
+  // 시뮬 영향 없는 econ augment 라 effects 수치는 무관, 카탈로그 노출만 검증.
+  it('17.2b 신병 augment 가 raw JSON 에 추가되어 있다 (apiName=TFT6_Augment_ForceOfNature)', () => {
+    const recruit = rawAugments.find(a => a.apiName === 'TFT6_Augment_ForceOfNature');
+    expect(recruit).toBeDefined();
+    expect(recruit?.name).toBe('신병');
+    expect(recruit?.disable).toBe(false);
+  });
+
+  it('신병 augment 가 loadServerCatalogs() 결과에 노출된다', () => {
+    const recruit = filteredAugments.find(a => a.apiName === 'TFT6_Augment_ForceOfNature');
+    expect(recruit).toBeDefined();
+  });
+
+  it('meta.totalAugments 가 augments 배열 길이와 일치한다', () => {
+    expect(rawJson.meta.totalAugments).toBe(rawAugments.length);
   });
 });


### PR DESCRIPTION
## Summary

- **PR2 (17.2b 후속)** — raw JSON 에 누락되어 있던 **신병** 증강을 CommunityDragon ko_kr.json 에서 가져와 추가. 시뮬 무관 econ augment 라 카탈로그 노출만 목적.
- **Stargazer Fountain 비활성 표기 (작은 docs 정정)** — handoff 문서의 PR-4 옵션 A 가 17.2 LIVE 비활성 사실을 반영 못 하고 잘못 추천하던 문제 정정.

## PR2 — 신병 (New Recruit) 추가 상세

| 항목 | 값 |
|------|-----|
| apiName | `TFT6_Augment_ForceOfNature` (cross-set, set 6 기원) |
| name | 신병 |
| effects | `{ MaxArmySizeIncrease: 1, NumUnits: 3 }` (CDragon raw 그대로) |
| icon | `NewRecruit3.tex` |
| disable | false |
| set 17 활성 | ✅ (`setData.augments` 에 등록됨) |

### 17.2b NumUnits 결정

- 라이브: NumUnits=1 (4코스트 챔프 너프)
- CDragon raw: NumUnits=3 (mid-patch hot fix 미반영)
- **사용자 결정**: 시뮬 무관 econ augment 라 raw 그대로 가져오기. 카탈로그 노출 + desc/icon 만 정확하면 충분.

### 데이터 수정 원칙 준수

- **다른 augment 객체 0개 변경** — `git diff` 로 추가분만 확인 가능 (사용자 작성 한글 desc/name 보존)
- `meta.totalAugments` 435 → 436 (정합성)

## Stargazer Fountain 정정 상세

`combatLoop.ts:2565` 코멘트 \"17.2 LIVE 비활성 (Riot patch note: 룰루와 자야 효과 찾는 중)\" 사실이 두 출처에 반영 안 되어 매 세션마다 잘못된 추천 반복:

| 출처 | 정정 내용 |
|------|---------|
| `docs/superpowers/plans/2026-04-27-stargazer-system-handoff.md` | PR-4 옵션 A \"Fountain 스킬 힐\" 취소선 + 17.2 비활성 명시 + 추천 순서 \"B → C → D → E\" 로 변경 |
| `~/.claude/projects/.../memory/stargazer_fountain_inactive.md` | 별도 메모리 entry (이 PR 외부) — 새 세션에서 자동 컨텍스트 |

## Test plan

- [x] 새 회귀 가드 3종 추가 (`tests/unit/data/augments-disable-filter.test.ts`):
  - 신병이 raw JSON 에 존재 (apiName, name, disable=false)
  - 신병이 `loadServerCatalogs()` 결과에 노출됨
  - `meta.totalAugments` 가 augments 배열 길이와 일치
- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 0 errors (14 warnings 는 본 PR 무관 기존 항목)
- [x] `pnpm build` 통과
- [x] augments-disable-filter.test.ts 10 passed (기존 7 + 신규 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)