### PR TITLE
feat(patch-17-2b): Akali 단검 출혈 +10% (PR7-C.7) — Akali NOVA selector 마무리

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6355,6 +6355,20 @@ export function simulateCombat(
             }
           }
 
+          // codex P1 (PR #82): PR7-C.7 Akali 단검 burn refresh OOR 동기화 — in-range cast loop
+          // (line ~6011) 와 동일 패턴. Akali raw ability OOR 도 burn × 1.10 적용.
+          if (unit.champion.apiName === 'TFT17_Akali') {
+            for (const t of abilityTargets) {
+              if (t.state === 'dead') continue;
+              const akaliBurn = t.statusEffects.find(
+                se => se.type === 'burn' && se.sourceId === 'akali-nova-selector'
+              );
+              if (akaliBurn && akaliBurn.value) {
+                akaliBurn.value *= 1.10;
+              }
+            }
+          }
+
           // === 이즈리얼 드론: 스킬 사용 시 타겟에게 추가 물리 피해 ===
           const ezDronesOOR = (unit as CombatUnit & { _ezrealDrones?: number })._ezrealDrones ?? 0;
           if (ezDronesOOR > 0 && abilityTarget.state !== 'dead') {

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6009,6 +6009,22 @@ export function simulateCombat(
                 unit.aatroxCycleCounter++;
               }
 
+              // === PR7-C.7 (17.2b): Akali raw ability "단검" hit 시 burn refresh ===
+              // 사용자 spec: "단검은 출혈 피해량을 10% 증가". Akali raw ability (관통 단검 5개) hit
+              // 한 적의 akali-nova-selector burn value × 1.10 (refresh). 적이 mark 없으면 무관.
+              // surge 전 (akali-nova-selector burn 없음) → 자연스럽게 무효.
+              if (unit.champion.apiName === 'TFT17_Akali') {
+                for (const t of abilityTargets) {
+                  if (t.state === 'dead') continue;
+                  const akaliBurn = t.statusEffects.find(
+                    se => se.type === 'burn' && se.sourceId === 'akali-nova-selector'
+                  );
+                  if (akaliBurn && akaliBurn.value) {
+                    akaliBurn.value *= 1.10;
+                  }
+                }
+              }
+
               // 최신상 Phase 3C-2 — ability AOE (BlastRadius / SympatheticDetonation).
               // ability primary hit 처리 끝난 직후 호출. abilityTarget 위치 기준.
               // baseDmg = abilityDmg (raw hit count damage 단위, mitigation 전).

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -787,6 +787,25 @@ describe('PR7-C — 아트록스 carry 3-skill cycle + N.O.V.A. 추가 발동', 
     expect(file).toMatch(/akaliBurn\.value \*= 1\.10/);
   });
 
