### PR TITLE
refactor(combat): OOR cast loop applyAbilityMitigation 통합 (in-range 완전 일관)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6052,8 +6052,6 @@ export function simulateCombat(
             let oorStunApplied = false;
             for (const t of abilityTargets) {
               if (t.state === 'dead') continue;
-              const resistance = dmgType === 'magic' ? t.stats.magicResist : t.stats.armor;
-              const pen = dmgType === 'magic' ? unit.stats.magicPen : unit.stats.armorPen;
               // 저격수 (Sniper) — 거리 기반 추가 damage amp
               const sniperAmp = computeSniperDamageAmp(unit, t);
               // refactor (carry-damage-modifier): 통합 helper 호출 — 5 carry modifier 모두 적용.
@@ -6071,10 +6069,11 @@ export function simulateCombat(
               }
               // raw 누적 — mitigation 전 per-target modifier 적용 후.
               totalRawAbilityDmg += rawDmg;
-              let dmg = dmgType === 'true' ? rawDmg : applyResistance(rawDmg, resistance, pen);
-              if (t.damageReduction > 0) dmg *= (1 - t.damageReduction);
-              dmg = applyShield(t, dmg, eventBus, tick);
-              if (t.statusEffects.some(e => e.type === 'invulnerable')) dmg = 0;
+              // refactor (oor-cast-mitigation): 통합 mitigation helper — in-range 와 완전 일관.
+              // 정정 사항 2건: (1) non-target reduction (Fighter/Assassin ×0.85) OOR 도 적용.
+              // (2) true damage 처리 helper applyResistance(rawDmg, 0, 0) = rawDmg 자동 동일.
+              // 사용자 결정 (refactor/oor-cast-mitigation): in-range 와 완전 일관.
+              const dmg = applyAbilityMitigation(unit, t, rawDmg, dmgType, eventBus, tick);
               t.currentHp -= dmg;
               t.totalDamageTaken += dmg;
               unit.totalDamageDealt += dmg;
@@ -6084,14 +6083,10 @@ export function simulateCombat(
               triggerSerpentPoison(unit, t, dmg);
 
               if (t.currentHp <= 0) {
-                t.state = 'dead';
-                t.currentHp = 0;
-                unit.killCount++;
-                if (unit.team === 'player') playerArbiterState.enemyDeathCount++;
-                else enemyArbiterState.enemyDeathCount++;
-                eventBus.emit('on_kill', { sourceId: unit.id, targetId: t.id, tick });
-                eventBus.emit('on_death', { sourceId: t.id, targetId: unit.id, tick });
+                // refactor: 통합 markTargetDead helper + deathLog 별도 작성
+                const ownArbOOR = unit.team === 'player' ? playerArbiterState : enemyArbiterState;
                 logs.push({ tick, time, type: 'death', sourceId: t.id, message: `${t.champion.name} 사망!` });
+                markTargetDead(unit, t, ownArbOOR, eventBus, tick);
               }
 
               if (outOfRangeConfig.stun && outOfRangeConfig.stun > 0 && t.currentHp > 0) {

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -975,6 +975,31 @@ describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
       expect(file).toMatch(/ad\.hexReduction !== undefined[\s\S]+?TFT17_Augment_IvernMinionCarry/);
     });
 
+    // refactor: oor-cast-mitigation — OOR cast loop 가 applyAbilityMitigation helper 사용.
+    // in-range 와 완전 일관 (non-target reduction OOR 정정 + true damage helper 자연 처리).
+    it('OOR cast loop applyAbilityMitigation 호출 (refactor: oor-cast-mitigation)', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const file = fs.readFileSync(
+        path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+        'utf8',
+      );
+      // OOR cast loop helper 호출 (rawDmg, dmgType 기반)
+      expect(file).toMatch(/const dmg = applyAbilityMitigation\(unit, t, rawDmg, dmgType, eventBus, tick\)/);
+    });
+
+    it('OOR cast loop markTargetDead 호출 (refactor: oor-cast-mitigation)', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const file = fs.readFileSync(
+        path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+        'utf8',
+      );
+      // OOR cast loop ownArbOOR + markTargetDead 호출
+      expect(file).toMatch(/ownArbOOR\s*=\s*unit\.team === 'player'/);
+      expect(file).toMatch(/markTargetDead\(unit, t, ownArbOOR/);
+    });
+
     it('cast loop main + OOR cast loop 모두 applyCarryDamageModifiers 호출 (refactor)', async () => {
       const fs = await import('node:fs');
       const path = await import('node:path');


### PR DESCRIPTION
## Summary

- **PR #77 (cast-mitigation-helpers) / PR #78 (carry-damage-modifier) 후속** — 사용자 답글 및 codex P1 #76 의 마지막 권장 사항.
- OOR cast loop 의 mitigation 패턴을 in-range 와 **완전 일관**시켜 다른 OOR 누락 회귀 최종 해소.

## 사용자 결정

**in-range 와 완전 일관** (helper 통합 + 정정 2건):
1. **non-target reduction (Fighter/Assassin ×0.85) OOR 적용** — 기존 누락. helper 사용으로 자동 적용. codex P1 #76 의 다른 OOR 누락 회귀 최종 해소.
2. **true damage 처리 helper 흡수** — \`applyResistance(rawDmg, 0, 0) = rawDmg\` 자연 동일 효과. 별도 분기 제거.

## 변경 (OOR cast loop)

**Before** (8 lines):
\`\`\`ts
const resistance = dmgType === 'magic' ? t.stats.magicResist : t.stats.armor;
const pen = dmgType === 'magic' ? unit.stats.magicPen : unit.stats.armorPen;
let dmg = dmgType === 'true' ? rawDmg : applyResistance(rawDmg, resistance, pen);
if (t.damageReduction > 0) dmg *= (1 - t.damageReduction);
dmg = applyShield(t, dmg, eventBus, tick);
if (t.statusEffects.some(e => e.type === 'invulnerable')) dmg = 0;
// ... non-target reduction 누락
\`\`\`

**After** (1 line):
\`\`\`ts
const dmg = applyAbilityMitigation(unit, t, rawDmg, dmgType, eventBus, tick);
\`\`\`

## 효과

- **OOR Fighter/Assassin 회귀 해소**: 기존엔 OOR cast 시 Fighter/Assassin 적이 non-target reduction 안 받음 → in-range 와 결과 다름. 정정 후 일관.
- **PR #77/#78 리팩토링 완성**: 모든 cast site (in-range + OOR) 가 동일 helper 호출 → 신규 cast 메커니즘 추가 시 helper 만 수정.

## helper 리팩토링 종합 (PR #77 + #78 + 본 PR)

| helper | 추출 PR | caller |
|--------|---------|--------|
| applyAbilityMitigation | PR #77 | 7 site (PR4 / cast main / PR7-A cascade / PR7-C N.O.V.A. / PR7-D bouncing / PR7-E onAttack / **OOR cast** ← 본 PR) |
| markTargetDead | PR #77 | 7 site (위와 동일) |
| applyCarryDamageModifiers | PR #78 | 2 site (cast main + OOR) |

**3 helper × 16 caller 통합** — 모든 cast 메커니즘 단일 진입점 보장.

## 회귀 가드 (2개 추가)

1. OOR cast loop applyAbilityMitigation 호출 fingerprint
2. OOR cast loop ownArbOOR + markTargetDead 호출 fingerprint

## Test plan

- [x] \`pnpm typecheck\` 통과
- [x] \`pnpm lint\` 0 errors (14 warnings 본 PR 무관)
- [x] \`pnpm build\` 통과
- [x] 전체 테스트: **724 passed | 8 skipped** (회귀 0건, +2 신규)
- [x] hero-augment-stat-system.test.ts: **76 passed** (기존 74 + 신규 2)

## 후속 권장

- **Graves bouncing / Briar / Annie tibbers** 등 ability mitigation 사이트 helper 통합 (별도 PR)
- **PR7-C.5** 다른 NOVA 유닛 효과 (Maokai/Kindred/Caitlyn/Akali)
- **PR6** statOverrides 채우기 (사용자 인게임 측정)

## PR 의존성

PR #67 → ... → PR #77 → PR #78 → **oor-cast-mitigation** ← 본 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)