### PR TITLE
feat(patch-17-2b): 꼬마정령 carry to_largest_cluster + hexReduction + multi-stun (PR7-B)

### DIFF
--- a/src/data/carryAugments.ts
+++ b/src/data/carryAugments.ts
@@ -184,7 +184,8 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
   {
     augmentApiName: 'TFT17_Augment_IvernMinionCarry',
     targetChampionApiName: 'TFT17_IvernMinion',
-    abilityOverride: { pattern: 'aoe_circle', radius: 3, dash: 'to_farthest' },
+    // PR7-B (17.2b): dash to_largest_cluster (2칸 내 가장 큰 적 무리). aoe_circle radius 3.
+    abilityOverride: { pattern: 'aoe_circle', radius: 3, dash: 'to_largest_cluster' },
     abilityData: {
       name: '빅뱅',
       desc: '주문력 전사로 변환. 패시브: 기본 공격당 추가 magic damage (미프 시너지 잠재력 스케일). 사용: 2칸 내 가장 큰 적 무리에 도약, 반경 3칸 magic damage (1칸당 45% 감소), 가장 가까운 3명 1.25/1.5/1.75초 공중 띄움.',

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6030,7 +6030,15 @@ export function simulateCombat(
               const pen = dmgType === 'magic' ? unit.stats.magicPen : unit.stats.armorPen;
               // 저격수 (Sniper) — 거리 기반 추가 damage amp
               const sniperAmp = computeSniperDamageAmp(unit, t);
-              let rawDmg = abilityDmg * (1 + unit.damageAmp + sniperAmp);
+              // codex P1 (PR #76): PR7-B 꼬마정령 hexReduction OOR 동기화 — in-range cast 와
+              // 동일 multiplicative falloff. 일반 cast loop (line ~5378) 와 같은 패턴.
+              let oorBaseDmg = abilityDmg;
+              if (oorCarryCfg?.abilityData?.hexReduction !== undefined
+                  && oorCarryCfg.augmentApiName === 'TFT17_Augment_IvernMinionCarry') {
+                const distFromCenter = hexDistance(abilityTarget.position, t.position);
+                oorBaseDmg *= Math.pow(1 - oorCarryCfg.abilityData.hexReduction, distFromCenter);
+              }
+              let rawDmg = oorBaseDmg * (1 + unit.damageAmp + sniperAmp);
               if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
                 rawDmg *= unit.stats.critMultiplier;
               }
@@ -6067,6 +6075,30 @@ export function simulateCombat(
                 t.state = 'idle';
                 t.attackCooldown = 0;
                 oorStunApplied = true;
+              }
+            }
+          }
+
+          // codex P1 (PR #76): PR7-B 꼬마정령 multi-stun OOR 동기화 — in-range cast (line ~5828)
+          // 와 동일 패턴. abilityData.stunDuration 정의 시 caster 위치 기준 가장 가까운 3명 stun.
+          if (oorCarryCfg?.abilityData?.stunDuration
+              && oorCarryCfg.augmentApiName === 'TFT17_Augment_IvernMinionCarry') {
+            const stunArr = oorCarryCfg.abilityData.stunDuration;
+            const ivernStunDur = stunArr[unit.starLevel - 1] ?? stunArr[0];
+            if (ivernStunDur > 0) {
+              const ivernStunTicks = Math.round(ivernStunDur * TICKS_PER_SECOND);
+              const IVERN_STUN_TARGETS_OOR = 3;
+              const sortedCloseOOR = abilityTargets
+                .filter(t => t.state !== 'dead')
+                .slice()
+                .sort((a, b) =>
+                  hexDistance(unit.position, a.position) - hexDistance(unit.position, b.position)
+                )
+                .slice(0, IVERN_STUN_TARGETS_OOR);
+              for (const t of sortedCloseOOR) {
+                t.statusEffects.push({ type: 'stun', sourceId: unit.id, remainingTicks: ivernStunTicks });
+                t.state = 'idle';
+                t.attackCooldown = 0;
               }
             }
           }

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -623,10 +623,29 @@ function findBacklineEnemy(unit: CombatUnit, enemies: CombatUnit[]): CombatUnit 
   return findFarthestEnemy(unit, backline);
 }
 
