### PR TITLE
feat(patch-17-2b): 미프 (정령족 잠재력) 시너지 + carry onAttack 패시브 (PR7-E)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -250,6 +250,7 @@ function createCombatUnit(
     aatroxCycleCounter: 0,
     aatroxPreviouslyDead: false,
     aatroxNovaStrikeSelector: false,
+    astronautMeepsStack: 0,
     attackCount: 0,
     castCount: 0,
     killCount: 0,
@@ -1270,11 +1271,19 @@ function applyAstronautEffects(activeTraits: ActiveTrait[], units: CombatUnit[])
   const trait = activeTraits.find(t => t.trait.apiName === 'TFT17_Astronaut');
   if (!trait || !trait.activeEffect || trait.style === 0) return;
   const bonusHp = (trait.activeEffect.variables['BonusHealth'] ?? 0) as number;
-  if (bonusHp <= 0) return;
+  // PR7-E (17.2b): Meeps stack 저장 — 정령족 unit 의 carry damage / onAttack 패시브 사용.
+  // 사용자 결정: trait Meeps 변수 사용 (2/3/4/6 = tier 3/5/7/10).
+  const meeps = (trait.activeEffect.variables['Meeps'] ?? 0) as number;
   for (const u of units) {
     if (!unitHasTrait(u, '정령족')) continue;
-    u.maxHp += bonusHp;
-    u.currentHp += bonusHp;
+    if (bonusHp > 0) {
+      u.maxHp += bonusHp;
+      u.currentHp += bonusHp;
+    }
+    // PR7-E: Meeps stack 저장 (뽀삐 carry spiritEffectPerStack 등에 사용)
+    if (meeps > 0) {
+      u.astronautMeepsStack = meeps;
+    }
   }
 }
 