+  // codex P1 (PR #82) 회귀 가드 — Akali 단검 burn refresh OOR cast 동기화.
+  // in-range cast 와 OOR cast 모두 적용되도록 두 site 호출 검증.
+  it('Akali 단검 burn refresh in-range + OOR 둘 다 적용 (codex P1 PR #82)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // unit.champion.apiName === 'TFT17_Akali' 매치 횟수 >= 2 (in-range + OOR)
+    const akaliMatches = file.match(/unit\.champion\.apiName === 'TFT17_Akali'/g);
+    expect(akaliMatches).toBeDefined();
+    expect(akaliMatches!.length).toBeGreaterThanOrEqual(2);
+    // akali-nova-selector burn 검색 매치 횟수 >= 2
+    const burnMatches = file.match(/se\.type === 'burn' && se\.sourceId === 'akali-nova-selector'/g);
+    expect(burnMatches).toBeDefined();
+    expect(burnMatches!.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('Akali N.O.V.A. selector 효과 코드 fingerprint (PR7-C.6)', async () => {
     const fs = await import('node:fs');
     const path = await import('node:path');

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -770,6 +770,23 @@ describe('PR7-C — 아트록스 carry 3-skill cycle + N.O.V.A. 추가 발동', 
     expect(file).toMatch(/triggeredSet\.add\(e\.id\)/);
   });
 
+  // PR7-C.7 (17.2b 후속) — Akali 단검 출혈 +10% 메커니즘.
+  // 사용자 spec: "단검은 출혈 피해량을 10% 증가". Akali raw ability hit 적의 burn value × 1.10.
+  it('Akali 단검 burn refresh 코드 fingerprint (PR7-C.7)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+    // unit.champion.apiName === 'TFT17_Akali' 검사
+    expect(file).toMatch(/unit\.champion\.apiName === 'TFT17_Akali'/);
+    // akali-nova-selector burn 검색
+    expect(file).toMatch(/se\.type === 'burn' && se\.sourceId === 'akali-nova-selector'/);
+    // burn value × 1.10 refresh
+    expect(file).toMatch(/akaliBurn\.value \*= 1\.10/);
+  });
+
   it('Akali N.O.V.A. selector 효과 코드 fingerprint (PR7-C.6)', async () => {
     const fs = await import('node:fs');
     const path = await import('node:path');


### PR DESCRIPTION
## Summary

- **PR7-C.7 (17.2b 후속)** — PR7-C.6 의 Akali 도메인 spec 마지막 메커니즘.
- "단검은 출혈 피해량을 10% 증가" — Akali raw ability hit 적의 burn value × 1.10 refresh.

## 사용자 spec (PR7-C.6 답변에서)

- Akali raw ability "관통 단검 5개" hit 시 → 적의 출혈 (akali-nova-selector burn) +10%
- surge 전 (akali-nova-selector burn 없음) → 자연스럽게 무효
- surge 후 → 매 cast 시 hit 적의 burn value 누적 ×1.10

## 변경

\`combatLoop.ts\` cast loop 끝 (post-cast pipeline 직전):

\`\`\`ts
if (unit.champion.apiName === 'TFT17_Akali') {
  for (const t of abilityTargets) {
    if (t.state === 'dead') continue;
    const akaliBurn = t.statusEffects.find(
      se => se.type === 'burn' && se.sourceId === 'akali-nova-selector'
    );
    if (akaliBurn && akaliBurn.value) {
      akaliBurn.value *= 1.10;
    }
  }
}
\`\`\`

## 효과

- Akali NOVA selector 활성 + raw ability 반복 cast 시 burn damage 누적 증가
- hit 1회: ×1.10 → 매초 11/15.4/19.8 (1성/2성/3성)
- hit 2회: ×1.21 → 매초 12.1/16.94/21.78
- hit N회: ×1.10^N (Akali 매 cast 마다 누적)

## 회귀 가드 (1개)

Akali 단검 burn refresh fingerprint (TFT17_Akali + akali-nova-selector burn + value × 1.10)

## NOVA 타격 선택기 메커니즘 종합 — 완료

| NOVA 유닛 | 효과 | 적용 PR |
|-----------|------|--------|
| Aatrox | cast 마다 모든 적 novaDamage + knockup | PR7-C |
| Maokai | surge 1회 광역 stun | PR7-C.5 |
| Kindred | surge + 5초 주기 mark | PR7-C.5 |
| Caitlyn | surge mark + 받는 피해 +10% + 50% HP 헤드샷 | PR7-C.6 |
| **Akali** | surge 출혈 + **단검 hit 시 burn +10%** | **PR7-C.6 + PR7-C.7** |

## Test plan

- [x] \`pnpm typecheck\` 통과
- [x] \`pnpm lint\` 0 errors (14 warnings 본 PR 무관)
- [x] \`pnpm build\` 통과
- [x] 전체 테스트: **734 passed | 8 skipped** (회귀 0건, +1 신규)
- [x] hero-augment-stat-system.test.ts: **86 passed** (기존 85 + 신규 1)

## PR 의존성

PR #67 → ... → PR #81 (PR7-C.6 + codex P1×2) → **PR7-C.7 (Akali 단검 +10%)** ← 본 PR

후속 (선택적):
- 다른 ability mitigation site (Graves bouncing / Briar / Annie) mark amp 적용
- PR6 statOverrides 채우기 (사용자 인게임 측정)
- Meeps 챔프별 메커니즘

🤖 Generated with [Claude Code](https://claude.com/claude-code)