### PR TITLE
feat(patch-17-2b): 파이크 carry X-shape + secondary + tankBonus + onKillRecast cascade (PR7-A)

### DIFF
--- a/src/data/carryAugments.ts
+++ b/src/data/carryAugments.ts
@@ -208,7 +208,8 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
   {
     augmentApiName: 'TFT17_Augment_PykeCarry',
     targetChampionApiName: 'TFT17_Pyke',
-    abilityOverride: { pattern: 'single', dash: 'to_lowest_hp' },
+    // PR7-A (17.2b): X-shape pattern (대상 + 4 diagonal hex). dash to_lowest_hp 후 X 모양 베기.
+    abilityOverride: { pattern: 'x_shape', dash: 'to_lowest_hp' },
     damageTypeOverride: 'physical',
     scalingInput: { label: '처치 수', unit: '회', max: 999, effectPerStack: '골드 +1' },
     abilityData: {

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -5167,8 +5167,25 @@ export function simulateCombat(
                 if (unit.mfReplicatorEffectiveness > 0) {
                   abilityDamageAmp += unit.mfReplicatorEffectiveness;
                 }
-                // 초가스: % 최대체력 피해 추가
+                // PR7-A (17.2b): 파이크 carry primary vs secondary damage 분기 + tankBonus.
+                //   primary target (대상): abilityData.damage (rawAbilityDmg, abilityDmg 에 이미 반영됨)
+                //   secondary targets (X-shape 주변 적): abilityData.secondaryDamage
+                //   tankBonusMultiplier: primary target 이 탱커 일 때만 +N% (사용자 결정 PR4 동일 — role==='Tank' 만)
                 let baseDmg = abilityDmg;
+                const isPrimaryTarget = t === abilityTarget;
+                if (carryCfg?.abilityData?.secondaryDamage && !isPrimaryTarget) {
+                  const secArr = carryCfg.abilityData.secondaryDamage;
+                  const secBase = secArr[unit.starLevel - 1] ?? secArr[0];
+                  const secDmgType: DamageType = carryCfg.damageTypeOverride
+                    ?? carryCfg.abilityData.damageType ?? 'magic';
+                  baseDmg = secDmgType === 'magic'
+                    ? secBase * (1 + unit.stats.ap / 100)
+                    : secBase;
+                }
+                if (isPrimaryTarget && carryCfg?.abilityData?.tankBonusMultiplier && t.role === 'Tank') {
+                  baseDmg *= (1 + carryCfg.abilityData.tankBonusMultiplier);
+                }
+                // 초가스: % 최대체력 피해 추가
                 if (unit.champion.apiName === 'TFT17_Chogath') {
                   const pctVar = unit.champion.ability.variables?.find(v => v.name === 'PercentMaximumHealthDamage');
                   const pctHp = pctVar?.value?.[unit.starLevel] ?? 0.08;
@@ -5256,6 +5273,101 @@ export function simulateCombat(
                   tickLogs.push(deathLog);
                   eventBus.emit('on_kill', { sourceId: unit.id, targetId: t.id, tick });
                   eventBus.emit('on_death', { sourceId: t.id, targetId: unit.id, tick });
+                }
+              }
+
+              // === PR7-A (17.2b) — 파이크 carry onKillRecast cascade ===
+              // primary target 처치 시 완전 재 cast (새 dash + 새 X-shape) damage × recastMul.
+              // 사용자 결정: cascade max chain 5 (무한 루프 방지). 새 dash to_lowest_hp.
+              // 재시전 damage 는 totalAbilityDmg / totalRawAbilityDmg 에 누적 — omnivamp / Fountain
+              // / on_cast 정합. damageAmp / sniper / crit / mitigation 은 cast loop 와 동일 적용.
+              const recastMul = carryCfg?.abilityData?.onKillRecastMultiplier ?? 0;
+              if (recastMul > 0 && abilityTarget.state === 'dead') {
+                const MAX_RECAST_CHAIN = 5;
+                let chainCount = 0;
+                while (chainCount < MAX_RECAST_CHAIN) {
+                  chainCount++;
+                  const aliveOpp = opposingTeam.filter(u => u.state !== 'dead');
+                  if (aliveOpp.length === 0) break;
+                  const newPrimary = findLowestHpEnemy(aliveOpp);
+                  if (!newPrimary) break;
+
+                  // 새 dash + 새 X-shape 재계산
+                  let recastTarget = newPrimary;
+                  if (config.dash) {
+                    recastTarget = applyAbilityDash(
+                      unit, config.dash, newPrimary, opposingTeam,
+                      occupiedPositions, logs, tickLogs, tick, time
+                    );
+                  }
+                  const recastTargets = findAbilityTargets(unit, recastTarget, opposingTeam, config);
+                  const recastAlive = recastTargets.filter(rt => rt.state !== 'dead');
+
+                  for (const t of recastAlive) {
+                    const isPrimaryRecast = t === recastTarget;
+                    // primary vs secondary base damage 분기 (cast loop 패턴 동일)
+                    let recastBaseDmg: number;
+                    if (carryCfg?.abilityData?.secondaryDamage && !isPrimaryRecast) {
+                      const secArr = carryCfg.abilityData.secondaryDamage;
+                      const secBase = secArr[unit.starLevel - 1] ?? secArr[0];
+                      const secDt: DamageType = carryCfg.damageTypeOverride
+                        ?? carryCfg.abilityData.damageType ?? 'magic';
+                      recastBaseDmg = secDt === 'magic'
+                        ? secBase * (1 + unit.stats.ap / 100)
+                        : secBase;
+                    } else {
+                      recastBaseDmg = abilityDmg;
+                    }
+                    recastBaseDmg *= recastMul;
+                    if (isPrimaryRecast && carryCfg?.abilityData?.tankBonusMultiplier && t.role === 'Tank') {
+                      recastBaseDmg *= (1 + carryCfg.abilityData.tankBonusMultiplier);
+                    }
+
+                    const ampMul = 1 + unit.damageAmp + computeSniperDamageAmp(unit, t);
+                    let dmg = recastBaseDmg * ampMul;
+                    if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
+                      dmg *= unit.stats.critMultiplier;
+                    }
+                    totalRawAbilityDmg += dmg;
+
+                    const resistance = dmgType === 'magic' ? t.stats.magicResist
+                      : dmgType === 'physical' ? t.stats.armor : 0;
+                    const pen = dmgType === 'magic' ? unit.stats.magicPen
+                      : dmgType === 'physical' ? unit.stats.armorPen : 0;
+                    let effectiveDmg = applyResistance(dmg, resistance, pen);
+                    if (t.damageReduction > 0) effectiveDmg *= (1 - t.damageReduction);
+                    if ((t.role === 'Fighter' || t.role === 'Assassin') && t.target !== unit.id) {
+                      effectiveDmg *= (1 - NON_TARGET_DAMAGE_REDUCTION);
+                    }
+                    effectiveDmg = applyShield(t, effectiveDmg, eventBus, tick);
+                    if (t.statusEffects.some(e => e.type === 'invulnerable')) effectiveDmg = 0;
+
+                    t.currentHp -= effectiveDmg;
+                    t.totalDamageTaken += effectiveDmg;
+                    unit.totalDamageDealt += effectiveDmg;
+                    totalAbilityDmg += effectiveDmg;
+
+                    const recastLog: CombatLog = {
+                      tick, time, type: 'ability',
+                      sourceId: unit.id, targetId: t.id,
+                      value: Math.round(effectiveDmg),
+                      message: `${unit.champion.name} 자동 재시전 #${chainCount}! ${t.champion.name}에게 ${Math.round(effectiveDmg)} 피해 (×${recastMul})`,
+                    };
+                    logs.push(recastLog);
+                    tickLogs.push(recastLog);
+
+                    if (t.currentHp <= 0) {
+                      t.currentHp = 0;
+                      t.state = 'dead';
+                      unit.killCount++;
+                      if (unit.team === 'player') playerArbiterState.enemyDeathCount++;
+                      else enemyArbiterState.enemyDeathCount++;
+                      eventBus.emit('on_kill', { sourceId: unit.id, targetId: t.id, tick });
+                      eventBus.emit('on_death', { sourceId: t.id, targetId: unit.id, tick });
+                    }
+                  }
+                  // primary recast target 처치 못했으면 cascade 종료
+                  if (recastTarget.state !== 'dead') break;
                 }
               }
 

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -5323,8 +5323,22 @@ export function simulateCombat(
                       recastBaseDmg *= (1 + carryCfg.abilityData.tankBonusMultiplier);
                     }
 
-                    const ampMul = 1 + unit.damageAmp + computeSniperDamageAmp(unit, t);
-                    let dmg = recastBaseDmg * ampMul;
+                    // codex P2 (PR #72): full damage amp stack — 일반 cast loop (line ~5155)
+                    // 와 동일하게 inventionTankDamageAmp / gravesTankDamageAmp /
+                    // mfReplicatorEffectiveness 포함. Tank target 한정 buff 누락 시
+                    // recast under-damage 회귀.
+                    let recastDamageAmp = unit.damageAmp;
+                    if (unit.inventionTankDamageAmp > 0 && t.role === 'Tank') {
+                      recastDamageAmp += unit.inventionTankDamageAmp;
+                    }
+                    if (unit.gravesTankDamageAmp > 0 && t.role === 'Tank') {
+                      recastDamageAmp += unit.gravesTankDamageAmp;
+                    }
+                    recastDamageAmp += computeSniperDamageAmp(unit, t);
+                    if (unit.mfReplicatorEffectiveness > 0) {
+                      recastDamageAmp += unit.mfReplicatorEffectiveness;
+                    }
+                    let dmg = recastBaseDmg * (1 + recastDamageAmp);
                     if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
                       dmg *= unit.stats.critMultiplier;
                     }
@@ -5346,6 +5360,10 @@ export function simulateCombat(
                     t.totalDamageTaken += effectiveDmg;
                     unit.totalDamageDealt += effectiveDmg;
                     totalAbilityDmg += effectiveDmg;
+
+                    // codex P2 (PR #72): Serpent poison — 일반 cast loop 와 동일하게
+                    // 강화 칸 별돌보미 ability 명중 시 중독 적용. recast hits 도 동일 처리.
+                    triggerSerpentPoison(unit, t, effectiveDmg);
 
                     const recastLog: CombatLog = {
                       tick, time, type: 'ability',

--- a/src/lib/simulator/systems/ability.ts
+++ b/src/lib/simulator/systems/ability.ts
@@ -336,6 +336,23 @@ export function findAbilityTargets(
     case 'self_buff':
       return [caster];
 
+    case 'x_shape': {
+      // PR7-A (17.2b): 파이크 carry "X 모양으로 베기" — 대상 + 4 diagonal hex direction.
+      // axial 6 directions 중 horizontal (E/W = [±1, 0]) 제외, 4 angled direction 선택:
+      //   NE [+1,-1], NW [0,-1], SE [0,+1], SW [-1,+1]
+      // 시각적으로 X 형태. 사용자 결정 (PR #?? 후속) — raw 데이터 비어있어 추정.
+      const tp = primaryTarget.position;
+      const xHexes: { q: number; r: number }[] = [
+        tp, // 대상 본인
+        { q: tp.q + 1, r: tp.r - 1 }, // NE
+        { q: tp.q,     r: tp.r - 1 }, // NW
+        { q: tp.q,     r: tp.r + 1 }, // SE
+        { q: tp.q - 1, r: tp.r + 1 }, // SW
+      ];
+      const xSet = new Set(xHexes.map(h => `${h.q},${h.r}`));
+      return alive.filter(u => xSet.has(`${u.position.q},${u.position.r}`));
+    }
+
     default:
       return [primaryTarget];
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -402,7 +402,8 @@ export type AbilityPattern =
   | 'multi'       // 지정 다수
   | 'bounce'      // 튕김
   | 'global'      // 전체 적
-  | 'self_buff';  // 자기 버프
+  | 'self_buff'   // 자기 버프
+  | 'x_shape';    // X 모양 (대상 + 4 diagonal hex direction) — 파이크 carry
 
 export type StatusEffectType = 'stun' | 'slow' | 'burn' | 'shield' | 'invulnerable' | 'disarm' | 'taunt' | 'mark' | 'poison';
 

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -482,6 +482,42 @@ describe('PR7-A — 파이크 carry X-shape 멀티 타겟 + onKill cascade', () 
     expect(file).toMatch(/recastTarget\.state !== 'dead'\) break/);
   });
 
+  // codex P2 (PR #72) 회귀 가드 — recast 코드가 일반 cast loop 의 4개 buff 모두 포함.
+  // 누락 시 inventionTankDamageAmp / gravesTankDamageAmp / mfReplicatorEffectiveness 미적용
+  // → recast under-damage 회귀.
+  it('cascade recast 가 full damage amp stack 포함 (codex P2 PR #72)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // recast loop 안에 4개 amp source 모두 포함:
+    //   - inventionTankDamageAmp (Tank 한정)
+    //   - gravesTankDamageAmp (Tank 한정)
+    //   - computeSniperDamageAmp (per target)
+    //   - mfReplicatorEffectiveness (replicator)
+    expect(file).toMatch(/recastDamageAmp\s*\+=\s*unit\.inventionTankDamageAmp/);
+    expect(file).toMatch(/recastDamageAmp\s*\+=\s*unit\.gravesTankDamageAmp/);
+    expect(file).toMatch(/recastDamageAmp\s*\+=\s*computeSniperDamageAmp/);
+    expect(file).toMatch(/recastDamageAmp\s*\+=\s*unit\.mfReplicatorEffectiveness/);
+  });
+
+  // codex P2 (PR #72) 회귀 가드 — recast hits 가 Serpent poison trigger 호출.
+  it('cascade recast 가 triggerSerpentPoison 호출 (codex P2 PR #72)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // recast loop 안 (recastBaseDmg / recastDamageAmp 등) 에서 triggerSerpentPoison 호출 확인.
+    // 일반 cast loop 1회 + recast loop 1회 = 총 2회 호출되어야 함.
+    const calls = file.match(/triggerSerpentPoison\(unit,\s*t,\s*effectiveDmg\)/g);
+    expect(calls).toBeDefined();
+    expect(calls!.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('파이크 carry 활성 시 시뮬 정상 작동 (sanity)', () => {
     const pyke = champions.find(c => c.apiName === 'TFT17_Pyke');
     const enemy = champions.find(c => c.apiName === 'TFT17_Aatrox');

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -423,6 +423,86 @@ describe('PR5 — augment-specific damage 시뮬 분기 (resolveAbilityDamage)',
   });
 });
 
+// PR7-A (17.2b 후속) — 파이크 carry X-shape + secondary + tankBonus + onKillRecast cascade.
+// 사용자 결정:
+//   - X-shape = 새 pattern 'x_shape' (대상 + 4 diagonal hex direction)
+//   - cascade = 완전 재 cast (새 dash + 새 X-shape, max chain 5)
+describe('PR7-A — 파이크 carry X-shape 멀티 타겟 + onKill cascade', () => {
+  it('PykeCarry abilityOverride 가 x_shape pattern 으로 변경됨', () => {
+    const pyke = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_PykeCarry');
+    expect(pyke).toBeDefined();
+    expect(pyke!.abilityOverride.pattern).toBe('x_shape');
+    expect(pyke!.abilityOverride.dash).toBe('to_lowest_hp');
+  });
+
+  it('PykeCarry abilityData 핵심 변수 (PR7-A 시뮬 의존)', () => {
+    const pyke = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_PykeCarry');
+    expect(pyke?.abilityData?.damage).toEqual([220, 330, 500]);
+    expect(pyke?.abilityData?.secondaryDamage).toEqual([60, 90, 135]);
+    expect(pyke?.abilityData?.tankBonusMultiplier).toBe(0.60);
+    expect(pyke?.abilityData?.onKillRecastMultiplier).toBe(0.70);
+    expect(pyke?.abilityData?.damageType).toBe('physical');
+  });
+
+  it('AbilityPattern 에 x_shape 추가됨 (회귀 가드 — type 정의 직접 검증)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/types/index.ts'),
+      'utf8',
+    );
+    expect(file).toMatch(/'x_shape'/);
+  });
+
+  it('findAbilityTargets x_shape case 정의됨 (4 diagonal hex)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/systems/ability.ts'),
+      'utf8',
+    );
+    // x_shape case + 4 diagonal direction 패턴 (NE/NW/SE/SW axial offset)
+    expect(file).toMatch(/case 'x_shape'/);
+    expect(file).toMatch(/q: tp\.q \+ 1, r: tp\.r - 1/); // NE
+    expect(file).toMatch(/q: tp\.q - 1, r: tp\.r \+ 1/); // SW
+  });
+
+  it('onKillRecast cascade 코드 fingerprint — combatLoop.ts (max chain 5)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // cascade 핵심 패턴 검증
+    expect(file).toMatch(/MAX_RECAST_CHAIN\s*=\s*5/);
+    expect(file).toMatch(/onKillRecastMultiplier/);
+    expect(file).toMatch(/while \(chainCount < MAX_RECAST_CHAIN\)/);
+    // cascade 종료 조건 — primary recast target 처치 못했으면 break
+    expect(file).toMatch(/recastTarget\.state !== 'dead'\) break/);
+  });
+
+  it('파이크 carry 활성 시 시뮬 정상 작동 (sanity)', () => {
+    const pyke = champions.find(c => c.apiName === 'TFT17_Pyke');
+    const enemy = champions.find(c => c.apiName === 'TFT17_Aatrox');
+    const carryAug = augments.find(a => a.apiName === 'TFT17_Augment_PykeCarry');
+    if (!pyke || !enemy || !carryAug) return;
+    const result = simulateCombat(
+      [placed(pyke, 0, 3, 2)],
+      [placed(enemy, 0, 4, 2)],
+      {
+        seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+        playerAugments: [carryAug],
+      }
+    );
+    const p = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Pyke');
+    if (!p) return;
+    expect(p.role).toBe('Fighter');
+    // x_shape pattern + cascade 정상 작동 (crash 없음, totalDamageDealt 산출됨)
+    expect(p.totalDamageDealt).toBeGreaterThanOrEqual(0);
+  });
+});
+
 describe('CarryAugmentConfig.statOverrides — 슬롯 추후 채움 가드', () => {
   it('현재는 모든 augment 의 statOverrides 가 미정의 (사용자 추후 인게임 측정 후 채움)', () => {
     // 본 PR 은 슬롯만 추가. 사용자가 인게임 stat 측정 후 채울 예정.


### PR DESCRIPTION
## Summary

- **PR7-A (17.2b 후속)** — 파이크 carry "청부 살인마" 핵심 메커니즘 4종 시뮬 적용:
  - X 모양 멀티 타겟 (대상 + 4 diagonal hex)
  - secondaryDamage [60,90,135] AD (주변 적)
  - tankBonusMultiplier 0.60 (탱커 +60%, primary 한정)
  - onKillRecast 0.70 cascade (처치 시 70% damage 즉시 재시전, max chain 5)

## 사용자 결정

| 항목 | 결정 | 이유 |
|------|------|------|
| **X-shape 정의** | 새 pattern \`'x_shape'\` (대상 + 4 diagonal) | hex axial 6 directions 중 horizontal (E/W) 제외, 4 angled (NE/NW/SE/SW) 선택 — 시각적 X 형태 |
| **cascade 구현** | 완전 재 cast (새 dash + 새 X-shape) | 게임 의도 가까움. max chain 5 (무한 루프 방지) |

## 변경 파일 (5개)

| 파일 | 변경 |
|------|------|
| \`src/types/index.ts\` | AbilityPattern 에 \`'x_shape'\` 추가 |
| \`src/lib/simulator/systems/ability.ts\` | findAbilityTargets x_shape case (대상 + NE/NW/SE/SW axial offset) |
| \`src/data/carryAugments.ts\` | PykeCarry abilityOverride pattern 'single' → 'x_shape' |
| \`src/lib/simulator/engine/combatLoop.ts\` | cast loop primary/secondary 분기 + tankBonus + onKillRecast cascade (~95 lines) |
| \`tests/unit/simulator/hero-augment-stat-system.test.ts\` | PR7-A describe 6개 회귀 가드 |

## 핵심 구현

### cast loop primary vs secondary 분기

\`\`\`ts
let baseDmg = abilityDmg;
const isPrimaryTarget = t === abilityTarget;
if (carryCfg?.abilityData?.secondaryDamage && !isPrimaryTarget) {
  // X-shape 주변 적 — abilityData.secondaryDamage 사용
  baseDmg = secDmgType === 'magic' ? secBase * (1 + AP/100) : secBase;
}
if (isPrimaryTarget && carryCfg?.abilityData?.tankBonusMultiplier && t.role === 'Tank') {
  baseDmg *= (1 + carryCfg.abilityData.tankBonusMultiplier);
}
\`\`\`

### onKillRecast cascade (post-cast pipeline 직전)

\`\`\`ts
if (recastMul > 0 && abilityTarget.state === 'dead') {
  while (chainCount < MAX_RECAST_CHAIN) {  // max 5
    // alive lowest HP 적 선택 → 새 dash → 새 X-shape 재계산
    // damage × 0.70 + primary/secondary + tankBonus + 일반 mitigation
    // cascade damage 는 totalAbilityDmg / Raw 누적 → omnivamp / Fountain / on_cast 정합
    if (recastTarget.state !== 'dead') break;  // 처치 못하면 종료
  }
}
\`\`\`

## Test plan

- [x] \`pnpm typecheck\` 통과
- [x] \`pnpm lint\` 0 errors (14 warnings 본 PR 무관)
- [x] \`pnpm build\` 통과
- [x] 전체 테스트: **686 passed | 8 skipped** (회귀 0건, +6 신규)
- [x] hero-augment-stat-system.test.ts: **38 passed** (기존 30 + 신규 6, +PR5/P1 가드 2개)

## 회귀 가드 (6개)

1. PykeCarry abilityOverride.pattern === 'x_shape'
2. PykeCarry abilityData 핵심 변수 검증 ([220,330,500] / [60,90,135] / 0.60 / 0.70 / physical)
3. AbilityPattern 에 'x_shape' 추가 (types/index.ts)
4. findAbilityTargets x_shape case + NE/SW axial offset
5. cascade 코드 fingerprint (MAX_RECAST_CHAIN=5, while loop, 종료 조건)
6. 파이크 carry 시뮬 sanity (role=Fighter, 정상 작동, crash 없음)

## PR 의존성

PR #67 → PR #68 → PR #69 → PR #70 → PR #71 → **PR7-A** ← 본 PR

후속 PR7+ 후보:
- PR7-C (아트록스 3-skill cycle + N.O.V.A.) — 가장 복잡
- PR7-B (꼬마정령 multi-stun + dash to_largest_cluster) — 의존: PR7-E (미프)
- PR7-D (뽀삐 bouncing projectile + 미프) — 의존: PR7-E
- PR7-E (미프 시너지 — 정령족 잠재력)
- PR6 (statOverrides 채우기) — 사용자 인게임 측정 의존

🤖 Generated with [Claude Code](https://claude.com/claude-code)