### PR TITLE
refactor(combat): carry-specific damage modifier helper 추출 + OOR cast 통합

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -794,6 +794,72 @@ function applyShield(unit: CombatUnit, damage: number, eventBus: EventBus, tick:
 }
 
 /**
+ * 통합 carry-specific damage modifier helper (refactor: carry-damage-modifier).
+ *
+ * cast loop 안의 baseDmg 계산 분기 5종 통합:
+ *   1. **singleTargetMultiplier** (아트록스 찍기 cycle): aliveTargets.length === 1 시 ×N
+ *   2. **secondaryDamage** (파이크 X-shape, 레오나 line): primary 외 target 에 별도 damage
+ *   3. **tankBonusMultiplier** (파이크 onKillRecast): primary target 이 Tank 일 때 ×(1+N)
+ *   4. **armorScale** (뽀삐): baseDmg + (target.armor × armorScale) — raw 가산
+ *   5. **hexReduction** (꼬마정령): abilityTarget 위치 기준 multiplicative falloff
+ *
+ * 자폭 (그라가스) 의 hexReduction / tankBonusMultiplier / baseDamageHpFrac 은 selfDamage
+ * 분기 special path (PR4) 라 본 helper 무관.
+ *
+ * caller 2 site (cast loop main + OOR cast loop). OOR 도 동일 helper 호출 → in-range 와
+ * 동작 일관 보장 (codex P1 #76 권장 사항: 다른 carry-specific 메커니즘 OOR 누락 회귀 자동 해소).
+ *
+ * **호출 순서**: 단독 적중 → secondary → tankBonus → armorScale → hexReduction
+ *   (기존 cast loop 분기 순서 보존).
+ */
+function applyCarryDamageModifiers(
+  baseDmg: number,
+  unit: CombatUnit,
+  t: CombatUnit,
+  carryCfg: CarryAugmentConfig | null | undefined,
+  context: {
+    abilityTarget: CombatUnit;
+    aliveTargetCount: number;
+    aatroxIsSingleTargetSlam: boolean;
+  },
+): number {
+  if (!carryCfg?.abilityData) return baseDmg;
+  const ad = carryCfg.abilityData;
+  const isPrimaryTarget = t === context.abilityTarget;
+
+  // 1. 단독 적중 multiplier (아트록스 찍기 cycle 한정)
+  if (context.aatroxIsSingleTargetSlam
+      && context.aliveTargetCount === 1
+      && ad.singleTargetMultiplier) {
+    baseDmg *= ad.singleTargetMultiplier;
+  }
+  // 2. secondary damage (파이크 X-shape 주변 적, 레오나 line 추가 적)
+  if (ad.secondaryDamage && !isPrimaryTarget) {
+    const secArr = ad.secondaryDamage;
+    const secBase = secArr[unit.starLevel - 1] ?? secArr[0];
+    const secDmgType: DamageType = carryCfg.damageTypeOverride ?? ad.damageType ?? 'magic';
+    baseDmg = secDmgType === 'magic'
+      ? secBase * (1 + unit.stats.ap / 100)
+      : secBase;
+  }
+  // 3. tankBonusMultiplier (primary target 이 Tank 일 때만 +N%)
+  if (isPrimaryTarget && ad.tankBonusMultiplier && t.role === 'Tank') {
+    baseDmg *= (1 + ad.tankBonusMultiplier);
+  }
+  // 4. armorScale (뽀삐: raw damage + target.armor × armorScale)
+  if (ad.armorScale) {
+    baseDmg += t.stats.armor * ad.armorScale;
+  }
+  // 5. hexReduction (꼬마정령 한정 — augmentApiName 검사. 자폭 그라가스는 selfDamage 분기 별도)
+  if (ad.hexReduction !== undefined
+      && carryCfg.augmentApiName === 'TFT17_Augment_IvernMinionCarry') {
+    const distFromCenter = hexDistance(context.abilityTarget.position, t.position);
+    baseDmg *= Math.pow(1 - ad.hexReduction, distFromCenter);
+  }
+  return baseDmg;
+}
+
+/**
  * 통합 ability mitigation pipeline (refactor: cast-mitigation-helpers).
  *
  * 8 cast site 에서 동일하게 호출하던 mitigation 5단계 통합:
@@ -5420,47 +5486,17 @@ export function simulateCombat(
                 if (unit.mfReplicatorEffectiveness > 0) {
                   abilityDamageAmp += unit.mfReplicatorEffectiveness;
                 }
-                // PR7-A (17.2b): 파이크 carry primary vs secondary damage 분기 + tankBonus.
-                //   primary target (대상): abilityData.damage (rawAbilityDmg, abilityDmg 에 이미 반영됨)
-                //   secondary targets (X-shape 주변 적): abilityData.secondaryDamage
-                //   tankBonusMultiplier: primary target 이 탱커 일 때만 +N% (사용자 결정 PR4 동일 — role==='Tank' 만)
-                let baseDmg = abilityDmg;
-                const isPrimaryTarget = t === abilityTarget;
-                // PR7-C (17.2b): Aatrox 찍기 단독 적중 ×2.5 — 찍기 cycle (cycleIdx=2)
-                // + abilityTargets 단일 (대상 본인만, radius 1 안에 다른 적 없음).
-                // N.O.V.A. 변환 (global pattern) 시에는 abilityTargets 다수라 자연스럽게 미적용.
-                if (aatroxIsSingleTargetSlam
-                    && aliveTargets.length === 1
-                    && carryCfg?.abilityData?.singleTargetMultiplier) {
-                  baseDmg *= carryCfg.abilityData.singleTargetMultiplier;
-                }
-                if (carryCfg?.abilityData?.secondaryDamage && !isPrimaryTarget) {
-                  const secArr = carryCfg.abilityData.secondaryDamage;
-                  const secBase = secArr[unit.starLevel - 1] ?? secArr[0];
-                  const secDmgType: DamageType = carryCfg.damageTypeOverride
-                    ?? carryCfg.abilityData.damageType ?? 'magic';
-                  baseDmg = secDmgType === 'magic'
-                    ? secBase * (1 + unit.stats.ap / 100)
-                    : secBase;
-                }
-                if (isPrimaryTarget && carryCfg?.abilityData?.tankBonusMultiplier && t.role === 'Tank') {
-                  baseDmg *= (1 + carryCfg.abilityData.tankBonusMultiplier);
-                }
-                // PR7-D (17.2b): 뽀삐 carry armorScale — base damage + (target.armor × armorScale).
-                // 사용자 결정: raw damage 에 가산 (mitigation 전). 도메인 desc 자연스러운 해석.
-                // 도메인 line 142: "1성 damage 표기 385 = 340 AD + 100% armor + 미프 효과"
-                if (carryCfg?.abilityData?.armorScale) {
-                  baseDmg += t.stats.armor * carryCfg.abilityData.armorScale;
-                }
-                // PR7-B (17.2b): 꼬마정령 carry hexReduction — abilityTarget 위치 기준 distance 기반
-                // multiplicative falloff (PR4 자폭 패턴 일관). 1칸당 -45%.
-                // (1 - hexReduction) ^ distance. 꼬마정령 carry 한정 (다른 carry 는 hexReduction
-                // 정의 안 됨). 자폭 그라가스는 selfDamage 분기 별도 처리라 본 분기 영향 없음.
-                if (carryCfg?.abilityData?.hexReduction !== undefined
-                    && carryCfg.augmentApiName === 'TFT17_Augment_IvernMinionCarry') {
-                  const distFromCenter = hexDistance(abilityTarget.position, t.position);
-                  baseDmg *= Math.pow(1 - carryCfg.abilityData.hexReduction, distFromCenter);
-                }
+                // refactor: 통합 carry-specific damage modifier helper (PR4~PR7-D 5 메커니즘).
+                //   1. singleTargetMultiplier (아트록스 찍기 cycle 단독 적중)
+                //   2. secondaryDamage (파이크 X-shape, 레오나 line)
+                //   3. tankBonusMultiplier (파이크 primary target Tank)
+                //   4. armorScale (뽀삐 raw 가산)
+                //   5. hexReduction (꼬마정령 abilityTarget 기준 multiplicative falloff)
+                let baseDmg = applyCarryDamageModifiers(abilityDmg, unit, t, carryCfg, {
+                  abilityTarget,
+                  aliveTargetCount: aliveTargets.length,
+                  aatroxIsSingleTargetSlam,
+                });
                 // 초가스: % 최대체력 피해 추가
                 if (unit.champion.apiName === 'TFT17_Chogath') {
                   const pctVar = unit.champion.ability.variables?.find(v => v.name === 'PercentMaximumHealthDamage');
@@ -6020,14 +6056,15 @@ export function simulateCombat(
               const pen = dmgType === 'magic' ? unit.stats.magicPen : unit.stats.armorPen;
               // 저격수 (Sniper) — 거리 기반 추가 damage amp
               const sniperAmp = computeSniperDamageAmp(unit, t);
-              // codex P1 (PR #76): PR7-B 꼬마정령 hexReduction OOR 동기화 — in-range cast 와
-              // 동일 multiplicative falloff. 일반 cast loop (line ~5378) 와 같은 패턴.
-              let oorBaseDmg = abilityDmg;
-              if (oorCarryCfg?.abilityData?.hexReduction !== undefined
-                  && oorCarryCfg.augmentApiName === 'TFT17_Augment_IvernMinionCarry') {
-                const distFromCenter = hexDistance(abilityTarget.position, t.position);
-                oorBaseDmg *= Math.pow(1 - oorCarryCfg.abilityData.hexReduction, distFromCenter);
-              }
+              // refactor (carry-damage-modifier): 통합 helper 호출 — 5 carry modifier 모두 적용.
+              // OOR cast 는 아트록스 cycle 미적용 (cycle counter 는 in-range cast 에서만 진행) →
+              // aatroxIsSingleTargetSlam=false. 다른 메커니즘 (secondary/tankBonus/armorScale/
+              // hexReduction) 은 in-range 와 일관 — codex P1 #76 의 다른 OOR 누락 회귀 자동 해소.
+              const oorBaseDmg = applyCarryDamageModifiers(abilityDmg, unit, t, oorCarryCfg, {
+                abilityTarget,
+                aliveTargetCount: oorAlive.length,
+                aatroxIsSingleTargetSlam: false,
+              });
               let rawDmg = oorBaseDmg * (1 + unit.damageAmp + sniperAmp);
               if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
                 rawDmg *= unit.stats.critMultiplier;

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -593,8 +593,8 @@ describe('PR7-C — 아트록스 carry 3-skill cycle + N.O.V.A. 추가 발동', 
     expect(file).toMatch(/cycleIdx === 0[\s\S]+?pattern:\s*'single'/);
     expect(file).toMatch(/cycleIdx === 1[\s\S]+?pattern:\s*'cone'/);
     expect(file).toMatch(/pattern:\s*'aoe_circle'[\s\S]+?slamStunDuration/);
-    // 단독 적중 ×2.5
-    expect(file).toMatch(/aatroxIsSingleTargetSlam[\s\S]+?aliveTargets\.length === 1/);
+    // 단독 적중 ×2.5 — refactor (carry-damage-modifier): helper 안 패턴 검증
+    expect(file).toMatch(/context\.aatroxIsSingleTargetSlam[\s\S]+?context\.aliveTargetCount === 1[\s\S]+?ad\.singleTargetMultiplier/);
   });
 
   it('N.O.V.A. 추가 발동 코드 fingerprint — cycle 별개 + 모든 적 + 1초 knockup', async () => {
@@ -775,8 +775,8 @@ describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
       path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
       'utf8',
     );
-    // baseDmg += t.stats.armor × armorScale
-    expect(file).toMatch(/carryCfg\?\.abilityData\?\.armorScale[\s\S]+?baseDmg \+=\s*t\.stats\.armor \* carryCfg\.abilityData\.armorScale/);
+    // baseDmg += t.stats.armor × armorScale — refactor (carry-damage-modifier): helper 안 패턴 검증
+    expect(file).toMatch(/ad\.armorScale[\s\S]+?baseDmg \+= t\.stats\.armor \* ad\.armorScale/);
   });
 
   it('spiritBounceOnKill 코드 fingerprint — overkill chain (max 50 hard limit)', async () => {
@@ -886,7 +886,9 @@ describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
         'utf8',
       );
       // 꼬마정령 carry hexReduction multiplicative falloff
-      expect(file).toMatch(/carryCfg\.augmentApiName === 'TFT17_Augment_IvernMinionCarry'[\s\S]+?Math\.pow\(1 - carryCfg\.abilityData\.hexReduction, distFromCenter\)/);
+      // refactor (carry-damage-modifier): helper 안 패턴 검증 (in-range cast loop) +
+      // OOR cast loop 의 oorBaseDmg fingerprint 는 별도 테스트 유지.
+      expect(file).toMatch(/carryCfg\.augmentApiName === 'TFT17_Augment_IvernMinionCarry'[\s\S]+?Math\.pow\(1 - ad\.hexReduction, distFromCenter\)/);
     });
 
     it('multi-stun 코드 fingerprint — caster 위치 기준 가장 가까운 3명', async () => {
@@ -953,6 +955,39 @@ describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
       expect(deadCalls!.length).toBeGreaterThanOrEqual(6);
     });
 
+    // refactor: carry-damage-modifier — applyCarryDamageModifiers helper 추출.
+    // 5 carry 메커니즘 (singleTargetMultiplier / secondaryDamage / tankBonusMultiplier /
+    // armorScale / hexReduction) 통합. cast loop main + OOR cast loop 모두 helper 호출.
+    it('applyCarryDamageModifiers helper 정의 + 5 메커니즘 검증 (refactor)', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const file = fs.readFileSync(
+        path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+        'utf8',
+      );
+      // helper 함수 시그니처
+      expect(file).toMatch(/function applyCarryDamageModifiers\(/);
+      // 5 메커니즘 모두 helper 안에 정의됨
+      expect(file).toMatch(/ad\.singleTargetMultiplier/);
+      expect(file).toMatch(/ad\.secondaryDamage && !isPrimaryTarget/);
+      expect(file).toMatch(/isPrimaryTarget && ad\.tankBonusMultiplier && t\.role === 'Tank'/);
+      expect(file).toMatch(/ad\.armorScale/);
+      expect(file).toMatch(/ad\.hexReduction !== undefined[\s\S]+?TFT17_Augment_IvernMinionCarry/);
+    });
+
+    it('cast loop main + OOR cast loop 모두 applyCarryDamageModifiers 호출 (refactor)', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const file = fs.readFileSync(
+        path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+        'utf8',
+      );
+      // helper 호출 count >= 2 (cast loop main + OOR cast loop)
+      const calls = file.match(/applyCarryDamageModifiers\(abilityDmg, unit, t/g);
+      expect(calls).toBeDefined();
+      expect(calls!.length).toBeGreaterThanOrEqual(2);
+    });
+
     it('OOR cast 경로 꼬마정령 hexReduction + multi-stun 동기화 (codex P1 PR #76)', async () => {
       const fs = await import('node:fs');
       const path = await import('node:path');
@@ -960,8 +995,9 @@ describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
         path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
         'utf8',
       );
-      // OOR cast loop 안 hexReduction (oorBaseDmg 변수 + IvernMinionCarry 체크)
-      expect(file).toMatch(/oorBaseDmg \*= Math\.pow\(1 - oorCarryCfg\.abilityData\.hexReduction/);
+      // OOR cast loop 안 carry damage modifier — refactor (carry-damage-modifier) 후
+      // helper 호출로 통합 (oorBaseDmg = applyCarryDamageModifiers(...)). hexReduction 포함.
+      expect(file).toMatch(/oorBaseDmg = applyCarryDamageModifiers\(abilityDmg, unit, t, oorCarryCfg/);
       // OOR cast 끝 multi-stun (oorCarryCfg + IvernMinionCarry + IVERN_STUN_TARGETS_OOR=3)
       expect(file).toMatch(/IVERN_STUN_TARGETS_OOR\s*=\s*3/);
       expect(file).toMatch(/oorCarryCfg\?\.abilityData\?\.stunDuration[\s\S]+?TFT17_Augment_IvernMinionCarry/);


### PR DESCRIPTION
## Summary

- **PR #77 (cast-mitigation-helpers) 후속** — 사용자 답글에서 명시적으로 권장한 다음 단계.
- PR4~PR7-D 까지 누적된 cast loop 의 carry-specific damage modifier 5종을 단일 helper 통합.
- **OOR cast loop 도 helper 호출 → in-range 와 동일 동작 보장** (codex P1 #76 회귀 자동 해소).

## 추출된 helper

### \`applyCarryDamageModifiers(baseDmg, unit, t, carryCfg, context): number\`

5 carry 메커니즘 통합:
1. **singleTargetMultiplier** (아트록스 찍기 cycle 단독 적중)
2. **secondaryDamage** (파이크 X-shape, 레오나 line)
3. **tankBonusMultiplier** (파이크 onKillRecast)
4. **armorScale** (뽀삐 raw 가산)
5. **hexReduction** (꼬마정령 abilityTarget 기준 multiplicative falloff)

context 인자: \`{ abilityTarget, aliveTargetCount, aatroxIsSingleTargetSlam }\`

자폭 (그라가스) selfDamage special path (PR4) 무관.

## caller 2 site 통합

| caller | 변경 전 | 변경 후 |
|--------|---------|---------|
| cast loop main | 5 inline 분기 (~36 lines) | helper 호출 1 line |
| OOR cast loop | hexReduction 만 (PR #76 P1 fix, 6 lines) | helper 호출 1 line + comment |

## OOR cast loop 정정 (codex P1 #76 회귀 자동 해소)

기존엔 OOR cast loop 에 hexReduction (PR #76 P1 fix) 만 적용. helper 통합 후 5 메커니즘 모두 적용 → in-range 와 일관:
- **armorScale** — 뽀삐 carry OOR cast 시에도 적용 (이전 누락)
- **secondaryDamage** — 파이크 OOR cast 시 secondary 적도 적절 damage (이전 primary 와 동일)
- **tankBonusMultiplier** — 파이크 OOR cast 시 Tank 상대 +60% (이전 누락)
- **singleTargetMultiplier** — OOR cast 는 아트록스 cycle counter 미진행이라 기본 false 전달

## 효과

- **코드 라인 감소**: cast loop 36→5 lines + OOR 6→1 line - helper +60 = 약 +30 net
- **OOR 회귀 자동 해소**: codex P1 #76 답글의 "다른 OOR 누락 가능 패턴" 4 메커니즘 한꺼번에 정상화
- **확장성**: PR7+ 새 carry 메커니즘 추가 시 helper 안에 한 분기만 추가 → cast loop main + OOR 자동 적용

## 회귀 가드 (2개 신규 + 3개 갱신)

신규:
1. applyCarryDamageModifiers helper 정의 + 5 메커니즘 fingerprint
2. cast loop main + OOR cast loop helper 호출 count >= 2

갱신 (helper 추출로 fingerprint 위치 변경):
- PR7-C 단독 적중 ×2.5 (helper 안)
- PR7-D armorScale (helper 안)
- PR7-B hexReduction (helper 안 + OOR oorBaseDmg helper 호출)

## Test plan

- [x] \`pnpm typecheck\` 통과
- [x] \`pnpm lint\` 0 errors (14 warnings 본 PR 무관)
- [x] \`pnpm build\` 통과
- [x] 전체 테스트: **722 passed | 8 skipped** (회귀 0건, +2 신규)
- [x] hero-augment-stat-system.test.ts: **74 passed** (기존 72 + 신규 2)

## 향후 후속 PR 권장

1. **OOR cast loop true damage 분기 정책 결정** — applyAbilityMitigation helper 통합 시 true damage 도 mitigation 거치도록 할지
2. **Graves bouncing / Briar / Annie tibbers** mitigation 사이트 helper 통합

## PR 의존성

PR #67 → ... → PR #77 (cast-mitigation-helpers) → **carry-damage-modifier** ← 본 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)