### PR TITLE
feat(patch-17-2b): Maokai/Kindred N.O.V.A. 타격 선택기 추가 효과 (PR7-C.5)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -4123,6 +4123,58 @@ export function simulateCombat(
         });
       }
     }
+
+    // === PR7-C.5 (17.2b): N.O.V.A. 타격 선택기 받은 NOVA 유닛 추가 효과 ===
+    // 사용자 spec: DRX (5) + 타격 선택기 → NOVA 유닛 1명에 6초 surge 시 추가 효과.
+    // Aatrox 는 cast loop 끝 별도 발동 (PR7-C). Maokai/Kindred 는 surge 시점 1회 발동.
+
+    // Maokai selector — 적군 광역 stun (starLevel 1/2/3 = 1.5/1.5/1.75초). 회복은 hasMaokai 기존.
+    const maokaiSelector = state.teamUnits.find(u =>
+      u.champion.apiName === 'TFT17_Maokai'
+      && u.aatroxNovaStrikeSelector
+      && u.state !== 'dead'
+    );
+    if (maokaiSelector) {
+      const maokaiStunArr = [1.5, 1.5, 1.75]; // starLevel 1/2/3
+      const maokaiStunDur = maokaiStunArr[maokaiSelector.starLevel - 1] ?? maokaiStunArr[0];
+      const maokaiStunTicks = Math.round(maokaiStunDur * TICKS_PER_SECOND);
+      for (const e of state.opposingTeam) {
+        if (e.state === 'dead') continue;
+        e.statusEffects.push({
+          type: 'stun', sourceId: 'maokai-nova-selector',
+          remainingTicks: maokaiStunTicks,
+        });
+        e.state = 'idle';
+        e.attackCooldown = 0;
+      }
+      logs.push({
+        tick, time, type: 'ability', sourceId: 'maokai-nova-selector',
+        message: `Maokai N.O.V.A. 선택기! 모든 적 ${maokaiStunDur}초 광역 기절`,
+      });
+    }
+
+    // Kindred selector — Kindred damageAmp +5% (영구) + 모든 적 표식. 5초 주기 mark 갱신은
+    // main loop tick 별도 처리 (kindredNovaMarkState). Tank shield 는 hasKindred 기존.
+    const kindredSelector = state.teamUnits.find(u =>
+      u.champion.apiName === 'TFT17_Kindred'
+      && u.aatroxNovaStrikeSelector
+      && u.state !== 'dead'
+    );
+    if (kindredSelector) {
+      kindredSelector.damageAmp += 0.05;
+      for (const e of state.opposingTeam) {
+        if (e.state === 'dead') continue;
+        e.statusEffects.push({
+          type: 'mark', sourceId: 'kindred-nova-selector',
+          remainingTicks: 9999,
+        });
+      }
+      logs.push({
+        tick, time, type: 'ability', sourceId: 'kindred-nova-selector',
+        message: `Kindred N.O.V.A. 선택기! +5% damage amp + 모든 적 표식`,
+      });
+    }
+
     logs.push({
       tick, time, type: 'ability',
       sourceId: 'drx-nova',
@@ -4442,6 +4494,41 @@ export function simulateCombat(
     // N.O.V.A. (DRX) power surge — TeamAttackDelay 도달 시 한 번만 발동.
     tickDrxNova(playerDrxState, tick, time);
     tickDrxNova(enemyDrxState, tick, time);
+
+    // PR7-C.5 (17.2b): Kindred N.O.V.A. 선택기 — surge 후 5초 주기로 모든 적 표식 갱신.
+    // 사용자 spec: surge (6초) → 5초 주기 (11초, 16초, ...) 로 모든 적 표식 부여.
+    // 표식은 statusEffect 'mark' (영구). 5초 주기 = 5 × TICKS_PER_SECOND.
+    const tickKindredNovaMark = (
+      drxState: ReturnType<typeof setupDrxNova>,
+      teamUnits: CombatUnit[],
+      opposingTeam: CombatUnit[],
+    ) => {
+      if (!drxState || !drxState.triggered) return;
+      const elapsedSinceSurge = tick - drxState.delayTicks;
+      if (elapsedSinceSurge <= 0) return;
+      const periodTicks = 5 * TICKS_PER_SECOND;
+      // 5초 주기 도달 시점 (surge 직후 첫 발동은 tickDrxNova 에서 처리. 본 helper 는 후속 갱신).
+      if (elapsedSinceSurge % periodTicks !== 0) return;
+      const kindredSelector = teamUnits.find(u =>
+        u.champion.apiName === 'TFT17_Kindred'
+        && u.aatroxNovaStrikeSelector
+        && u.state !== 'dead'
+      );
+      if (!kindredSelector) return;
+      for (const e of opposingTeam) {
+        if (e.state === 'dead') continue;
+        // 기존 mark 있으면 갱신 (제거 후 재추가) — duration refresh 패턴
+        e.statusEffects = e.statusEffects.filter(
+          se => !(se.type === 'mark' && se.sourceId === 'kindred-nova-selector')
+        );
+        e.statusEffects.push({
+          type: 'mark', sourceId: 'kindred-nova-selector',
+          remainingTicks: 9999,
+        });
+      }
+    };
+    tickKindredNovaMark(playerDrxState, playerUnits, enemies);
+    tickKindredNovaMark(enemyDrxState, enemies, playerUnits);
 
     // 아이템 효과 runtime — interval timer dispatch
     itemRuntime.onTick(tick);

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -660,6 +660,54 @@ describe('PR7-C — 아트록스 carry 3-skill cycle + N.O.V.A. 추가 발동', 
     expect(file).toMatch(/isAatroxCarry && unit\.aatroxNovaStrikeSelector && novaSurgeActive/);
   });
 
+  // PR7-C.5 (17.2b 후속) — 다른 NOVA 유닛 (Maokai/Kindred) 타격 선택기 추가 효과.
+  // 사용자 spec:
+  //   - Maokai: surge 시 적군 광역 stun (starLevel 1/2/3 = 1.5/1.5/1.75초) + 기존 회복 12% 유지
+  //   - Kindred: surge 시 본인 damageAmp +5% (영구) + 모든 적 표식, 5초 주기 표식 갱신
+  it('Maokai N.O.V.A. selector 효과 코드 fingerprint (PR7-C.5)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // tickDrxNova 안 maokaiSelector 검사 (TFT17_Maokai + aatroxNovaStrikeSelector)
+    expect(file).toMatch(/maokaiSelector\s*=\s*state\.teamUnits\.find\([\s\S]+?'TFT17_Maokai'[\s\S]+?aatroxNovaStrikeSelector/);
+    // starLevel 기반 stun 시간 [1.5, 1.5, 1.75]
+    expect(file).toMatch(/maokaiStunArr\s*=\s*\[1\.5, 1\.5, 1\.75\]/);
+    // 적군 stun statusEffect 추가 (sourceId='maokai-nova-selector')
+    expect(file).toMatch(/sourceId: 'maokai-nova-selector'/);
+  });
+
+  it('Kindred N.O.V.A. selector 효과 코드 fingerprint (PR7-C.5)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // tickDrxNova 안 kindredSelector 검사 (TFT17_Kindred + aatroxNovaStrikeSelector)
+    expect(file).toMatch(/kindredSelector\s*=\s*state\.teamUnits\.find\([\s\S]+?'TFT17_Kindred'[\s\S]+?aatroxNovaStrikeSelector/);
+    // damageAmp +5%
+    expect(file).toMatch(/kindredSelector\.damageAmp \+= 0\.05/);
+    // mark statusEffect (sourceId='kindred-nova-selector')
+    expect(file).toMatch(/sourceId: 'kindred-nova-selector'/);
+  });
+
+  it('Kindred 5초 주기 mark 갱신 코드 fingerprint (PR7-C.5)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // tickKindredNovaMark helper + 5초 주기 (5 × TICKS_PER_SECOND)
+    expect(file).toMatch(/tickKindredNovaMark/);
+    expect(file).toMatch(/periodTicks\s*=\s*5\s*\*\s*TICKS_PER_SECOND/);
+    // surge triggered 후만 발동
+    expect(file).toMatch(/drxState\.triggered/);
+  });
+
   it('N.O.V.A. selector 지정 시 selector flag = true (sanity)', () => {
     const aatrox = champions.find(c => c.apiName === 'TFT17_Aatrox');
     const enemy = champions.find(c => c.apiName === 'TFT17_Briar');


### PR DESCRIPTION
## Summary

- **PR7-C.5 (17.2b 후속)** — PR7-C 의 Aatrox N.O.V.A. 선택기 효과 패턴 확장.
- Maokai / Kindred N.O.V.A. 타격 선택기 추가 효과 시뮬 적용.
- DRX (5) + selector 받은 NOVA 유닛 한정 6초 surge 시점 발동.

## 사용자 spec

### Maokai 타격 선택기
DRX (5) + Maokai selector → 6초 surge 시점에:
- **모든 적군 광역 stun** (Maokai starLevel 1/2/3 = **1.5 / 1.5 / 1.75초**)
- 아군 maxHp 12% 회복 (기존 hasMaokai (2)+ 효과 유지)

### Kindred 타격 선택기
사용자 자세한 spec:
- **6초 surge 시점**: Kindred 본인 damageAmp +5% (영구) + 모든 적 표식 (statusEffect 'mark')
- **11초, 16초, ... 5초 주기**로 모든 적 표식 갱신 (mark refresh pattern)
- "타격 선택기" 효과는 surge 후만 활성화

## 변경 파일 (2개)

| 파일 | 변경 |
|------|------|
| \`src/lib/simulator/engine/combatLoop.ts\` | tickDrxNova 안 maokaiSelector/kindredSelector 처리 + main loop tick tickKindredNovaMark helper (~70 lines) |
| \`tests/unit/simulator/hero-augment-stat-system.test.ts\` | PR7-C.5 회귀 가드 3개 |

## 핵심 구현

### Maokai (tickDrxNova 안)
\`\`\`ts
const maokaiSelector = state.teamUnits.find(u =>
  u.champion.apiName === 'TFT17_Maokai'
  && u.aatroxNovaStrikeSelector
  && u.state !== 'dead'
);
if (maokaiSelector) {
  const maokaiStunArr = [1.5, 1.5, 1.75]; // starLevel 1/2/3
  const maokaiStunDur = maokaiStunArr[maokaiSelector.starLevel - 1];
  // 모든 적 stun + state='idle'
}
\`\`\`

### Kindred (tickDrxNova 안)
\`\`\`ts
const kindredSelector = state.teamUnits.find(...);
if (kindredSelector) {
  kindredSelector.damageAmp += 0.05;
  // 모든 적 mark statusEffect 추가
}
\`\`\`

### Kindred 5초 주기 mark refresh (main loop tick)
\`\`\`ts
const tickKindredNovaMark = (drxState, teamUnits, opposingTeam) => {
  if (!drxState?.triggered) return;
  const elapsedSinceSurge = tick - drxState.delayTicks;
  if (elapsedSinceSurge <= 0) return;
  const periodTicks = 5 * TICKS_PER_SECOND;
  if (elapsedSinceSurge % periodTicks !== 0) return;
  const kindredSelector = teamUnits.find(...);
  if (!kindredSelector) return;
  // 모든 적 mark filter 후 재추가 (refresh)
};
\`\`\`

## 회귀 가드 (3개)

1. Maokai N.O.V.A. selector 효과 (maokaiSelector + stunArr [1.5,1.5,1.75] + sourceId)
2. Kindred N.O.V.A. selector 효과 (kindredSelector + damageAmp +0.05 + sourceId)
3. Kindred 5초 주기 mark 갱신 (tickKindredNovaMark + periodTicks=5×TICKS_PER_SECOND)

## NOVA 타격 선택기 메커니즘 종합 (PR7-C + PR7-C.5)

| NOVA 유닛 | 효과 | 발동 패턴 | 적용 PR |
|-----------|------|----------|--------|
| Aatrox | 모든 적 novaDamage 물리 + 1초 knockup | cast 마다 (carry + selector + surge) | PR7-C |
| **Maokai** | 모든 적 광역 stun (1.5/1.5/1.75초) | surge 1회 | **PR7-C.5** |
| **Kindred** | 본인 damageAmp +5% + 모든 적 mark | surge 1회 + 5초 주기 mark refresh | **PR7-C.5** |
| Caitlyn | (spec 미제공) | — | 후속 PR |
| Akali | (spec 미제공) | — | 후속 PR |

## Test plan

- [x] \`pnpm typecheck\` 통과
- [x] \`pnpm lint\` 0 errors (14 warnings 본 PR 무관)
- [x] \`pnpm build\` 통과
- [x] 전체 테스트: **727 passed | 8 skipped** (회귀 0건, +3 신규)
- [x] hero-augment-stat-system.test.ts: **79 passed** (기존 76 + 신규 3)

## 향후 후속 PR

- **Caitlyn / Akali** 타격 선택기 추가 효과 (사용자 spec 제공 시)
- mark statusEffect 효과 확장 (현재는 표시만, 추후 incomingDamageAmp 등 추가)

## PR 의존성

PR #67 → ... → PR #79 → **PR7-C.5 (Maokai/Kindred NOVA selector)** ← 본 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)