+/**
+ * PR7-B (17.2b) — dash to_largest_cluster: 가장 큰 적 무리 식별.
+ * 사용자 결정: 각 alive 적 위치 중심으로 radius 2 내 타 적 개수 카운트 → max count 적 반환.
+ * tie 시 첫 번째 적 (정렬 stable). 꼬마정령 carry 전용.
+ */
+function findLargestClusterTarget(enemies: CombatUnit[]): CombatUnit {
+  let best = enemies[0];
+  let bestCount = -1;
+  for (const center of enemies) {
+    let count = 0;
+    for (const other of enemies) {
+      if (other === center) continue;
+      if (hexDistance(center.position, other.position) <= 2) count++;
+    }
+    if (count > bestCount) { bestCount = count; best = center; }
+  }
+  return best;
+}
+
 /** 스킬 시전 시 대쉬 이동 — 대상 인접 빈 칸으로 이동 */
 function applyAbilityDash(
   unit: CombatUnit,
-  dashType: 'to_target' | 'to_farthest' | 'to_lowest_hp' | 'to_backline',
+  dashType: 'to_target' | 'to_farthest' | 'to_lowest_hp' | 'to_backline' | 'to_largest_cluster',
   currentTarget: CombatUnit,
   enemyTeam: CombatUnit[],
   occupiedPositions: Set<string>,
@@ -644,6 +663,7 @@ function applyAbilityDash(
     case 'to_farthest': dashTarget = findFarthestEnemy(unit, aliveEnemies); break;
     case 'to_lowest_hp': dashTarget = findLowestHpEnemy(aliveEnemies); break;
     case 'to_backline': dashTarget = findBacklineEnemy(unit, aliveEnemies); break;
+    case 'to_largest_cluster': dashTarget = findLargestClusterTarget(aliveEnemies); break;
   }
 
   const neighbors = getNeighbors(dashTarget.position);
@@ -5381,6 +5401,15 @@ export function simulateCombat(
                 if (carryCfg?.abilityData?.armorScale) {
                   baseDmg += t.stats.armor * carryCfg.abilityData.armorScale;
                 }
+                // PR7-B (17.2b): 꼬마정령 carry hexReduction — abilityTarget 위치 기준 distance 기반
+                // multiplicative falloff (PR4 자폭 패턴 일관). 1칸당 -45%.
+                // (1 - hexReduction) ^ distance. 꼬마정령 carry 한정 (다른 carry 는 hexReduction
+                // 정의 안 됨). 자폭 그라가스는 selfDamage 분기 별도 처리라 본 분기 영향 없음.
+                if (carryCfg?.abilityData?.hexReduction !== undefined
+                    && carryCfg.augmentApiName === 'TFT17_Augment_IvernMinionCarry') {
+                  const distFromCenter = hexDistance(abilityTarget.position, t.position);
+                  baseDmg *= Math.pow(1 - carryCfg.abilityData.hexReduction, distFromCenter);
+                }
                 // 초가스: % 최대체력 피해 추가
                 if (unit.champion.apiName === 'TFT17_Chogath') {
                   const pctVar = unit.champion.ability.variables?.find(v => v.name === 'PercentMaximumHealthDamage');
@@ -5792,6 +5821,32 @@ export function simulateCombat(
                 t.state = 'idle';
                 t.attackCooldown = 0;
                 stunCount++;
+              }
+            }
+
+            // === PR7-B (17.2b) — 꼬마정령 carry multi-stun ===
+            // abilityData.stunDuration[star] 정의 시 가장 가까운 N명 (default 3) 에 stun.
+            // 사용자 결정: caster (unit) 위치 기준 가장 가까운 3명 (radius 3 AOE 안 alive 적).
+            // 도메인 line 105: "가장 가까운 3명 1.25/1.5/1.75초 공중 띄움 (stun + knockup)"
+            if (carryCfg?.abilityData?.stunDuration
+                && carryCfg.augmentApiName === 'TFT17_Augment_IvernMinionCarry') {
+              const stunArr = carryCfg.abilityData.stunDuration;
+              const ivernStunDur = stunArr[unit.starLevel - 1] ?? stunArr[0];
+              if (ivernStunDur > 0) {
+                const ivernStunTicks = Math.round(ivernStunDur * TICKS_PER_SECOND);
+                const IVERN_STUN_TARGETS = 3;
+                const sortedClose = abilityTargets
+                  .filter(t => t.state !== 'dead')
+                  .slice()
+                  .sort((a, b) =>
+                    hexDistance(unit.position, a.position) - hexDistance(unit.position, b.position)
+                  )
+                  .slice(0, IVERN_STUN_TARGETS);
+                for (const t of sortedClose) {
+                  t.statusEffects.push({ type: 'stun', sourceId: unit.id, remainingTicks: ivernStunTicks });
+                  t.state = 'idle';
+                  t.attackCooldown = 0;
+                }
               }
             }
 

--- a/src/lib/simulator/systems/ability.ts
+++ b/src/lib/simulator/systems/ability.ts
@@ -16,7 +16,7 @@ export interface AbilityConfig {
   maxTargets?: number;
   damageDecay?: number;
   /** 스킬 시전 시 이동 유형 */
-  dash?: 'to_target' | 'to_farthest' | 'to_lowest_hp' | 'to_backline';
+  dash?: 'to_target' | 'to_farthest' | 'to_lowest_hp' | 'to_backline' | 'to_largest_cluster';
   /** CC 기절 지속시간 (초). 데미지 대상에 적용 */
   stun?: number;
   /** 기절 대상 수 제한 (기본: 데미지 대상 전원) */

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -833,6 +833,95 @@ describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
     expect(p.totalDamageDealt).toBeGreaterThanOrEqual(0);
   });
 
+  // PR7-B (17.2b 후속) — 꼬마정령 carry to_largest_cluster + hexReduction + multi-stun.
+  // 사용자 결정:
+  //   - to_largest_cluster: 각 적 위치 중심 radius 2 내 타 적 개수 max 적 → dash target
+  //   - multi-stun: caster (unit) 위치 기준 가장 가까운 3명 (radius 3 AOE 안 alive)
+  //   - hexReduction 0.45: abilityTarget 중심 multiplicative falloff (PR4 자폭 일관)
+  describe('PR7-B — 꼬마정령 carry multi-stun + dash to_largest_cluster + hexReduction', () => {
+    it('IvernMinionCarry abilityOverride dash = to_largest_cluster (기존 to_farthest 변경)', () => {
+      const ivern = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_IvernMinionCarry');
+      expect(ivern).toBeDefined();
+      expect(ivern!.abilityOverride.pattern).toBe('aoe_circle');
+      expect(ivern!.abilityOverride.radius).toBe(3);
+      expect(ivern!.abilityOverride.dash).toBe('to_largest_cluster');
+    });
+
+    it('IvernMinionCarry abilityData hexReduction 0.45 / stunDuration [1.25, 1.5, 1.75]', () => {
+      const ivern = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_IvernMinionCarry');
+      expect(ivern?.abilityData?.hexReduction).toBe(0.45);
+      expect(ivern?.abilityData?.stunDuration).toEqual([1.25, 1.5, 1.75]);
+      expect(ivern?.abilityData?.damage).toEqual([240, 360, 560]);
+    });
+
+    it('AbilityConfig.dash 에 to_largest_cluster 추가됨', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const file = fs.readFileSync(
+        path.join(process.cwd(), 'src/lib/simulator/systems/ability.ts'),
+        'utf8',
+      );
+      expect(file).toMatch(/'to_largest_cluster'/);
+    });
+
+    it('findLargestClusterTarget helper 정의 + applyAbilityDash switch case', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const file = fs.readFileSync(
+        path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+        'utf8',
+      );
+      // helper 함수 + radius 2 내 타 적 카운트 패턴
+      expect(file).toMatch(/function findLargestClusterTarget/);
+      expect(file).toMatch(/hexDistance\(center\.position, other\.position\) <= 2/);
+      // applyAbilityDash switch case
+      expect(file).toMatch(/case 'to_largest_cluster':\s*dashTarget = findLargestClusterTarget/);
+    });
+
+    it('cast loop hexReduction 적용 코드 fingerprint (꼬마정령 한정 multiplicative)', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const file = fs.readFileSync(
+        path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+        'utf8',
+      );
+      // 꼬마정령 carry hexReduction multiplicative falloff
+      expect(file).toMatch(/carryCfg\.augmentApiName === 'TFT17_Augment_IvernMinionCarry'[\s\S]+?Math\.pow\(1 - carryCfg\.abilityData\.hexReduction, distFromCenter\)/);
+    });
+
+    it('multi-stun 코드 fingerprint — caster 위치 기준 가장 가까운 3명', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const file = fs.readFileSync(
+        path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+        'utf8',
+      );
+      // 꼬마정령 multi-stun + caster 위치 기준 정렬 + IVERN_STUN_TARGETS=3
+      expect(file).toMatch(/IVERN_STUN_TARGETS\s*=\s*3/);
+      expect(file).toMatch(/hexDistance\(unit\.position, a\.position\) - hexDistance\(unit\.position, b\.position\)/);
+    });
+
+    it('꼬마정령 carry 활성 시 시뮬 정상 작동 (sanity)', () => {
+      const ivern = champions.find(c => c.apiName === 'TFT17_IvernMinion');
+      const enemy = champions.find(c => c.apiName === 'TFT17_Briar');
+      const carryAug = augments.find(a => a.apiName === 'TFT17_Augment_IvernMinionCarry');
+      if (!ivern || !enemy || !carryAug) return;
+      const result = simulateCombat(
+        [placed(ivern, 0, 3, 2)],
+        [placed(enemy, 0, 4, 2)],
+        {
+          seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+          playerAugments: [carryAug],
+        }
+      );
+      const u = result.playerUnits.find(p => p.champion.apiName === 'TFT17_IvernMinion');
+      if (!u) return;
+      expect(u.role).toBe('Fighter');
+      // dash + hexReduction + multi-stun 정상 작동 (crash 없음)
+      expect(u.totalDamageDealt).toBeGreaterThanOrEqual(0);
+    });
+  });
+
   it('정령족 trait 활성 시 정령족 unit 의 astronautMeepsStack > 0 (sanity)', () => {
     const poppy = champions.find(c => c.apiName === 'TFT17_Poppy');
     const enemy = champions.find(c => c.apiName === 'TFT17_Briar');

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -901,6 +901,22 @@ describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
       expect(file).toMatch(/hexDistance\(unit\.position, a\.position\) - hexDistance\(unit\.position, b\.position\)/);
     });
 
