### PR TITLE
feat(patch-17-2b): Caitlyn/Akali N.O.V.A. 타격 선택기 추가 효과 (PR7-C.6)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -900,6 +900,14 @@ function applyAbilityMitigation(
   }
   effectiveDmg = applyShield(t, effectiveDmg, eventBus, tick);
   if (t.statusEffects.some(e => e.type === 'invulnerable')) effectiveDmg = 0;
+  // PR7-C.6 (17.2b): Caitlyn N.O.V.A. selector mark — incoming damage amp +10%.
+  // mark statusEffect 의 value 가 incoming amp 비율 (0.10). caitlyn-nova-selector source 한정.
+  // Kindred mark 는 value 없어 (표시만) 자연스럽게 무관.
+  for (const mark of t.statusEffects) {
+    if (mark.type === 'mark' && mark.sourceId === 'caitlyn-nova-selector' && mark.value) {
+      effectiveDmg *= (1 + mark.value);
+    }
+  }
   return effectiveDmg;
 }
 
@@ -4068,6 +4076,10 @@ export function simulateCombat(
   };
   const playerDrxState = setupDrxNova(playerActiveTraits, playerUnits, enemies);
   const enemyDrxState = setupDrxNova(enemyActiveTraits, enemies, playerUnits);
+  // PR7-C.6 (17.2b): Caitlyn N.O.V.A. selector 헤드샷 1회 추적용. mark 적이 처음 50% HP 이하
+  // 떨어진 시점만 trigger 발동 — 이후 HP 회복/재손실 시 재발동 안 함.
+  const playerCaitlynHeadshotTriggered = new Set<string>();
+  const enemyCaitlynHeadshotTriggered = new Set<string>();
 
   /**
    * main loop tick 마다 호출 — delayTicks 도달 시 한 번만 effect 적용.
@@ -4150,6 +4162,54 @@ export function simulateCombat(
       logs.push({
         tick, time, type: 'ability', sourceId: 'maokai-nova-selector',
         message: `Maokai N.O.V.A. 선택기! 모든 적 ${maokaiStunDur}초 광역 기절`,
+      });
+    }
+
+    // === PR7-C.6 (17.2b): Caitlyn N.O.V.A. 타격 선택기 추가 효과 ===
+    // 사용자 spec: surge 시 모든 적 mark + mark 적 받는 피해 +10%. mark 적 HP 처음 50% 이하 시
+    // 헤드샷 (76/114/222 물리, starLevel별, 1회). mark amp 적용은 applyAbilityMitigation 안
+    // (caitlyn-nova-selector mark.value=0.10 검사). 헤드샷 trigger 는 main loop tick 별도.
+    const caitlynSelector = state.teamUnits.find(u =>
+      u.champion.apiName === 'TFT17_Caitlyn'
+      && u.aatroxNovaStrikeSelector
+      && u.state !== 'dead'
+    );
+    if (caitlynSelector) {
+      for (const e of state.opposingTeam) {
+        if (e.state === 'dead') continue;
+        e.statusEffects.push({
+          type: 'mark', sourceId: 'caitlyn-nova-selector',
+          remainingTicks: 9999, value: 0.10, // incoming damage +10% (사용자 spec)
+        });
+      }
+      logs.push({
+        tick, time, type: 'ability', sourceId: 'caitlyn-nova-selector',
+        message: `Caitlyn N.O.V.A. 선택기! 모든 적 표식 (받는 피해 +10%)`,
+      });
+    }
+
+    // === PR7-C.6 (17.2b): Akali N.O.V.A. 타격 선택기 추가 효과 ===
+    // 사용자 spec: surge 시 모든 적 출혈 (매초 10/14/18 starLevel별 물리). 영구 적용 (전투 끝까지).
+    // burn statusEffect 사용 — value 는 매 tick damage. 매초 damage / TICKS_PER_SECOND.
+    const akaliSelector = state.teamUnits.find(u =>
+      u.champion.apiName === 'TFT17_Akali'
+      && u.aatroxNovaStrikeSelector
+      && u.state !== 'dead'
+    );
+    if (akaliSelector) {
+      const akaliBleedPerSec = [10, 14, 18];
+      const akaliBleedSec = akaliBleedPerSec[akaliSelector.starLevel - 1] ?? akaliBleedPerSec[0];
+      const akaliBleedPerTick = akaliBleedSec / TICKS_PER_SECOND;
+      for (const e of state.opposingTeam) {
+        if (e.state === 'dead') continue;
+        e.statusEffects.push({
+          type: 'burn', sourceId: 'akali-nova-selector',
+          remainingTicks: 9999, value: akaliBleedPerTick,
+        });
+      }
+      logs.push({
+        tick, time, type: 'ability', sourceId: 'akali-nova-selector',
+        message: `Akali N.O.V.A. 선택기! 모든 적 출혈 (매초 ${akaliBleedSec} 물리)`,
       });
     }
 
@@ -4529,6 +4589,56 @@ export function simulateCombat(
     };
     tickKindredNovaMark(playerDrxState, playerUnits, enemies);
     tickKindredNovaMark(enemyDrxState, enemies, playerUnits);
+
+    // PR7-C.6 (17.2b): Caitlyn N.O.V.A. 선택기 헤드샷 trigger.
+    // mark 적 (caitlyn-nova-selector source) 이 처음으로 HP 50% 이하 떨어질 때 1회 헤드샷.
+    // 사용자 spec: 헤드샷 damage = [76, 114, 222] (starLevel 1/2/3 물리). caster = Caitlyn selector.
+    // per-target Set (caitlynHeadshotTriggered) 으로 1회 보장. main loop tick 매번 검사.
+    const tickCaitlynHeadshot = (
+      teamUnits: CombatUnit[],
+      opposingTeam: CombatUnit[],
+      triggeredSet: Set<string>,
+    ) => {
+      const caitlynShooter = teamUnits.find(u =>
+        u.champion.apiName === 'TFT17_Caitlyn'
+        && u.aatroxNovaStrikeSelector
+        && u.state !== 'dead'
+      );
+      if (!caitlynShooter) return;
+      const headshotArr = [76, 114, 222];
+      const headshotBase = headshotArr[caitlynShooter.starLevel - 1] ?? headshotArr[0];
+      for (const e of opposingTeam) {
+        if (e.state === 'dead') continue;
+        if (triggeredSet.has(e.id)) continue;
+        const hasMark = e.statusEffects.some(
+          se => se.type === 'mark' && se.sourceId === 'caitlyn-nova-selector'
+        );
+        if (!hasMark) continue;
+        if (e.currentHp / e.maxHp > 0.50) continue;
+        // 처음으로 50% 이하 — 헤드샷 1회 발동
+        triggeredSet.add(e.id);
+        const ownArbHs = caitlynShooter.team === 'player' ? playerArbiterState : enemyArbiterState;
+        // mitigation 통합 helper 사용 (in-range cast 와 일관)
+        const headshotDmg = applyAbilityMitigation(caitlynShooter, e, headshotBase, 'physical', eventBus, tick);
+        e.currentHp -= headshotDmg;
+        e.totalDamageTaken += headshotDmg;
+        caitlynShooter.totalDamageDealt += headshotDmg;
+        triggerSerpentPoison(caitlynShooter, e, headshotDmg);
+        const headshotLog: CombatLog = {
+          tick, time, type: 'ability',
+          sourceId: caitlynShooter.id, targetId: e.id,
+          value: Math.round(headshotDmg),
+          message: `Caitlyn N.O.V.A. 헤드샷! ${e.champion.name}에게 ${Math.round(headshotDmg)} 물리 피해`,
+        };
+        logs.push(headshotLog);
+        tickLogs.push(headshotLog);
+        if (e.currentHp <= 0) {
+          markTargetDead(caitlynShooter, e, ownArbHs, eventBus, tick);
+        }
+      }
+    };
+    tickCaitlynHeadshot(playerUnits, enemies, playerCaitlynHeadshotTriggered);
+    tickCaitlynHeadshot(enemies, playerUnits, enemyCaitlynHeadshotTriggered);
 
     // 아이템 효과 runtime — interval timer dispatch
     itemRuntime.onTick(tick);

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -4199,17 +4199,25 @@ export function simulateCombat(
     if (akaliSelector) {
       const akaliBleedPerSec = [10, 14, 18];
       const akaliBleedSec = akaliBleedPerSec[akaliSelector.starLevel - 1] ?? akaliBleedPerSec[0];
-      const akaliBleedPerTick = akaliBleedSec / TICKS_PER_SECOND;
+      const akaliBleedRawPerTick = akaliBleedSec / TICKS_PER_SECOND;
       for (const e of state.opposingTeam) {
         if (e.state === 'dead') continue;
+        // codex P1 (PR #81): burn statusEffect 는 tickStatusEffects 에서 raw HP 차감 (mitigation 없음).
+        // 사용자 spec "물리 피해" → armor + pen 미리 적용 후 mitigated value 저장.
+        // DR 도 적용 (DOT snapshot 패턴 — 적용 시점 mitigation, armor 변동 시 추적 안 함).
+        // shield/invulnerable 은 매 tick 검사 어려워 단순화 (DOT 일반 패턴).
+        const mitigatedPerTick = applyResistance(akaliBleedRawPerTick, e.stats.armor, akaliSelector.stats.armorPen);
+        const finalPerTick = e.damageReduction > 0
+          ? mitigatedPerTick * (1 - e.damageReduction)
+          : mitigatedPerTick;
         e.statusEffects.push({
           type: 'burn', sourceId: 'akali-nova-selector',
-          remainingTicks: 9999, value: akaliBleedPerTick,
+          remainingTicks: 9999, value: finalPerTick,
         });
       }
       logs.push({
         tick, time, type: 'ability', sourceId: 'akali-nova-selector',
-        message: `Akali N.O.V.A. 선택기! 모든 적 출혈 (매초 ${akaliBleedSec} 물리)`,
+        message: `Akali N.O.V.A. 선택기! 모든 적 출혈 (매초 ${akaliBleedSec} 물리, mitigation 적용)`,
       });
     }
 
@@ -4997,6 +5005,15 @@ export function simulateCombat(
 
           if (target.statusEffects.some(e => e.type === 'invulnerable')) {
             finalDamage = 0;
+          }
+
+          // codex P1 (PR #81): Caitlyn N.O.V.A. selector mark — basic attack 도 +10% incoming amp.
+          // applyAbilityMitigation 안에만 적용하면 ability 만 amp → basic attack 누락.
+          // 사용자 spec "표식이 남은 대상이 받는 피해를 10% 증가" 모든 damage path 일관.
+          for (const mark of target.statusEffects) {
+            if (mark.type === 'mark' && mark.sourceId === 'caitlyn-nova-selector' && mark.value) {
+              finalDamage *= (1 + mark.value);
+            }
           }
 
           target.currentHp -= finalDamage;

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -694,6 +694,64 @@ describe('PR7-C — 아트록스 carry 3-skill cycle + N.O.V.A. 추가 발동', 
     expect(file).toMatch(/sourceId: 'kindred-nova-selector'/);
   });
 
+  // PR7-C.6 (17.2b 후속) — Caitlyn / Akali N.O.V.A. 타격 선택기 추가 효과.
+  // 사용자 spec:
+  //   - Caitlyn: surge 시 모든 적 mark + mark 적 받는 피해 +10%. 50% HP 첫 trigger 헤드샷 (76/114/222).
+  //   - Akali: surge 시 모든 적 출혈 (매초 10/14/18 starLevel별 물리, 영구).
+  it('Caitlyn N.O.V.A. selector 효과 코드 fingerprint (PR7-C.6)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // tickDrxNova 안 caitlynSelector 검사
+    expect(file).toMatch(/caitlynSelector\s*=\s*state\.teamUnits\.find\([\s\S]+?'TFT17_Caitlyn'[\s\S]+?aatroxNovaStrikeSelector/);
+    // mark statusEffect (sourceId='caitlyn-nova-selector', value=0.10)
+    expect(file).toMatch(/sourceId: 'caitlyn-nova-selector'[\s\S]+?value: 0\.10/);
+  });
+
+  it('caitlyn mark amp +10% applyAbilityMitigation 안 적용 (PR7-C.6)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // mitigation 안 caitlyn-nova-selector mark amp 처리
+    expect(file).toMatch(/mark\.sourceId === 'caitlyn-nova-selector' && mark\.value/);
+    expect(file).toMatch(/effectiveDmg \*= \(1 \+ mark\.value\)/);
+  });
+
+  it('Caitlyn 헤드샷 trigger 코드 fingerprint (PR7-C.6)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // tickCaitlynHeadshot helper + headshot damage [76, 114, 222]
+    expect(file).toMatch(/tickCaitlynHeadshot/);
+    expect(file).toMatch(/headshotArr\s*=\s*\[76, 114, 222\]/);
+    // 50% HP trigger + Set 추적 (1회)
+    expect(file).toMatch(/e\.currentHp \/ e\.maxHp > 0\.50/);
+    expect(file).toMatch(/triggeredSet\.add\(e\.id\)/);
+  });
+
+  it('Akali N.O.V.A. selector 효과 코드 fingerprint (PR7-C.6)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // tickDrxNova 안 akaliSelector 검사
+    expect(file).toMatch(/akaliSelector\s*=\s*state\.teamUnits\.find\([\s\S]+?'TFT17_Akali'[\s\S]+?aatroxNovaStrikeSelector/);
+    // 출혈 starLevel별 [10, 14, 18] per second + burn statusEffect (sourceId='akali-nova-selector')
+    expect(file).toMatch(/akaliBleedPerSec\s*=\s*\[10, 14, 18\]/);
+    expect(file).toMatch(/sourceId: 'akali-nova-selector'[\s\S]+?value: akaliBleedPerTick/);
+  });
+
   it('Kindred 5초 주기 mark 갱신 코드 fingerprint (PR7-C.5)', async () => {
     const fs = await import('node:fs');
     const path = await import('node:path');

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -723,6 +723,38 @@ describe('PR7-C — 아트록스 carry 3-skill cycle + N.O.V.A. 추가 발동', 
     expect(file).toMatch(/effectiveDmg \*= \(1 \+ mark\.value\)/);
   });
 
+  // codex P1 (PR #81) 회귀 가드 — Caitlyn mark amp 모든 damage path 적용.
+  // applyAbilityMitigation 외에 basic attack 도 적용.
+  it('basic attack 도 caitlyn mark amp 적용 (codex P1 PR #81)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // basic attack site (finalDamage *= (1 + mark.value)) — caitlyn-nova-selector mark 검사
+    // 출현 횟수: applyAbilityMitigation 안 1회 + basic attack 안 1회 = 최소 2회
+    const matches = file.match(/mark\.sourceId === 'caitlyn-nova-selector' && mark\.value/g);
+    expect(matches).toBeDefined();
+    expect(matches!.length).toBeGreaterThanOrEqual(2);
+    // basic attack 안 finalDamage *= (1 + mark.value) 패턴
+    expect(file).toMatch(/finalDamage \*= \(1 \+ mark\.value\)/);
+  });
+
+  // codex P1 (PR #81) 회귀 가드 — Akali burn 에 armor + pen + DR mitigation 적용.
+  it('Akali burn 에 armor mitigation 적용 (codex P1 PR #81)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // mitigatedPerTick = applyResistance(akaliBleedRawPerTick, e.stats.armor, akaliSelector.stats.armorPen)
+    expect(file).toMatch(/mitigatedPerTick\s*=\s*applyResistance\(akaliBleedRawPerTick, e\.stats\.armor, akaliSelector\.stats\.armorPen\)/);
+    // DR 적용
+    expect(file).toMatch(/finalPerTick\s*=\s*e\.damageReduction > 0[\s\S]+?mitigatedPerTick \* \(1 - e\.damageReduction\)/);
+  });
+
   it('Caitlyn 헤드샷 trigger 코드 fingerprint (PR7-C.6)', async () => {
     const fs = await import('node:fs');
     const path = await import('node:path');
@@ -748,8 +780,9 @@ describe('PR7-C — 아트록스 carry 3-skill cycle + N.O.V.A. 추가 발동', 
     // tickDrxNova 안 akaliSelector 검사
     expect(file).toMatch(/akaliSelector\s*=\s*state\.teamUnits\.find\([\s\S]+?'TFT17_Akali'[\s\S]+?aatroxNovaStrikeSelector/);
     // 출혈 starLevel별 [10, 14, 18] per second + burn statusEffect (sourceId='akali-nova-selector')
+    // codex P1 (PR #81): mitigated value 저장 (armor + pen 적용 후, DR 적용 후)
     expect(file).toMatch(/akaliBleedPerSec\s*=\s*\[10, 14, 18\]/);
-    expect(file).toMatch(/sourceId: 'akali-nova-selector'[\s\S]+?value: akaliBleedPerTick/);
+    expect(file).toMatch(/sourceId: 'akali-nova-selector'[\s\S]+?value: finalPerTick/);
   });
 
   it('Kindred 5초 주기 mark 갱신 코드 fingerprint (PR7-C.5)', async () => {


### PR DESCRIPTION
## Summary

- **PR7-C.6 (17.2b 후속)** — PR7-C.5 (Maokai/Kindred) 후속. 나머지 NOVA 유닛 (Caitlyn/Akali) 타격 선택기 추가 효과.
- 5/5 NOVA 유닛 spec 모두 적용 완료.

## 사용자 spec

### Caitlyn 타격 선택기
- **6초 surge 시점**: 모든 적 표식 (mark statusEffect, value=0.10) + 표식 적이 받는 피해 +10%
- **HP 50% 첫 trigger**: mark 적의 HP 처음 50% 이하 떨어질 때 헤드샷 1회
  - damage = [76, 114, 222] (starLevel 1/2/3 물리)
  - Set 추적 (이후 HP 회복/재손실 시 재발동 안 함)

### Akali 타격 선택기
- **6초 surge 시점**: 모든 적 출혈 (burn statusEffect, sourceId='akali-nova-selector')
  - 매초 [10, 14, 18] (starLevel 1/2/3 물리), 영구 (전투 끝까지)

향후 후속: Akali 단검 출혈 +10% (raw ability hook 별도 PR).

## 변경 파일 (2개)

| 파일 | 변경 |
|------|------|
| \`src/lib/simulator/engine/combatLoop.ts\` | tickDrxNova caitlyn/akali selector + applyAbilityMitigation mark amp + main loop tickCaitlynHeadshot helper (~75 lines) |
| \`tests/unit/simulator/hero-augment-stat-system.test.ts\` | PR7-C.6 회귀 가드 4개 |

## 핵심 구현

### Caitlyn surge (tickDrxNova 안)
\`\`\`ts
const caitlynSelector = state.teamUnits.find(u =>
  u.champion.apiName === 'TFT17_Caitlyn' && u.aatroxNovaStrikeSelector && u.state !== 'dead'
);
if (caitlynSelector) {
  for (const e of state.opposingTeam) {
    if (e.state === 'dead') continue;
    e.statusEffects.push({
      type: 'mark', sourceId: 'caitlyn-nova-selector',
      remainingTicks: 9999, value: 0.10, // incoming damage +10%
    });
  }
}
\`\`\`

### caitlyn mark amp (applyAbilityMitigation 안)
\`\`\`ts
// mitigation pipeline 마지막 단계 (shield/invulnerable 후)
for (const mark of t.statusEffects) {
  if (mark.type === 'mark' && mark.sourceId === 'caitlyn-nova-selector' && mark.value) {
    effectiveDmg *= (1 + mark.value);
  }
}
\`\`\`

### Caitlyn 헤드샷 (main loop tick)
\`\`\`ts
const tickCaitlynHeadshot = (teamUnits, opposingTeam, triggeredSet) => {
  const caitlynShooter = teamUnits.find(...);
  if (!caitlynShooter) return;
  const headshotArr = [76, 114, 222];
  for (const e of opposingTeam) {
    if (triggeredSet.has(e.id)) continue;
    const hasMark = e.statusEffects.some(se => se.type === 'mark' && se.sourceId === 'caitlyn-nova-selector');
    if (!hasMark || e.currentHp / e.maxHp > 0.50) continue;
    triggeredSet.add(e.id);
    // applyAbilityMitigation helper (in-range cast 와 일관)
    const headshotDmg = applyAbilityMitigation(caitlynShooter, e, headshotBase, 'physical', eventBus, tick);
    // damage 적용 + sociopath + serpent + markTargetDead
  }
};
\`\`\`

### Akali surge (tickDrxNova 안)
\`\`\`ts
const akaliBleedPerSec = [10, 14, 18];
const akaliBleedPerTick = akaliBleedPerSec[starLevel - 1] / TICKS_PER_SECOND;
for (const e of state.opposingTeam) {
  e.statusEffects.push({
    type: 'burn', sourceId: 'akali-nova-selector',
    remainingTicks: 9999, value: akaliBleedPerTick,
  });
}
\`\`\`

## 회귀 가드 (4개)

1. Caitlyn N.O.V.A. selector 효과 (caitlynSelector + mark sourceId/value)
2. caitlyn mark amp +10% applyAbilityMitigation 안
3. Caitlyn 헤드샷 trigger (tickCaitlynHeadshot + headshotArr [76,114,222] + 50% HP + Set)
4. Akali N.O.V.A. selector 효과 (akaliSelector + bleedPerSec [10,14,18] + burn sourceId)

## NOVA 타격 선택기 메커니즘 종합 (PR7-C + PR7-C.5 + PR7-C.6) — 완료

| NOVA 유닛 | 효과 | 발동 패턴 | 적용 PR |
|-----------|------|----------|--------|
| Aatrox | 모든 적 novaDamage 물리 + 1초 knockup | cast 마다 | PR7-C |
| Maokai | 모든 적 광역 stun (1.5/1.5/1.75초) | surge 1회 | PR7-C.5 |
| Kindred | 본인 damageAmp +5% + 모든 적 mark | surge + 5초 주기 | PR7-C.5 |
| **Caitlyn** | 모든 적 mark + 받는 피해 +10% + 50% HP 헤드샷 (76/114/222) | surge + 지속 검사 | **PR7-C.6** |
| **Akali** | 모든 적 출혈 (10/14/18 매초 물리) | surge 1회 | **PR7-C.6** |

**5/5 NOVA 유닛 spec 적용 완료**.

## Test plan

- [x] \`pnpm typecheck\` 통과
- [x] \`pnpm lint\` 0 errors (14 warnings 본 PR 무관)
- [x] \`pnpm build\` 통과
- [x] 전체 테스트: **731 passed | 8 skipped** (회귀 0건, +4 신규)
- [x] hero-augment-stat-system.test.ts: **83 passed** (기존 79 + 신규 4)

## 향후 후속 PR

- **Akali 단검 출혈 +10%** — raw Akali ability hit 시 burn value × 1.10 refresh
- mark statusEffect 효과 다른 시너지 (Stargazer Huntress 등) 와의 상호작용 검토

## PR 의존성

PR #67 → ... → PR #80 (PR7-C.5) → **PR7-C.6 (Caitlyn/Akali NOVA selector)** ← 본 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)