@@ -2893,6 +2902,7 @@ function spawnFreljordTurrets(
             aatroxCycleCounter: 0,
             aatroxPreviouslyDead: false,
             aatroxNovaStrikeSelector: false,
+            astronautMeepsStack: 0,
             attackCount: 0,
             castCount: 0,
             killCount: 0,
@@ -3092,6 +3102,7 @@ function trySpawnGalio(
     aatroxCycleCounter: 0,
     aatroxPreviouslyDead: false,
     aatroxNovaStrikeSelector: false,
+    astronautMeepsStack: 0,
     attackCount: 0,
     castCount: 0,
     killCount: 0,
@@ -4633,6 +4644,56 @@ export function simulateCombat(
           target.totalDamageTaken += finalDamage;
           unit.totalDamageDealt += finalDamage;
 
+          // PR7-E (17.2b): carry augment onAttackBonus 패시브 — 매 기본 공격마다 추가 magic.
+          // 사용자 결정: onAttackBonus[star] AP 고정 magic damage 추가 (stack 무관).
+          //   꼬마정령 carry [40,60,90] AP / 잭스 carry [45,70,105] AP.
+          // 정령족 trait 활성 의존 없음 — 단순 carry augment 활성 시 onAttack 추가.
+          // mitigation: magic resist + magicPen + DR + non-target reduction + shield + invulnerable.
+          {
+            const augNamesAtk = unit.team === 'player' ? playerAugApiNames : enemyAugApiNames;
+            const carryAtk = findCarryAugment(unit.champion.apiName, augNamesAtk);
+            const onAttackArr = carryAtk?.abilityData?.onAttackBonus;
+            if (onAttackArr && target.state !== 'dead') {
+              const onAttackBase = onAttackArr[unit.starLevel - 1] ?? onAttackArr[0];
+              if (onAttackBase > 0) {
+                // AP scaling — magic damage (꼬마정령/잭스 모두 magic)
+                const onAttackRaw = onAttackBase * (1 + unit.stats.ap / 100);
+                let onAttackDmg = applyResistance(onAttackRaw, target.stats.magicResist, unit.stats.magicPen);
+                if (target.damageReduction > 0) onAttackDmg *= (1 - target.damageReduction);
+                if ((target.role === 'Fighter' || target.role === 'Assassin') && target.target !== unit.id) {
+                  onAttackDmg *= (1 - NON_TARGET_DAMAGE_REDUCTION);
+                }
+                onAttackDmg = applyShield(target, onAttackDmg, eventBus, tick);
+                if (target.statusEffects.some(e => e.type === 'invulnerable')) onAttackDmg = 0;
+
+                target.currentHp -= onAttackDmg;
+                target.totalDamageTaken += onAttackDmg;
+                unit.totalDamageDealt += onAttackDmg;
+
+                if (onAttackDmg > 0) {
+                  const onAttackLog: CombatLog = {
+                    tick, time, type: 'attack',
+                    sourceId: unit.id, targetId: target.id,
+                    value: Math.round(onAttackDmg),
+                    message: `${unit.champion.name} carry 패시브! ${target.champion.name}에게 추가 ${Math.round(onAttackDmg)} 마법 피해`,
+                  };
+                  logs.push(onAttackLog);
+                  tickLogs.push(onAttackLog);
+                }
+
+                if (target.currentHp <= 0) {
+                  target.currentHp = 0;
+                  target.state = 'dead';
+                  unit.killCount++;
+                  if (unit.team === 'player') playerArbiterState.enemyDeathCount++;
+                  else enemyArbiterState.enemyDeathCount++;
+                  eventBus.emit('on_kill', { sourceId: unit.id, targetId: target.id, tick });
+                  eventBus.emit('on_death', { sourceId: target.id, targetId: unit.id, tick });
+                }
+              }
+            }
+          }
+
           // 최신상 RevUp/2 — sticky target 매칭 시 stack++, 다른 대상 시 reset.
           // 한 공격 = 1 stack (DoubleTap/TripleTap extra hit 은 별도 카운트 안 함).
           // codex P2: sticky target 을 잡는 hit 도 자체로 1 stack — raw "AttackSpeedPerAttack"
@@ -5050,6 +5111,13 @@ export function simulateCombat(
               );
               rawAbilityDmgBase = result.damage;
               dmgType = result.type;
+            }
+            // PR7-E (17.2b): 뽀삐 carry spiritEffectPerStack — 미프 정령족 잠재력 stack 당
+            // damage amp. 사용자 결정: damage × (1 + Meeps × 0.15) multiplicative.
+            // 정령족 trait 활성 시 unit.astronautMeepsStack > 0 (applyAstronautEffects).
+            // 다른 carry (꼬마정령 spiritEffectPerStack=0) 는 자연스럽게 무관.
+            if (carryCfg?.abilityData?.spiritEffectPerStack && unit.astronautMeepsStack > 0) {
+              rawAbilityDmgBase *= (1 + unit.astronautMeepsStack * carryCfg.abilityData.spiritEffectPerStack);
             }
             // SharpshooterModule (위력 프레임) — 스킬 피해 +5% 가산.
             const rawAbilityDmg = rawAbilityDmgBase * (1 + (unit.gravesAbilityDamageBonus ?? 0));

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -4653,7 +4653,11 @@ export function simulateCombat(
             const augNamesAtk = unit.team === 'player' ? playerAugApiNames : enemyAugApiNames;
             const carryAtk = findCarryAugment(unit.champion.apiName, augNamesAtk);
             const onAttackArr = carryAtk?.abilityData?.onAttackBonus;
-            if (onAttackArr && target.state !== 'dead') {
+            // codex P1 (PR #74): basic attack damage 가 이미 target.currentHp 차감 적용됐으나
+            // target.state 는 아직 'dead' 로 변경 안 된 상태 (사망 처리는 별도 위치).
+            // currentHp <= 0 인 dead-but-not-yet-marked target 에 추가 damage 가해지면
+            // totalDamageDealt/Taken inflate + 대체 death path 강제. currentHp > 0 가드 추가.
+            if (onAttackArr && target.state !== 'dead' && target.currentHp > 0) {
               const onAttackBase = onAttackArr[unit.starLevel - 1] ?? onAttackArr[0];
               if (onAttackBase > 0) {
                 // AP scaling — magic damage (꼬마정령/잭스 모두 magic)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -771,6 +771,15 @@ export interface CombatUnit {
    * carry Aatrox + true 시 cycle 패턴이 global 로 확장 + 모든 적 knockup.
    */
   aatroxNovaStrikeSelector: boolean;
+  /**
+   * 정령족 (Astronaut) trait Meeps stack — PR7-E.
+   * applyAstronautEffects 가 trait 활성 tier 기준 Meeps 변수 (2/3/4/6) 저장.
+   * 정령족 unit (Bard/Gnar/Fizz/Rammus/Poppy/Corki/Veigar/IvernMinion) 만 > 0.
+   * 사용처:
+   *   - 뽀삐 carry: damage × (1 + Meeps × spiritEffectPerStack=0.15)
+   *   - 후속 PR (Meeps 챔프별 메커니즘): Bard MeepsPerMeep 등
+   */
+  astronautMeepsStack: number;
   /** MF 특성 선택 등으로 치환된 실제 트레이트 목록 */
   resolvedTraits?: string[];
   /** 스킬 치명타 가능 여부. 전투 시작 시 보건/무대 착용 또는 정밀 계열 시너지로 결정. */

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -680,6 +680,86 @@ describe('PR7-C — 아트록스 carry 3-skill cycle + N.O.V.A. 추가 발동', 
   });
 });
 
+// PR7-E (17.2b 후속) — 미프 (정령족 잠재력) 시너지 + carry onAttack 패시브.
+// 사용자 결정:
+//   - Meeps stack 공식: Astronaut trait Meeps 변수 (2/3/4/6 = tier 3/5/7/10)
+//   - 뽀삐 spiritEffectPerStack 0.15 적용: damage × (1 + Meeps × 0.15) multiplicative
+//   - 꼬마정령/잭스 onAttackBonus: 매 기본 공격마다 onAttackBonus[star] AP 고정 magic 추가
+describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
+  it('CombatUnit 에 astronautMeepsStack 필드 정의됨', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/types/index.ts'),
+      'utf8',
+    );
+    expect(file).toMatch(/astronautMeepsStack:\s*number/);
+  });
+
+  it('applyAstronautEffects 가 Meeps stack 저장 코드 포함', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // applyAstronautEffects 안에서 trait.activeEffect.variables['Meeps'] 추출 + unit.astronautMeepsStack 저장
+    expect(file).toMatch(/trait\.activeEffect\.variables\['Meeps'\]/);
+    expect(file).toMatch(/u\.astronautMeepsStack\s*=\s*meeps/);
+  });
+
+  it('뽀삐 spiritEffectPerStack 적용 코드 fingerprint (multiplicative damage amp)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // damage *= (1 + Meeps × spiritEffectPerStack)
+    expect(file).toMatch(/spiritEffectPerStack[\s\S]+?astronautMeepsStack[\s\S]+?\*=\s*\(1 \+ unit\.astronautMeepsStack \* carryCfg\.abilityData\.spiritEffectPerStack\)/);
+  });
+
+  it('basic attack onAttackBonus 코드 fingerprint (꼬마정령/잭스)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // basic attack 시 carry augment onAttackBonus 추출 + AP scaling magic damage
+    expect(file).toMatch(/onAttackArr\s*=\s*carryAtk\?\.abilityData\?\.onAttackBonus/);
+    expect(file).toMatch(/onAttackBase \* \(1 \+ unit\.stats\.ap \/ 100\)/);
+  });
+
+  it('carryAugments — 뽀삐 spiritEffectPerStack 0.15 / 꼬마정령 onAttackBonus / 잭스 onAttackBonus', () => {
+    const poppy = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_PoppyCarry');
+    expect(poppy?.abilityData?.spiritEffectPerStack).toBe(0.15);
+
+    const ivern = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_IvernMinionCarry');
+    expect(ivern?.abilityData?.onAttackBonus).toEqual([40, 60, 90]);
+
+    const jax = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_JaxCarry');
+    expect(jax?.abilityData?.onAttackBonus).toEqual([45, 70, 105]);
+  });
+
+  it('정령족 trait 활성 시 정령족 unit 의 astronautMeepsStack > 0 (sanity)', () => {
+    const poppy = champions.find(c => c.apiName === 'TFT17_Poppy');
+    const enemy = champions.find(c => c.apiName === 'TFT17_Briar');
+    if (!poppy || !enemy) return;
+    // 정령족 trait 활성 위해 정령족 챔프 다수 + 그 외 enemy. 단순화: poppy 1명 (trait 활성 의존
+    // 단계가 minUnits=3 일 가능성). 본 sanity 는 시뮬 crash 없이 stack 변수 존재 검증.
+    const result = simulateCombat(
+      [placed(poppy, 0, 3, 2)],
+      [placed(enemy, 0, 4, 2)],
+      { seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5 }
+    );
+    const p = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Poppy');
+    if (!p) return;
+    // stack 0 또는 양수 (trait 활성 안 됐으면 0). 변수 정의 검증.
+    expect(typeof p.astronautMeepsStack).toBe('number');
+  });
+});
+
 describe('CarryAugmentConfig.statOverrides — 슬롯 추후 채움 가드', () => {
   it('현재는 모든 augment 의 statOverrides 가 미정의 (사용자 추후 인게임 측정 후 채움)', () => {
     // 본 PR 은 슬롯만 추가. 사용자가 인게임 stat 측정 후 채울 예정.

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -731,6 +731,20 @@ describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
     expect(file).toMatch(/onAttackBase \* \(1 \+ unit\.stats\.ap \/ 100\)/);
   });
 
+  // codex P1 (PR #74) 회귀 가드 — onAttackBonus 가 currentHp > 0 검사 포함.
+  // basic attack damage 가 이미 currentHp 차감했으나 state 는 아직 'dead' 미변경 →
+  // currentHp <= 0 dead-but-not-yet-marked target 에 추가 damage 적용 회귀 방지.
+  it('onAttackBonus currentHp > 0 가드 (codex P1 PR #74)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // onAttackBonus 발동 조건에 target.currentHp > 0 포함
+    expect(file).toMatch(/onAttackArr && target\.state !== 'dead' && target\.currentHp > 0/);
+  });
+
   it('carryAugments — 뽀삐 spiritEffectPerStack 0.15 / 꼬마정령 onAttackBonus / 잭스 onAttackBonus', () => {
     const poppy = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_PoppyCarry');
     expect(poppy?.abilityData?.spiritEffectPerStack).toBe(0.15);


### PR DESCRIPTION
## Summary

- **PR7-E (17.2b 후속)** — PR7-D (뽀삐) / PR7-B (꼬마정령) 의 의존성 "미프 정령족 잠재력 스택" + carry augment onAttack 패시브 (꼬마정령/잭스) 동시 처리.
- 두 메커니즘 묶어서 후속 PR 의존성 해소 + 잭스 carry 도 동시 적용.

## 사용자 결정

| 항목 | 결정 |
|------|------|
| **Meeps stack 공식** | Astronaut trait Meeps 변수 사용 (2/3/4/6 = tier 3/5/7/10) |
| **뽀삐 spiritEffectPerStack** | damage × (1 + Meeps × 0.15) multiplicative |
| **꼬마정령/잭스 onAttackBonus** | 매 기본 공격마다 onAttackBonus[star] AP 고정 magic 추가 (stack 무관) |

## 적용 대상

| 챔프 | 기능 | 변수 |
|------|------|------|
| 뽀삐 carry | cast damage spirit amp | spiritEffectPerStack=0.15 × Meeps stack |
| 꼬마정령 carry | basic attack 추가 magic | onAttackBonus [40,60,90] AP |
| 잭스 carry | basic attack 추가 magic | onAttackBonus [45,70,105] AP |

## 변경 파일 (3개)

| 파일 | 변경 |
|------|------|
| \`src/types/index.ts\` | CombatUnit 에 \`astronautMeepsStack: number\` 추가 |
| \`src/lib/simulator/engine/combatLoop.ts\` | applyAstronautEffects Meeps 저장 + cast site 뽀삐 spirit amp + basic attack site onAttackBonus (~70 lines) |
| \`tests/unit/simulator/hero-augment-stat-system.test.ts\` | PR7-E describe 6개 회귀 가드 |

## 핵심 구현

### applyAstronautEffects 확장 — Meeps stack 저장

\`\`\`ts
const meeps = trait.activeEffect.variables['Meeps'] ?? 0;
for (const u of units) {
  if (!unitHasTrait(u, '정령족')) continue;
  if (bonusHp > 0) { u.maxHp += bonusHp; u.currentHp += bonusHp; }
  if (meeps > 0) u.astronautMeepsStack = meeps;  // PR7-E
}
\`\`\`

### 뽀삐 spiritEffectPerStack (cast site)

\`\`\`ts
if (carryCfg?.abilityData?.spiritEffectPerStack && unit.astronautMeepsStack > 0) {
  rawAbilityDmgBase *= (1 + unit.astronautMeepsStack * carryCfg.abilityData.spiritEffectPerStack);
}
\`\`\`

### 꼬마정령/잭스 onAttackBonus (basic attack site)

\`\`\`ts
const carryAtk = findCarryAugment(unit.champion.apiName, augNamesAtk);
const onAttackArr = carryAtk?.abilityData?.onAttackBonus;
if (onAttackArr && target.state !== 'dead') {
  const onAttackBase = onAttackArr[unit.starLevel - 1];
  const onAttackRaw = onAttackBase * (1 + unit.stats.ap / 100);  // AP scaling magic
  // mitigation + 사망 처리
}
\`\`\`

## 회귀 가드 (6개)

1. CombatUnit astronautMeepsStack 필드 정의
2. applyAstronautEffects Meeps 추출 + stack 저장
3. 뽀삐 spiritEffectPerStack 적용 (multiplicative damage amp)
4. basic attack onAttackBonus (AP scaling magic)
5. carryAugments 변수 검증 (뽀삐 0.15 / 꼬마정령 [40,60,90] / 잭스 [45,70,105])
6. 정령족 trait sanity (stack 변수 존재)

## Test plan

- [x] \`pnpm typecheck\` 통과
- [x] \`pnpm lint\` 0 errors (14 warnings 본 PR 무관)
- [x] \`pnpm build\` 통과
- [x] 전체 테스트: **703 passed | 8 skipped** (회귀 0건, +6 신규)
- [x] hero-augment-stat-system.test.ts: **55 passed** (기존 49 + 신규 6)

## 후속 PR 의존성 해소

- **PR7-D (뽀삐 bouncing projectile)** — spiritEffectPerStack 의존 해소 ✅
- **PR7-B (꼬마정령 multi-stun + dash to_largest_cluster)** — onAttackBonus 의존 해소 ✅

양쪽 모두 본 PR 머지 후 진행 가능.

## PR7-E 범위 외 (후속 PR)

Meeps 챔프별 메커니즘 (`docs/meta/simulator-synergy-todos.md` TODO 4):
- Bard: combat start Meep 부여
- Gnar: 5번째 attack 부메랑
- Fizz: spell 시 Mega Meep 소환
- Rammus: 보호막 + DR + 폭발
- Corki/Veigar: Meeptor 등
- 각 챔프별 별도 PR (PR7-E.5 ~ PR7-E.N)

## PR 의존성

PR #67 → PR #68 → PR #69 → PR #70 → PR #71 → PR #72 → PR #73 → **PR7-E** ← 본 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)