+    // codex P1 (PR #76) 회귀 가드 — OOR cast 경로에도 hexReduction + multi-stun 적용.
+    // in-range vs OOR 동일 결과 보장.
+    it('OOR cast 경로 꼬마정령 hexReduction + multi-stun 동기화 (codex P1 PR #76)', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const file = fs.readFileSync(
+        path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+        'utf8',
+      );
+      // OOR cast loop 안 hexReduction (oorBaseDmg 변수 + IvernMinionCarry 체크)
+      expect(file).toMatch(/oorBaseDmg \*= Math\.pow\(1 - oorCarryCfg\.abilityData\.hexReduction/);
+      // OOR cast 끝 multi-stun (oorCarryCfg + IvernMinionCarry + IVERN_STUN_TARGETS_OOR=3)
+      expect(file).toMatch(/IVERN_STUN_TARGETS_OOR\s*=\s*3/);
+      expect(file).toMatch(/oorCarryCfg\?\.abilityData\?\.stunDuration[\s\S]+?TFT17_Augment_IvernMinionCarry/);
+    });
+
     it('꼬마정령 carry 활성 시 시뮬 정상 작동 (sanity)', () => {
       const ivern = champions.find(c => c.apiName === 'TFT17_IvernMinion');
       const enemy = champions.find(c => c.apiName === 'TFT17_Briar');


### PR DESCRIPTION
## Summary

- **PR7-B (17.2b 후속)** — 꼬마정령 carry "빅뱅" 핵심 메커니즘 3종 시뮬 적용:
  - **dash to_largest_cluster** (2칸 내 가장 큰 적 무리)
  - **hexReduction 0.45** (1칸당 -45% damage 감소, multiplicative)
  - **multi-stun** (가장 가까운 3명 1.25/1.5/1.75초 stun)
- hero augment carry 메커니즘 마지막 PR7-B 완료 → 모든 PR7-A/B/C/D/E 종결.

## 사용자 결정

| 항목 | 결정 |
|------|------|
| **to_largest_cluster** | 각 alive 적 위치 중심 radius 2 내 타 적 개수 max → dash target |
| **multi-stun 정렬** | caster (unit) 위치 기준 가장 가까운 3명 |

## 변경 파일 (4개)

| 파일 | 변경 |
|------|------|
| \`src/lib/simulator/systems/ability.ts\` | AbilityConfig.dash 에 'to_largest_cluster' 추가 |
| \`src/lib/simulator/engine/combatLoop.ts\` | findLargestClusterTarget helper + applyAbilityDash case + cast loop hexReduction + multi-stun (~50 lines) |
| \`src/data/carryAugments.ts\` | IvernMinionCarry abilityOverride.dash = 'to_largest_cluster' |
| \`tests/unit/simulator/hero-augment-stat-system.test.ts\` | PR7-B 회귀 가드 7개 |

## 핵심 구현

### findLargestClusterTarget (helper)

\`\`\`ts
function findLargestClusterTarget(enemies: CombatUnit[]): CombatUnit {
  let best = enemies[0]; let bestCount = -1;
  for (const center of enemies) {
    let count = 0;
    for (const other of enemies) {
      if (other === center) continue;
      if (hexDistance(center.position, other.position) <= 2) count++;
    }
    if (count > bestCount) { bestCount = count; best = center; }
  }
  return best;
}
\`\`\`

### hexReduction (cast loop baseDmg 분기)

\`\`\`ts
if (carryCfg?.abilityData?.hexReduction !== undefined
    && carryCfg.augmentApiName === 'TFT17_Augment_IvernMinionCarry') {
  const distFromCenter = hexDistance(abilityTarget.position, t.position);
  baseDmg *= Math.pow(1 - carryCfg.abilityData.hexReduction, distFromCenter);
}
\`\`\`

### multi-stun (cast loop 끝, CC stun 직후)

\`\`\`ts
if (carryCfg?.abilityData?.stunDuration
    && carryCfg.augmentApiName === 'TFT17_Augment_IvernMinionCarry') {
  const sortedClose = abilityTargets
    .filter(t => t.state !== 'dead')
    .slice()
    .sort((a, b) => hexDistance(unit.position, a.position) - hexDistance(unit.position, b.position))
    .slice(0, IVERN_STUN_TARGETS);  // 3
  for (const t of sortedClose) {
    t.statusEffects.push({ type: 'stun', sourceId: unit.id, remainingTicks: ivernStunTicks });
    t.state = 'idle'; t.attackCooldown = 0;
  }
}
\`\`\`

## 적용 효과 (꼬마정령 carry 전체)

| 메커니즘 | 변수 | 적용 PR |
|---------|------|---------|
| primary damage | abilityData.damage [240/360/560] AP | PR5 |
| onAttack 패시브 | onAttackBonus [40/60/90] AP magic | PR7-E |
| **dash to_largest_cluster** | radius 2 cluster max | **PR7-B** |
| **hexReduction 0.45** | (1 - 0.45)^distance multiplicative | **PR7-B** |
| **multi-stun** | 가장 가까운 3명 1.25/1.5/1.75초 | **PR7-B** |

## hero augment carry 메커니즘 완료 종합

| carry | 메커니즘 | 완료 PR |
|-------|---------|---------|
| 그라가스 자폭 | self-damage + AOE + hexReduction + tankBonus | PR4 |
| 레오나 방패 여전사 | line dash + first hit stun + secondary | PR5 |
| 잭스 저 별을 향해 | self-buff + onAttack 패시브 | PR7-E |
| 모데카이저 뜨거운 죽음 | aoe_circle radius 1 + cast damage | PR5 (passive aura는 후속) |
| 파이크 청부 살인마 | X-shape + secondary + tankBonus + cascade | PR7-A |
| **꼬마정령 빅뱅** | dash + AOE + hexReduction + multi-stun + onAttack | **PR7-B + PR7-E** |
| 아트록스 별빛 연계 | 3-skill cycle + N.O.V.A. + 단독 적중 | PR7-C |
| **뽀삐 정령단 속도** | bouncing + armorScale + spirit amp | **PR7-D + PR7-E** |
| 나서스 꽁! | bonusPerKill | (도메인 단순, PR5 적용됨) |

## 회귀 가드 (7개)

1. IvernMinionCarry abilityOverride.dash = to_largest_cluster
2. abilityData hexReduction 0.45 / stunDuration / damage
3. AbilityConfig.dash 에 to_largest_cluster 추가 (types)
4. findLargestClusterTarget helper + applyAbilityDash switch case
5. cast loop hexReduction (꼬마정령 한정 multiplicative)
6. multi-stun (caster 위치 기준 + IVERN_STUN_TARGETS=3)
7. 꼬마정령 carry sanity (role=Fighter, 시뮬 정상 작동)

## Test plan

- [x] \`pnpm typecheck\` 통과
- [x] \`pnpm lint\` 0 errors (14 warnings 본 PR 무관)
- [x] \`pnpm build\` 통과
- [x] 전체 테스트: **716 passed | 8 skipped** (회귀 0건, +7 신규)
- [x] hero-augment-stat-system.test.ts: **68 passed** (기존 61 + 신규 7)

## PR 의존성

PR #67 → ... → PR #75 (PR7-D 뽀삐) → **PR7-B (꼬마정령)** ← 본 PR

후속 (PR7+ 외):
- PR7-C.5 (다른 NOVA 유닛 효과 — Maokai/Kindred 등)
- PR6 (statOverrides — 사용자 인게임 측정 의존)
- helper 리팩토링 (cast loop helper 추출)

🤖 Generated with [Claude Code](https://claude.com/claude-code)