### PR TITLE
feat(ui): N.O.V.A. 타격 선택기 UI 도구 + ItemGrid 동물특공대/초능력 탭 (PR8)

### DIFF
--- a/docs/meta/nova-selector-ui-handoff.md
+++ b/docs/meta/nova-selector-ui-handoff.md
@@ -1,0 +1,96 @@
+# N.O.V.A. 타격 선택기 UI + 아이템 탭 필터링 — 작업 인계 가이드
+
+**작성일**: 2026-05-04
+**브랜치**: `feature/nova-selector-ui-trait-tabs` (dev base)
+**재개 예정**: 2026-05-06 (수)
+**선행 PR**: #85 머지 완료 (raw data + 자동 할당)
+
+## 사용자 요청
+
+1. **N.O.V.A. 타격 선택기 UI**: 자석 제거기 패턴(`DraggableItemRemoverTool`) 따라서 사용자가 수동으로 NOVA 5종(Aatrox/Caitlyn/Akali/Maokai/Kindred) 중 하나에게 타격 선택기를 적용할 수 있는 드래그 도구 추가.
+2. **아이템 탭 필터링**: ItemGrid에 동물특공대(AnimaSquad) / 초능력(PsyOps) trait 전용 아이템 탭 추가.
+3. 자동 할당(`autoAssignNovaSelector`)은 명시적 선택 없을 때 fallback으로 유지.
+4. **하나의 PR로 진행** (사용자 명시).
+
+## 진행 상태
+
+**조사만 완료, 코드 변경 0**. 다음 세션에서 구현 시작.
+
+## 발견된 사항 (재개 시 즉시 반영)
+
+### 1. 시뮬 호출 사이트가 NOVA 옵션을 전달하지 않음 (중요)
+- PR #85에서 `simulateOptions.playerNovaStrikeSelectorUnit` / `enemyNovaStrikeSelectorUnit` 옵션은 추가됐지만 **호출 사이트 3곳 모두 미전달**:
+  - `src/app/api/simulate/route.ts:39-44` — body에서 안 받음
+  - `src/hooks/useCombatAnalysis.ts:154-158, 186-190` — options에 안 넣음
+- 즉 현재는 자동 할당만 동작. 수동 선택 UI를 만들려면 호출 경로도 손봐야 함.
+
+### 2. 영역 분리
+- `ItemGrid` (탭 추가 대상): `src/components/builder/ItemGrid.tsx` — `builder/SelectedUnitPanel.tsx`에서만 사용 (builder 영역)
+- `DraggableItemRemoverTool` (NOVA selector UI 패턴): `src/components/actual-data/` — `ChampionItemSidebar.ToolsSection`에서만 사용 (actual-data 영역)
+- 두 영역이 분리되어 있어 NOVA selector UI 위치는 actual-data만 우선, builder는 후속 PR 권장.
+
+### 3. PlacedChampion / PlacedUnit 스키마
+- `PlacedChampion` (`src/types/index.ts:334`): boolean 필드 없음. `mfMode?: MfMode | null` 같은 optional 패턴 존재 → `novaStrikeSelector?: boolean` 추가 가능
+- `PlacedUnit` (`src/lib/actualData/schema.ts:40`): zod schema. `novaStrikeSelector: z.boolean().optional()` 추가 (기존 데이터 호환 유지)
+
+### 4. 분류 함수 (이미 존재)
+- `src/lib/simulator/systems/item.ts:124-143` `getItemCategory()`
+  - `apiName.startsWith('TFT17_AnimaSquadItem_')` → 현재 `'combined'` 반환 → `'animasquad'`로 분기
+  - `apiName.startsWith('TFT17_Item_PsyOps_')` → 현재 `'combined'` 반환 → `'psyops'`로 분기
+- `ItemCategory` union 타입에 `'animasquad' | 'psyops'` 추가 필요
+
+## 작업 계획 (한 PR, 4 commits)
+
+### Commit 1 — 아이템 탭 추가 (animasquad / psyops)
+- `src/types/index.ts` — `ItemCategory` union 확장
+- `src/lib/simulator/systems/item.ts` — `getItemCategory()` 분기 + `canEquipItem()`에 통과 처리
+- `src/components/builder/ItemGrid.tsx` — `ItemTab` union 확장, `tabs` 배열에 라벨 추가, 필터 로직에 `tab === 'animasquad' | 'psyops'` 분기
+
+### Commit 2 — NOVA selector schema + 시뮬 옵션 변환
+- `src/types/index.ts` `PlacedChampion` 인터페이스에 `novaStrikeSelector?: boolean`
+- `src/lib/actualData/schema.ts` `PlacedUnitSchema`에 `novaStrikeSelector: z.boolean().optional()`
+- `src/app/api/simulate/route.ts` — request body에서 받아 `SimulateOptions`로 전달
+- `src/hooks/useCombatAnalysis.ts` — `reconstruction.playerTeam`/`enemyTeam`에서 `novaStrikeSelector === true`인 unit의 `champion.apiName`을 옵션으로 변환 (양 사이트)
+- (필요 시) reconstruction 함수에서 PlacedUnit boolean → PlacedChampion boolean 매핑 추가
+
+### Commit 3 — UI tool + drop handler
+- `src/types/index.ts` `DragData` union에 `'nova-selector'` toolKind 추가 (`{ type: 'tool'; toolKind: 'nova-selector' }`)
+- `src/components/actual-data/DraggableNovaSelectorTool.tsx` — 신규 (`DraggableItemRemoverTool` 복제 패턴)
+  - 아이콘: `/data/images/items/tft17_drxselector.tft_set17.png`
+  - 제목: "타격 선택기 — N.O.V.A. 유닛에 드롭하면 타격 효과 적용"
+- `src/components/actual-data/actualDndHandlers.ts` — `'nova-selector'` 핸들러 추가
+  - drop 대상이 NOVA 5종(`TFT17_Aatrox/Caitlyn/Akali/Maokai/Kindred`)이 아니면 무시
+  - 같은 팀 내 기존 selector 보유 unit의 boolean 해제 후 drop 대상에 set (단일성 보장)
+- `src/components/actual-data/ChampionItemSidebar.tsx:177-180` `ToolsSection`에 `<DraggableNovaSelectorTool size={44} />` 추가
+- (선택) drop된 unit에 시각적 마커(쉬머 보더 등) 추가 — `PlacedUnitTile`/`SetupBoardCore`
+
+### Commit 4 — 회귀 가드 + 검증
+- 새 가드 5건 (예시):
+  - `getItemCategory(AnimaSquadItem) === 'animasquad'`
+  - `getItemCategory(PsyOpsItem) === 'psyops'`
+  - `ItemTab` union에 신규 키 존재 fingerprint
+  - `DragData`에 `'nova-selector'` toolKind 존재 fingerprint
+  - simulate API/useCombatAnalysis 옵션 전달 fingerprint
+- `pnpm typecheck && pnpm lint && pnpm vitest run && pnpm build` 모두 통과 후 PR
+
+## 리스크 / 결정 미정 항목
+
+1. **PlacedUnit schema 확장 → 기존 저장 JSON 호환성**: optional이라 기존 데이터는 `undefined`로 안전. 새 필드 추가만으로 마이그레이션 불필요.
+2. **builder 영역 NOVA selector UI**: 이번 PR에서 제외 (후속 PR로). builder는 unit-by-unit 패널이라 별도 UX 설계 필요.
+3. **drop 시 중복 selector 처리**: 같은 팀에서 두 unit이 동시에 selector 가질 수 없도록 핸들러에서 강제 해제 (단일성).
+4. **자동 할당 fallback 우선순위**: `combatLoop.ts:4070-4078` (옵션 명시 시 적용) 후 `4110-4111` (autoAssignNovaSelector — 옵션 없을 때만 실행)이 이미 올바르게 처리됨. 추가 변경 불필요.
+
+## 재개 시 첫 액션
+
+1. `git checkout feature/nova-selector-ui-trait-tabs && git pull origin dev` (혹시 dev 진행)
+2. 본 문서 + 위 메모리(`project_nova_selector_ui_status.md`) 읽기
+3. Commit 1부터 순차 진행
+4. PR 제목 안: `feat(ui): N.O.V.A. 타격 선택기 UI 도구 + ItemGrid 동물특공대/초능력 탭 (PR8)`
+
+## 참고 파일
+
+- 자석 제거기 패턴: `src/components/actual-data/DraggableItemRemoverTool.tsx`
+- drop 핸들러 예시: `src/components/actual-data/actualDndHandlers.ts:122-128`
+- 기존 ItemGrid 탭 시스템: `src/components/builder/ItemGrid.tsx:16-72`
+- `getItemCategory()` 분류: `src/lib/simulator/systems/item.ts:124-143`
+- 자동 할당 코드 (수정 X): `src/lib/simulator/engine/combatLoop.ts:4080-4111`

--- a/src/app/api/simulate/route.ts
+++ b/src/app/api/simulate/route.ts
@@ -9,6 +9,13 @@ interface SimulateRequestBody {
   allTraits?: RawTrait[];
   playerAugments?: RawAugment[];
   enemyAugments?: RawAugment[];
+  /**
+   * N.O.V.A. (DRX) "타격 선택기" 적용할 NOVA 유닛 apiName. 미지정 시:
+   * 1) playerTeam/enemyTeam 의 unit.novaStrikeSelector === true 인 unit 으로 fallback,
+   * 2) 그것도 없으면 combatLoop 내부 autoAssignNovaSelector 가 활성 NOVA trait 기준 첫 unit 자동 지정.
+   */
+  playerNovaStrikeSelectorUnit?: string;
+  enemyNovaStrikeSelectorUnit?: string;
 }
 
 export async function POST(request: NextRequest) {
@@ -36,11 +43,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // NOVA 타격 선택기: 명시 지정 > playerTeam.novaStrikeSelector === true 인 unit fallback.
+    const playerNovaUnit = body.playerNovaStrikeSelectorUnit
+      ?? body.playerTeam.find((u) => u.novaStrikeSelector === true)?.champion.apiName;
+    const enemyNovaUnit = body.enemyNovaStrikeSelectorUnit
+      ?? body.enemyTeam.find((u) => u.novaStrikeSelector === true)?.champion.apiName;
+
     const options: SimulateOptions = {
       seed: body.seed ?? 42,
       allTraits: body.allTraits,
       playerAugments: body.playerAugments,
       enemyAugments: body.enemyAugments,
+      playerNovaStrikeSelectorUnit: playerNovaUnit,
+      enemyNovaStrikeSelectorUnit: enemyNovaUnit,
     };
 
     const result = simulateCombat(body.playerTeam, body.enemyTeam, options);

--- a/src/app/simulator/layout/SimulatorLayoutDesktop.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutDesktop.tsx
@@ -453,7 +453,7 @@ export default function SimulatorLayoutDesktop(props: SimulatorLayoutProps) {
                       }
                       if (itemSearch && !item.name.toLowerCase().includes(itemSearch.toLowerCase())) return false;
                       if (itemCategoryFilter !== 'all') {
-                        if (cat === 'void' || cat === 'darkin') {
+                        if (cat === 'void' || cat === 'darkin' || cat === 'animasquad' || cat === 'psyops') {
                           if (itemCategoryFilter !== 'combined') return false;
                         } else if (cat !== itemCategoryFilter) return false;
                       }

--- a/src/app/simulator/layout/SimulatorLayoutDesktop.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutDesktop.tsx
@@ -313,6 +313,7 @@ export default function SimulatorLayoutDesktop(props: SimulatorLayoutProps) {
                   onRemoveUnit={() => tm.handleRemoveUnit(tm.selectedUnit!.team, tm.selectedUnit!.index)}
                   onMfModeChange={(mode) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, mode)}
                   onPermanentStackChange={(value) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, value)}
+                  onNovaStrikeSelectorToggle={(next) => tm.handleNovaStrikeSelectorChange(tm.selectedUnit!.team, tm.selectedUnit!.index, next)}
                   onEditGravesWeapons={onEditGravesWeapons ? () => onEditGravesWeapons(tm.selectedUnit!.team) : undefined}
                   teamGravesPicks={tm.selectedUnit!.team === 'player' ? tm.playerGravesPicks : tm.enemyGravesPicks}
                 />
@@ -351,7 +352,8 @@ export default function SimulatorLayoutDesktop(props: SimulatorLayoutProps) {
                     onRemoveUnit={() => tm.handleRemoveUnit(tm.selectedUnit!.team, tm.selectedUnit!.index)}
                     onMfModeChange={(mode) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, mode)}
                     onPermanentStackChange={(value) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, value)}
-                  onEditGravesWeapons={onEditGravesWeapons ? () => onEditGravesWeapons(tm.selectedUnit!.team) : undefined}
+                    onNovaStrikeSelectorToggle={(next) => tm.handleNovaStrikeSelectorChange(tm.selectedUnit!.team, tm.selectedUnit!.index, next)}
+                    onEditGravesWeapons={onEditGravesWeapons ? () => onEditGravesWeapons(tm.selectedUnit!.team) : undefined}
                   />
                 </div>
               )}

--- a/src/app/simulator/layout/SimulatorLayoutMobile.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutMobile.tsx
@@ -93,6 +93,7 @@ export default function SimulatorLayoutMobile(props: SimulatorLayoutProps) {
           onRemoveUnit={() => tm.handleRemoveUnit(tm.selectedUnit!.team, tm.selectedUnit!.index)}
           onMfModeChange={(m) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, m)}
           onPermanentStackChange={(v) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, v)}
+          onNovaStrikeSelectorToggle={(next) => tm.handleNovaStrikeSelectorChange(tm.selectedUnit!.team, tm.selectedUnit!.index, next)}
           onEditGravesWeapons={props.onEditGravesWeapons ? () => props.onEditGravesWeapons!(tm.selectedUnit!.team) : undefined}
           teamGravesPicks={tm.selectedUnit!.team === 'player' ? tm.playerGravesPicks : tm.enemyGravesPicks}
         />

--- a/src/app/simulator/layout/SimulatorLayoutTablet.tsx
+++ b/src/app/simulator/layout/SimulatorLayoutTablet.tsx
@@ -462,6 +462,7 @@ function TabletUnitContent(props: SimulatorLayoutProps) {
         onRemoveUnit={() => tm.handleRemoveUnit(tm.selectedUnit!.team, tm.selectedUnit!.index)}
         onMfModeChange={(m) => tm.handleMfModeChange(tm.selectedUnit!.team, tm.selectedUnit!.index, m)}
         onPermanentStackChange={(v) => tm.handlePermanentStackChange(tm.selectedUnit!.team, tm.selectedUnit!.index, v)}
+        onNovaStrikeSelectorToggle={(next) => tm.handleNovaStrikeSelectorChange(tm.selectedUnit!.team, tm.selectedUnit!.index, next)}
         onEditGravesWeapons={onEditGravesWeapons ? () => onEditGravesWeapons(tm.selectedUnit!.team) : undefined}
         teamGravesPicks={tm.selectedUnit!.team === 'player' ? tm.playerGravesPicks : tm.enemyGravesPicks}
       />

--- a/src/app/simulator/layout/pool/ItemPoolContent.tsx
+++ b/src/app/simulator/layout/pool/ItemPoolContent.tsx
@@ -45,7 +45,7 @@ export default function ItemPoolContent({ data, poolFilters, tm }: SimulatorLayo
           }
           if (itemSearch && !item.name.toLowerCase().includes(itemSearch.toLowerCase())) return false;
           if (itemCategoryFilter !== 'all') {
-            if (cat === 'void' || cat === 'darkin') {
+            if (cat === 'void' || cat === 'darkin' || cat === 'animasquad' || cat === 'psyops') {
               if (itemCategoryFilter !== 'combined') return false;
             } else if (cat !== itemCategoryFilter) return false;
           }

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -250,6 +250,9 @@ function SimulatorContent() {
         enemyArbiterLaw: tm.enemyArbiterLaw ?? undefined,
         playerStargazerConstellation: tm.playerStargazerConstellation ?? undefined,
         enemyStargazerConstellation: tm.enemyStargazerConstellation ?? undefined,
+        // SelectedUnitPanel NOVA 토글 → 옵션 도출. 미지정 시 autoAssignNovaSelector fallback.
+        playerNovaStrikeSelectorUnit: tm.playerTeam.find(u => u.novaStrikeSelector === true)?.champion.apiName,
+        enemyNovaStrikeSelectorUnit: tm.enemyTeam.find(u => u.novaStrikeSelector === true)?.champion.apiName,
         playerGravesFrame,
         enemyGravesFrame,
         playerGravesUpgrades,
@@ -291,6 +294,8 @@ function SimulatorContent() {
           stageNumber,
           playerStargazerConstellation: tm.playerStargazerConstellation ?? undefined,
           enemyStargazerConstellation: tm.enemyStargazerConstellation ?? undefined,
+          playerNovaStrikeSelectorUnit: tm.playerTeam.find(u => u.novaStrikeSelector === true)?.champion.apiName,
+          enemyNovaStrikeSelectorUnit: tm.enemyTeam.find(u => u.novaStrikeSelector === true)?.champion.apiName,
           playerGravesFrame,
           enemyGravesFrame,
           playerGravesUpgrades,

--- a/src/components/actual-data/ChampionItemSidebar.tsx
+++ b/src/components/actual-data/ChampionItemSidebar.tsx
@@ -128,7 +128,7 @@ function ItemSection({ items, onItemClick }: { items: RawItem[]; onItemClick?: (
       if (cat === 'bilgewater') return false;
       if (cat === 'void') return false;
       if (tab === 'all') return true;
-      if (tab === 'combined' && (cat === 'darkin')) return true;
+      if (tab === 'combined' && (cat === 'darkin' || cat === 'animasquad' || cat === 'psyops')) return true;
       return cat === tab;
     });
   }, [items, search, tab]);

--- a/src/components/actual-data/ChampionItemSidebar.tsx
+++ b/src/components/actual-data/ChampionItemSidebar.tsx
@@ -7,6 +7,7 @@ import DraggableChampionCard from '@/components/builder/DraggableChampionCard';
 import DraggableItemIcon from '@/components/builder/DraggableItemIcon';
 import SearchBar from '@/components/ui/SearchBar';
 import DraggableItemRemoverTool from './DraggableItemRemoverTool';
+import DraggableNovaSelectorTool from './DraggableNovaSelectorTool';
 
 type Tab = 'champions' | 'items' | 'tools';
 type CostFilter = null | 1 | 2 | 3 | 4 | 5;
@@ -176,6 +177,7 @@ function ToolsSection() {
       </p>
       <div className="grid grid-cols-5 gap-1.5">
         <DraggableItemRemoverTool size={44} />
+        <DraggableNovaSelectorTool size={44} />
       </div>
     </div>
   );

--- a/src/components/actual-data/ChampionItemSidebar.tsx
+++ b/src/components/actual-data/ChampionItemSidebar.tsx
@@ -19,6 +19,12 @@ interface Props {
   /** Click fallback for non-DnD placement — receives either a champion or item selection. */
   onChampionClick?: (c: RawChampion) => void;
   onItemClick?: (i: RawItem) => void;
+  /**
+   * 어느 한 팀(player 또는 opponent)이라도 N.O.V.A.(5) 시너지가 활성이면 true.
+   * true 일 때만 ToolsSection 의 NOVA 타격 선택기 도구가 노출된다.
+   * 미지정 시 기본 false (도구 숨김 — fail-safe).
+   */
+  novaTraitActive?: boolean;
 }
 
 /**
@@ -27,7 +33,7 @@ interface Props {
  * Mirrors /simulator's pool UX: champions + items in tabs, drag to place on board
  * (click also works when DnD activation threshold isn't met).
  */
-export default function ChampionItemSidebar({ champions, items, onChampionClick, onItemClick }: Props) {
+export default function ChampionItemSidebar({ champions, items, onChampionClick, onItemClick, novaTraitActive = false }: Props) {
   const [tab, setTab] = useState<Tab>('champions');
 
   return (
@@ -61,7 +67,7 @@ export default function ChampionItemSidebar({ champions, items, onChampionClick,
       <div className="flex-1 overflow-hidden">
         {tab === 'champions' && <ChampionSection champions={champions} onChampionClick={onChampionClick} />}
         {tab === 'items' && <ItemSection items={items} onItemClick={onItemClick} />}
-        {tab === 'tools' && <ToolsSection />}
+        {tab === 'tools' && <ToolsSection novaTraitActive={novaTraitActive} />}
       </div>
     </aside>
   );
@@ -169,7 +175,7 @@ function ItemSection({ items, onItemClick }: { items: RawItem[]; onItemClick?: (
   );
 }
 
-function ToolsSection() {
+function ToolsSection({ novaTraitActive }: { novaTraitActive: boolean }) {
   return (
     <div className="flex flex-col h-full p-2 space-y-3">
       <p className="text-[11px] text-gray-400 leading-relaxed">
@@ -177,7 +183,7 @@ function ToolsSection() {
       </p>
       <div className="grid grid-cols-5 gap-1.5">
         <DraggableItemRemoverTool size={44} />
-        <DraggableNovaSelectorTool size={44} />
+        {novaTraitActive && <DraggableNovaSelectorTool size={44} />}
       </div>
     </div>
   );

--- a/src/components/actual-data/DraggableNovaSelectorTool.tsx
+++ b/src/components/actual-data/DraggableNovaSelectorTool.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useDraggable } from '@dnd-kit/core';
+import type { DragData } from '@/types';
+
+const ICON_SRC = '/data/images/items/tft17_drxselector.tft_set17.png';
+
+/**
+ * Drag source for the N.O.V.A. "타격 선택기" tool. Drop onto a NOVA unit
+ * (Aatrox/Caitlyn/Akali/Maokai/Kindred) to set its `novaStrikeSelector` flag.
+ * Same-team single-instance enforced by `createActualDragEndHandler`.
+ */
+export default function DraggableNovaSelectorTool({ size = 44 }: { size?: number }) {
+  const data: DragData = { type: 'tool', toolKind: 'nova-selector' };
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: 'tool-nova-selector',
+    data,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      style={{ width: size, height: size, opacity: isDragging ? 0.4 : 1, touchAction: 'none' }}
+      className="relative cursor-grab active:cursor-grabbing rounded border border-gray-700 bg-[#1f2937] hover:border-cyan-500 hover:bg-cyan-900/30 transition-colors flex items-center justify-center overflow-hidden"
+      title="타격 선택기 — N.O.V.A. 유닛(아트록스/케이틀린/아칼리/마오카이/킨드레드)에 드롭하면 타격 효과 적용"
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={ICON_SRC} alt="타격 선택기" width={size - 4} height={size - 4} draggable={false} />
+    </div>
+  );
+}

--- a/src/components/actual-data/PvPRoundEditor.tsx
+++ b/src/components/actual-data/PvPRoundEditor.tsx
@@ -20,7 +20,7 @@ import ChampionItemSidebar from './ChampionItemSidebar';
 import { createActualDragEndHandler } from './actualDndHandlers';
 import RoundDiffInlineCard from '@/components/validation/RoundDiffInlineCard';
 import { resolveTraits } from '@/lib/simulator/systems/trait';
-import { isNovaTraitActive } from '@/lib/simulator/novaSelector';
+import { isNovaStrikeSelectorActive } from '@/lib/simulator/novaSelector';
 import { normalizeChampionId } from '@/lib/analysis/championIdAliases';
 
 export default function PvPRoundEditor({ index, round }: { index: number; round: PvPRound }) {
@@ -42,7 +42,7 @@ export default function PvPRoundEditor({ index, round }: { index: number; round:
         .filter((c): c is RawChampion => !!c)
         .map(c => ({ champion: c }));
       if (inputs.length === 0) return false;
-      return isNovaTraitActive(resolveTraits(inputs, traits));
+      return isNovaStrikeSelectorActive(resolveTraits(inputs, traits));
     };
     return teamHasActive(round.playerTeam.units) || teamHasActive(round.opponent.units);
   }, [round.playerTeam.units, round.opponent.units, championMap, traits]);

--- a/src/components/actual-data/PvPRoundEditor.tsx
+++ b/src/components/actual-data/PvPRoundEditor.tsx
@@ -19,6 +19,9 @@ import ActualBoard from './ActualBoard';
 import ChampionItemSidebar from './ChampionItemSidebar';
 import { createActualDragEndHandler } from './actualDndHandlers';
 import RoundDiffInlineCard from '@/components/validation/RoundDiffInlineCard';
+import { resolveTraits } from '@/lib/simulator/systems/trait';
+import { isNovaTraitActive } from '@/lib/simulator/novaSelector';
+import { normalizeChampionId } from '@/lib/analysis/championIdAliases';
 
 export default function PvPRoundEditor({ index, round }: { index: number; round: PvPRound }) {
   const updateRoundMeta = useActualDataStore(s => s.updateRoundMeta);
@@ -26,7 +29,23 @@ export default function PvPRoundEditor({ index, round }: { index: number; round:
   const updatePlayerTeam = useActualDataStore(s => s.updatePlayerTeam);
   const updateOpponent = useActualDataStore(s => s.updateOpponent);
   const gameId = useActualDataStore(s => s.currentGame?.gameId);
-  const { champions, items, loading } = useGameData();
+  const { champions, items, traits, loading } = useGameData();
+
+  // NOVA(5) 시너지 활성 검사 — 어느 한 팀이라도 활성이면 ToolsSection 의 NOVA 도구 노출.
+  // resolveTraits 는 inputs 가 비면 빈 배열 반환 → safe.
+  const championMap = useMemo(() => new Map(champions.map(c => [c.apiName, c])), [champions]);
+  const novaTraitActive = useMemo(() => {
+    if (traits.length === 0) return false;
+    const teamHasActive = (units: PlacedUnit[]): boolean => {
+      const inputs = units
+        .map(u => championMap.get(normalizeChampionId(u.championId)))
+        .filter((c): c is RawChampion => !!c)
+        .map(c => ({ champion: c }));
+      if (inputs.length === 0) return false;
+      return isNovaTraitActive(resolveTraits(inputs, traits));
+    };
+    return teamHasActive(round.playerTeam.units) || teamHasActive(round.opponent.units);
+  }, [round.playerTeam.units, round.opponent.units, championMap, traits]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -242,6 +261,7 @@ export default function PvPRoundEditor({ index, round }: { index: number; round:
           items={items}
           onChampionClick={handleChampionClick}
           onItemClick={handleItemClick}
+          novaTraitActive={novaTraitActive}
         />
       </div>
 

--- a/src/components/actual-data/actualDndHandlers.ts
+++ b/src/components/actual-data/actualDndHandlers.ts
@@ -1,6 +1,7 @@
 import type { DragEndEvent } from '@dnd-kit/core';
 import type { DragData, HexCoord, RawItem } from '@/types';
 import type { PlacedUnit, PvPRound } from '@/lib/actualData/types';
+import { NOVA_SELECTOR_APIS } from '@/lib/simulator/novaSelector';
 
 /** Match the cell id scheme used by /simulator overlay (`cell-${row}-${col}`). */
 function parseCellId(id: string): { row: number; col: number } | null {
@@ -66,25 +67,13 @@ export function clearUnitItems(u: PlacedUnit): PlacedUnit {
 }
 
 /**
- * N.O.V.A. (DRX) "타격 선택기" 가 적용 가능한 NOVA 5종 챔피언 apiName.
- * combatLoop 의 NOVA_APIS 와 일치 — 다섯 명 중 한 명에게만 동시 적용 (팀 단일성).
- */
-const NOVA_SELECTOR_TARGETS: ReadonlySet<string> = new Set([
-  'TFT17_Aatrox',
-  'TFT17_Caitlyn',
-  'TFT17_Akali',
-  'TFT17_Maokai',
-  'TFT17_Kindred',
-]);
-
-/**
  * 같은 팀 내에서 NOVA 타격 선택기는 단일 unit 에만 부여 가능.
  * 기존 보유자가 있으면 false 로 해제하고 target 에 true 를 부여한 새 배열을 반환한다.
  * target 이 NOVA 5종이 아니면 null 반환 (호출 측에서 무시).
  */
 function applyNovaStrikeSelector(units: PlacedUnit[], targetIdx: number): PlacedUnit[] | null {
   const target = units[targetIdx];
-  if (!target || !NOVA_SELECTOR_TARGETS.has(target.championId)) return null;
+  if (!target || !NOVA_SELECTOR_APIS.has(target.championId)) return null;
   return units.map((u, i) => {
     if (i === targetIdx) return { ...u, novaStrikeSelector: true };
     if (u.novaStrikeSelector) return { ...u, novaStrikeSelector: false };

--- a/src/components/actual-data/actualDndHandlers.ts
+++ b/src/components/actual-data/actualDndHandlers.ts
@@ -178,7 +178,12 @@ export function createActualDragEndHandler(ctx: () => ActualDndContext | null) {
       if (srcTeam !== destTeam) {
         if (existingDestIdx >= 0) return; // no cross-team swap
         const nextSrc = srcUnits.filter((_, i) => i !== srcIdx);
-        const nextDest = [...destUnits, { ...dragged, hex: destHex }];
+        // 팀 이동 시 NOVA 타격 선택기 flag 는 자동 해제 — 양 팀에서 모두 단일성 invariant
+        // 보존 (PR #86 codex P2). 사용자가 dest 팀에서 다시 토글해야 함.
+        const movedUnit: PlacedUnit = dragged.novaStrikeSelector
+          ? { ...dragged, hex: destHex, novaStrikeSelector: false }
+          : { ...dragged, hex: destHex };
+        const nextDest = [...destUnits, movedUnit];
         if (srcTeam === 'player') {
           updatePlayerTeam(roundIndex, { units: nextSrc });
           updateOpponent(roundIndex, { units: nextDest });

--- a/src/components/actual-data/actualDndHandlers.ts
+++ b/src/components/actual-data/actualDndHandlers.ts
@@ -65,6 +65,33 @@ export function clearUnitItems(u: PlacedUnit): PlacedUnit {
   return { ...u, items: [undefined, undefined, undefined] as PlacedUnit['items'] };
 }
 
+/**
+ * N.O.V.A. (DRX) "타격 선택기" 가 적용 가능한 NOVA 5종 챔피언 apiName.
+ * combatLoop 의 NOVA_APIS 와 일치 — 다섯 명 중 한 명에게만 동시 적용 (팀 단일성).
+ */
+const NOVA_SELECTOR_TARGETS: ReadonlySet<string> = new Set([
+  'TFT17_Aatrox',
+  'TFT17_Caitlyn',
+  'TFT17_Akali',
+  'TFT17_Maokai',
+  'TFT17_Kindred',
+]);
+
+/**
+ * 같은 팀 내에서 NOVA 타격 선택기는 단일 unit 에만 부여 가능.
+ * 기존 보유자가 있으면 false 로 해제하고 target 에 true 를 부여한 새 배열을 반환한다.
+ * target 이 NOVA 5종이 아니면 null 반환 (호출 측에서 무시).
+ */
+function applyNovaStrikeSelector(units: PlacedUnit[], targetIdx: number): PlacedUnit[] | null {
+  const target = units[targetIdx];
+  if (!target || !NOVA_SELECTOR_TARGETS.has(target.championId)) return null;
+  return units.map((u, i) => {
+    if (i === targetIdx) return { ...u, novaStrikeSelector: true };
+    if (u.novaStrikeSelector) return { ...u, novaStrikeSelector: false };
+    return u;
+  });
+}
+
 export interface ActualDndContext {
   round: PvPRound;
   roundIndex: number;
@@ -124,6 +151,16 @@ export function createActualDragEndHandler(ctx: () => ActualDndContext | null) {
       if (existingDestIdx < 0) return;
       const cleared = clearUnitItems(destUnits[existingDestIdx]);
       setDest(destUnits.map((u, i) => (i === existingDestIdx ? cleared : u)));
+      return;
+    }
+
+    // Tool: nova-selector — assign the NOVA 타격 선택기 flag to the target NOVA unit.
+    // Non-NOVA targets are ignored. Same-team single-instance enforced.
+    if (dragData.type === 'tool' && dragData.toolKind === 'nova-selector') {
+      if (existingDestIdx < 0) return;
+      const next = applyNovaStrikeSelector(destUnits, existingDestIdx);
+      if (!next) return;
+      setDest(next);
       return;
     }
 

--- a/src/components/builder/ItemGrid.tsx
+++ b/src/components/builder/ItemGrid.tsx
@@ -13,7 +13,7 @@ interface ItemGridProps {
   champion?: PlacedChampion;
 }
 
-type ItemTab = 'all' | 'component' | 'combined' | 'artifact' | 'emblem' | 'radiant';
+type ItemTab = 'all' | 'component' | 'combined' | 'artifact' | 'emblem' | 'radiant' | 'animasquad' | 'psyops';
 
 export default function ItemGrid({ items, onSelect, activeTraits, champion }: ItemGridProps) {
   const [search, setSearch] = useState('');
@@ -48,7 +48,7 @@ export default function ItemGrid({ items, onSelect, activeTraits, champion }: It
     }
 
     if (tab === 'all') return true;
-    if (tab === 'combined' && (cat === 'bilgewater' || cat === 'void' || cat === 'darkin')) return true;
+    if (tab === 'combined' && (cat === 'bilgewater' || cat === 'void' || cat === 'darkin' || cat === 'animasquad' || cat === 'psyops')) return true;
     return cat === tab;
   });
 
@@ -66,6 +66,8 @@ export default function ItemGrid({ items, onSelect, activeTraits, champion }: It
   const tabs: { key: ItemTab; label: string }[] = [
     { key: 'all', label: '전체' },
     { key: 'combined', label: '완성템' },
+    { key: 'animasquad', label: '동물특공대' },
+    { key: 'psyops', label: '초능력' },
     { key: 'artifact', label: '유물' },
     { key: 'radiant', label: '찬란' },
     { key: 'emblem', label: '상징' },

--- a/src/components/builder/SelectedUnitPanel.tsx
+++ b/src/components/builder/SelectedUnitPanel.tsx
@@ -11,6 +11,7 @@ import { useState, useMemo } from 'react';
 import { getItemCategory } from '@/lib/simulator/systems/item';
 import { resolveDescription } from '@/lib/utils/text';
 import { FACTORY_NEW_TREE, suffixToApiName } from '@/data/factoryNewTree';
+import { isNovaSelectorTarget } from '@/lib/simulator/novaSelector';
 
 interface SelectedUnitPanelProps {
   placed: PlacedChampion;
@@ -24,6 +25,11 @@ interface SelectedUnitPanelProps {
   onRemoveUnit: () => void;
   onMfModeChange?: (mode: MfMode) => void;
   onPermanentStackChange?: (value: number) => void;
+  /**
+   * NOVA 5종(Aatrox/Caitlyn/Akali/Maokai/Kindred) 일 때만 노출되는 타격 선택기 토글.
+   * useTeamManagement.handleNovaStrikeSelectorChange 가 같은 팀 단일성을 강제한다.
+   */
+  onNovaStrikeSelectorToggle?: (next: boolean) => void;
   /** 그레이브즈일 때만 활성화 — 무기고 편집 모달 open 콜백. */
   onEditGravesWeapons?: () => void;
   /**
@@ -46,6 +52,7 @@ export default function SelectedUnitPanel({
   onRemoveUnit,
   onMfModeChange,
   onPermanentStackChange,
+  onNovaStrikeSelectorToggle,
   onEditGravesWeapons,
   teamGravesPicks,
 }: SelectedUnitPanelProps) {
@@ -94,6 +101,24 @@ export default function SelectedUnitPanel({
       </div>
 
       <StarSelector starLevel={placed.starLevel} onChange={onStarChange} />
+
+      {isNovaSelectorTarget(placed.champion.apiName) && onNovaStrikeSelectorToggle && (
+        <div>
+          <div className="text-xs text-gray-400 mb-1.5">N.O.V.A. 타격 선택기</div>
+          <button
+            onClick={() => onNovaStrikeSelectorToggle(!placed.novaStrikeSelector)}
+            className={`w-full flex items-center justify-center gap-2 px-2 py-1.5 rounded border text-[11px] transition-colors ${
+              placed.novaStrikeSelector
+                ? 'border-cyan-500 bg-cyan-500/20 text-cyan-300'
+                : 'border-gray-700 bg-gray-800/50 text-gray-400 hover:border-gray-500'
+            }`}
+            title="NOVA 5종 중 한 명에게만 적용 가능 — 같은 팀의 다른 NOVA 유닛은 자동 해제"
+          >
+            <Image src="/data/images/items/tft17_drxselector.tft_set17.png" alt="타격 선택기" width={16} height={16} unoptimized />
+            {placed.novaStrikeSelector ? '적용 중 (해제)' : '적용'}
+          </button>
+        </div>
+      )}
 
       {placed.champion.apiName === 'TFT17_MissFortune' && onMfModeChange && (
         <div>

--- a/src/components/builder/SelectedUnitPanel.tsx
+++ b/src/components/builder/SelectedUnitPanel.tsx
@@ -11,7 +11,7 @@ import { useState, useMemo } from 'react';
 import { getItemCategory } from '@/lib/simulator/systems/item';
 import { resolveDescription } from '@/lib/utils/text';
 import { FACTORY_NEW_TREE, suffixToApiName } from '@/data/factoryNewTree';
-import { isNovaSelectorTarget, isNovaTraitActive } from '@/lib/simulator/novaSelector';
+import { isNovaSelectorTarget, isNovaStrikeSelectorActive } from '@/lib/simulator/novaSelector';
 
 interface SelectedUnitPanelProps {
   placed: PlacedChampion;
@@ -102,7 +102,7 @@ export default function SelectedUnitPanel({
 
       <StarSelector starLevel={placed.starLevel} onChange={onStarChange} />
 
-      {isNovaSelectorTarget(placed.champion.apiName) && isNovaTraitActive(activeTraits) && onNovaStrikeSelectorToggle && (
+      {isNovaSelectorTarget(placed.champion.apiName) && isNovaStrikeSelectorActive(activeTraits) && onNovaStrikeSelectorToggle && (
         <div>
           <div className="text-xs text-gray-400 mb-1.5">N.O.V.A. 타격 선택기</div>
           <button

--- a/src/components/builder/SelectedUnitPanel.tsx
+++ b/src/components/builder/SelectedUnitPanel.tsx
@@ -11,7 +11,7 @@ import { useState, useMemo } from 'react';
 import { getItemCategory } from '@/lib/simulator/systems/item';
 import { resolveDescription } from '@/lib/utils/text';
 import { FACTORY_NEW_TREE, suffixToApiName } from '@/data/factoryNewTree';
-import { isNovaSelectorTarget } from '@/lib/simulator/novaSelector';
+import { isNovaSelectorTarget, isNovaTraitActive } from '@/lib/simulator/novaSelector';
 
 interface SelectedUnitPanelProps {
   placed: PlacedChampion;
@@ -102,7 +102,7 @@ export default function SelectedUnitPanel({
 
       <StarSelector starLevel={placed.starLevel} onChange={onStarChange} />
 
-      {isNovaSelectorTarget(placed.champion.apiName) && onNovaStrikeSelectorToggle && (
+      {isNovaSelectorTarget(placed.champion.apiName) && isNovaTraitActive(activeTraits) && onNovaStrikeSelectorToggle && (
         <div>
           <div className="text-xs text-gray-400 mb-1.5">N.O.V.A. 타격 선택기</div>
           <button

--- a/src/hooks/useCombatAnalysis.ts
+++ b/src/hooks/useCombatAnalysis.ts
@@ -154,7 +154,17 @@ export function useCombatAnalysis() {
       const result = simulateCombat(
         reconstruction.playerTeam,
         reconstruction.enemyTeam,
-        { seed: 42, skipMirror: true, allTraits: reconstruction.options.allTraits },
+        {
+          seed: 42,
+          skipMirror: true,
+          allTraits: reconstruction.options.allTraits,
+          // 사용자가 PlacedChampion 에 novaStrikeSelector 를 표시한 경우 옵션으로 전달.
+          // Riot API 재구성 결과는 일반적으로 미지정 → autoAssignNovaSelector fallback.
+          playerNovaStrikeSelectorUnit: reconstruction.playerTeam
+            .find((u) => u.novaStrikeSelector === true)?.champion.apiName,
+          enemyNovaStrikeSelectorUnit: reconstruction.enemyTeam
+            .find((u) => u.novaStrikeSelector === true)?.champion.apiName,
+        },
       );
 
       const defeatReport = result.winner !== 'player'
@@ -186,7 +196,16 @@ export function useCombatAnalysis() {
       const modifiedResult = simulateCombat(
         modifiedPlayerTeam,
         state.reconstruction.enemyTeam,
-        { seed: 42, skipMirror: true, allTraits: state.reconstruction.options.allTraits },
+        {
+          seed: 42,
+          skipMirror: true,
+          allTraits: state.reconstruction.options.allTraits,
+          // What-if 에서 사용자가 NOVA 선택기 토글 가능 → modifiedPlayerTeam 우선 스캔.
+          playerNovaStrikeSelectorUnit: modifiedPlayerTeam
+            .find((u) => u.novaStrikeSelector === true)?.champion.apiName,
+          enemyNovaStrikeSelectorUnit: state.reconstruction.enemyTeam
+            .find((u) => u.novaStrikeSelector === true)?.champion.apiName,
+        },
       );
 
       // 유닛별 DPS/생존 비교

--- a/src/hooks/useDndHandlers.ts
+++ b/src/hooks/useDndHandlers.ts
@@ -99,7 +99,12 @@ export function useDndHandlers({
         if (isAutoUnit(dragged.champion.apiName)) return;
         if (existingIdx >= 0) return;
         setSrcTeam(prev => prev.filter((_, i) => i !== srcIdx));
-        setTeam(prev => [...prev, { ...dragged, position: pos }]);
+        // 팀 이동 시 NOVA 타격 선택기 flag 는 자동 해제 — 양 팀에서 모두 단일성 invariant
+        // 보존 (PR #86 codex P2). 사용자가 dest 팀에서 다시 토글해야 함.
+        const movedChamp = dragged.novaStrikeSelector
+          ? { ...dragged, position: pos, novaStrikeSelector: false }
+          : { ...dragged, position: pos };
+        setTeam(prev => [...prev, movedChamp]);
         onTeamSwitched?.();
         return;
       }

--- a/src/hooks/useTeamManagement.ts
+++ b/src/hooks/useTeamManagement.ts
@@ -526,6 +526,20 @@ export function useTeamManagement({ traits }: UseTeamManagementArgs) {
     setPendingMfPlacement(null);
   };
 
+  /**
+   * N.O.V.A. (DRX) 타격 선택기 토글. 같은 팀에서 단 한 명만 보유 가능 (단일성 강제).
+   *  - next === true  : target 에 set, 같은 팀의 다른 보유자는 자동 해제
+   *  - next === false : target 만 해제
+   */
+  const handleNovaStrikeSelectorChange = (team: 'player' | 'enemy', index: number, next: boolean) => {
+    const setTeam = team === 'player' ? updatePlayerTeam : updateEnemyTeam;
+    setTeam(prev => prev.map((p, i) => {
+      if (i === index) return { ...p, novaStrikeSelector: next };
+      if (next && p.novaStrikeSelector) return { ...p, novaStrikeSelector: false };
+      return p;
+    }));
+  };
+
   const handlePermanentStackChange = (team: 'player' | 'enemy', index: number, value: number) => {
     const setTeam = team === 'player' ? updatePlayerTeam : updateEnemyTeam;
     setTeam(prev => prev.map((p, i) => {
@@ -755,6 +769,7 @@ export function useTeamManagement({ traits }: UseTeamManagementArgs) {
     pendingMfPlacement,
     setPendingMfPlacement,
     handleMfModeChange,
+    handleNovaStrikeSelectorChange,
     handlePermanentStackChange,
 
     // Handlers

--- a/src/lib/actualData/schema.ts
+++ b/src/lib/actualData/schema.ts
@@ -43,6 +43,9 @@ export const PlacedUnitSchema = z.object({
   starLevel: z.union([z.literal(1), z.literal(2), z.literal(3)]),
   items: z.tuple([OptionalSlot, OptionalSlot, OptionalSlot]),
   grants: z.array(UnitGrantSchema).optional(),
+  // N.O.V.A. (DRX) 타격 선택기 수동 지정. NOVA 5종 중 1명에만 true; 미지정 시 자동 할당 fallback.
+  // optional 이므로 기존 저장 JSON 호환 (마이그레이션 불필요).
+  novaStrikeSelector: z.boolean().optional(),
 });
 
 export const SurvivorSchema = z.object({

--- a/src/lib/actualData/unitAdapter.ts
+++ b/src/lib/actualData/unitAdapter.ts
@@ -65,6 +65,7 @@ export function toPlacedChampion(
     permanentStacks: null,
     isDummy: false,
     isSummon: SUMMON_API_NAMES.has(championApiName),
+    novaStrikeSelector: u.novaStrikeSelector,
   };
 }
 
@@ -84,5 +85,6 @@ export function fromPlacedChampion(p: PlacedChampion): PlacedUnit {
       p.items[1]?.apiName,
       p.items[2]?.apiName,
     ] as PlacedUnit['items'],
+    novaStrikeSelector: p.novaStrikeSelector,
   };
 }

--- a/src/lib/analysis/itemRecommender.ts
+++ b/src/lib/analysis/itemRecommender.ts
@@ -80,10 +80,12 @@ function isDataIncomplete(item: RawItem): boolean {
 
 /** 추천 풀에 들어갈 수 있는 카테고리인가.
  *  편집 탭의 아이템 그리드에 실제로 나오는 "완성 아이템" 만 허용.
- *  유물 / 찬란한 / 타락한 / 재료 / 시너지 상징 / 발명품 / 빌지워터 / 비활성 아이템은 모두 제외. */
+ *  유물 / 찬란한 / 타락한 / 재료 / 시너지 상징 / 발명품 / 빌지워터 / 비활성 아이템은 모두 제외.
+ *  Set 17 동물특공대(animasquad) / 초능력(psyops) 전용 아이템도 완성템 취급으로 추천 가능. */
 function isRecommendable(item: RawItem): boolean {
   if (isDisabledItem(item)) return false;
-  return getItemCategory(item) === 'combined';
+  const cat = getItemCategory(item);
+  return cat === 'combined' || cat === 'animasquad' || cat === 'psyops';
 }
 
 /** 역할 + damageType 기반 아이템 풀 필터. ctx 주입 시 트레잇 규칙도 적용. */

--- a/src/lib/simulator/novaSelector.ts
+++ b/src/lib/simulator/novaSelector.ts
@@ -24,17 +24,25 @@ export function isNovaSelectorTarget(apiName: string): boolean {
 
 /**
  * N.O.V.A. trait apiName. 게임 데이터 (`tft_set17_traits.json` apiName='TFT17_DRX',
- * 표시명 'N.O.V.A.', minUnits=5) 기준. 5+ 시너지 활성 시에만 "타격 선택기" 가
- * 게임에서 부여되므로 UI 노출 조건으로 사용.
+ * 표시명 'N.O.V.A.') 기준. 트레잇은 두 tier 를 가짐:
+ *  - [0] minUnits=2~4, style=1 (힘의 고조만)
+ *  - [1] minUnits=5+,   style=5 (타격 선택기 부여 — UI 노출 조건)
  */
 export const NOVA_TRAIT_API = 'TFT17_DRX';
 
+/** 타격 선택기가 게임에서 부여되는 NOVA tier 의 minUnits 임계값. */
+export const NOVA_STRIKE_SELECTOR_MIN_UNITS = 5;
+
 /**
- * 활성 trait 배열에서 NOVA(5) 시너지가 활성화되었는지 검사.
- * `activeEffect` 가 truthy 면 minUnits >= 5 시너지가 동작 중.
+ * 활성 trait 배열에서 N.O.V.A. (5+) 시너지가 동작 중이고 따라서 "타격 선택기" 가
+ * 게임에서 부여된 상태인지 검사. (2~4) 하위 tier 는 false 를 반환한다.
  */
-export function isNovaTraitActive(
-  activeTraits: ReadonlyArray<{ trait: { apiName: string }; activeEffect?: unknown }>,
+export function isNovaStrikeSelectorActive(
+  activeTraits: ReadonlyArray<{ trait: { apiName: string }; activeEffect?: { minUnits?: number } | null }>,
 ): boolean {
-  return activeTraits.some(t => t.trait.apiName === NOVA_TRAIT_API && !!t.activeEffect);
+  return activeTraits.some(t =>
+    t.trait.apiName === NOVA_TRAIT_API
+    && !!t.activeEffect
+    && (t.activeEffect.minUnits ?? 0) >= NOVA_STRIKE_SELECTOR_MIN_UNITS,
+  );
 }

--- a/src/lib/simulator/novaSelector.ts
+++ b/src/lib/simulator/novaSelector.ts
@@ -1,0 +1,23 @@
+/**
+ * N.O.V.A. (DRX 5+) "타격 선택기" 적용 가능한 NOVA 5종 chamPApiName.
+ *
+ * combatLoop 의 autoAssignNovaSelector 내부 NOVA_APIS 와 동일한 5종.
+ * 사용처:
+ *  - actual-data 의 `'nova-selector'` drop 핸들러 (NOVA 5종 외 무시)
+ *  - simulator(builder) 의 SelectedUnitPanel NOVA 토글 노출 조건
+ *
+ * 본 PR 시점에는 carry Aatrox 에만 효과가 구현되어 있고 (cycle global + knockup),
+ * 나머지 4명은 후속 PR 에서 효과 변환 예정.
+ */
+export const NOVA_SELECTOR_APIS: ReadonlySet<string> = new Set([
+  'TFT17_Aatrox',
+  'TFT17_Caitlyn',
+  'TFT17_Akali',
+  'TFT17_Maokai',
+  'TFT17_Kindred',
+]);
+
+/** 챔피언 apiName 이 NOVA 타격 선택기 대상인지 검사. */
+export function isNovaSelectorTarget(apiName: string): boolean {
+  return NOVA_SELECTOR_APIS.has(apiName);
+}

--- a/src/lib/simulator/novaSelector.ts
+++ b/src/lib/simulator/novaSelector.ts
@@ -21,3 +21,20 @@ export const NOVA_SELECTOR_APIS: ReadonlySet<string> = new Set([
 export function isNovaSelectorTarget(apiName: string): boolean {
   return NOVA_SELECTOR_APIS.has(apiName);
 }
+
+/**
+ * N.O.V.A. trait apiName. 게임 데이터 (`tft_set17_traits.json` apiName='TFT17_DRX',
+ * 표시명 'N.O.V.A.', minUnits=5) 기준. 5+ 시너지 활성 시에만 "타격 선택기" 가
+ * 게임에서 부여되므로 UI 노출 조건으로 사용.
+ */
+export const NOVA_TRAIT_API = 'TFT17_DRX';
+
+/**
+ * 활성 trait 배열에서 NOVA(5) 시너지가 활성화되었는지 검사.
+ * `activeEffect` 가 truthy 면 minUnits >= 5 시너지가 동작 중.
+ */
+export function isNovaTraitActive(
+  activeTraits: ReadonlyArray<{ trait: { apiName: string }; activeEffect?: unknown }>,
+): boolean {
+  return activeTraits.some(t => t.trait.apiName === NOVA_TRAIT_API && !!t.activeEffect);
+}

--- a/src/lib/simulator/systems/item.ts
+++ b/src/lib/simulator/systems/item.ts
@@ -131,8 +131,11 @@ export function getItemCategory(item: RawItem): ItemCategory {
   if (item.apiName.includes('Consumable_Void')) return 'void';
   if (item.apiName.includes('TheDarkin')) return 'darkin';
   // Set 17 실제 장착 가능한 특수 세트 아이템 (composition이 비어도 조합 완성품 취급)
-  if (item.apiName.startsWith('TFT17_Item_PsyOps_')) return 'combined';
-  if (item.apiName.startsWith('TFT17_AnimaSquadItem_')) return 'combined';
+  // 동물특공대/초능력은 별도 카테고리로 분기 — ItemGrid 전용 탭 필터링용.
+  // 다른 "완성템" 필터(itemRecommender, ChampionItemSidebar, SimulatorLayoutDesktop, ItemPoolContent)는
+  // 'combined' 동작을 유지하기 위해 'animasquad'/'psyops'를 명시적으로 함께 포함시켜 호환성을 보존한다.
+  if (item.apiName.startsWith('TFT17_Item_PsyOps_')) return 'psyops';
+  if (item.apiName.startsWith('TFT17_AnimaSquadItem_')) return 'animasquad';
   // 에코 이상현상 아이템 (실제 장착 가능, 효과 복원 불가 — 기록 용도)
   if (item.apiName.includes('Anomaly')) return 'combined';
   if (isBaseComponent(item)) return 'component';

--- a/src/lib/validation/schemaAdapter.ts
+++ b/src/lib/validation/schemaAdapter.ts
@@ -91,7 +91,14 @@ function toPlacedChampion(
     starLevel: unit.starLevel,
     position: unit.hex,
     items,
+    novaStrikeSelector: unit.novaStrikeSelector,
   };
+}
+
+/** N.O.V.A. 타격 선택기 수동 지정된 unit 의 챔피언 apiName 반환. 미지정 시 undefined. */
+function deriveNovaStrikeSelectorUnit(team: PlacedChampion[]): string | undefined {
+  const target = team.find((u) => u.novaStrikeSelector === true);
+  return target?.champion.apiName;
 }
 
 function countTraitUnits(units: PlacedChampion[], traitName: string): number {
@@ -195,6 +202,10 @@ export function toNRunInput(
         // game-level 단일 별자리 → 양 팀에 동일 전달 (실제 게임은 양 팀 동일 별자리).
         playerStargazerConstellation: options.stargazerConstellation,
         enemyStargazerConstellation: options.stargazerConstellation,
+        // 사용자가 actual-data board 에서 N.O.V.A. 타격 선택기를 수동 지정한 경우 전달.
+        // 미지정 시 undefined 로 두어 combatLoop 의 autoAssignNovaSelector fallback 이 동작.
+        playerNovaStrikeSelectorUnit: deriveNovaStrikeSelectorUnit(playerPlaced),
+        enemyNovaStrikeSelectorUnit: deriveNovaStrikeSelectorUnit(opponentPlaced),
         skipMirror: true,
         stageNumber,
       },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,6 +98,8 @@ export type ItemCategory =
   | 'bilgewater'   // 빌지워터 아이템
   | 'void'         // 공허 돌연변이
   | 'darkin'       // 다르킨
+  | 'animasquad'   // 동물특공대 전용 아이템 (TFT17_AnimaSquadItem_*)
+  | 'psyops'       // 초능력 전용 아이템 (TFT17_Item_PsyOps_*)
   | 'special';     // 특수 (비전투)
 
 export interface EquipValidation {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -349,6 +349,13 @@ export interface PlacedChampion {
   permanentStacks?: PermanentStack | null;
   isDummy?: boolean;
   isSummon?: boolean;
+  /**
+   * N.O.V.A. (DRX 5+) "타격 선택기" 수동 지정 플래그.
+   * true 인 NOVA 유닛(Aatrox/Caitlyn/Akali/Maokai/Kindred) 1명만 팀당 허용.
+   * undefined/false 인 경우 combatLoop 의 autoAssignNovaSelector fallback 이 동작.
+   * 시뮬 옵션 변환 시 이 boolean 을 SimulateOptions.{player|enemy}NovaStrikeSelectorUnit 의 apiName 으로 매핑.
+   */
+  novaStrikeSelector?: boolean;
 }
 
 // === Arbiter Law (중재자 법률) ===

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -922,7 +922,7 @@ export type DragData =
   | { type: 'champion'; champion: RawChampion }
   | { type: 'placed-unit'; team: 'player' | 'enemy'; position: HexCoord }
   | { type: 'item'; item: RawItem }
-  | { type: 'tool'; toolKind: 'remove-all' };
+  | { type: 'tool'; toolKind: 'remove-all' | 'nova-selector' };
 
 export const STAR_SCALING: Record<number, number> = {
   1: 1,

--- a/tests/unit/actualData/novaSelector.test.ts
+++ b/tests/unit/actualData/novaSelector.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import { getItemCategory } from '@/lib/simulator/systems/item';
+import { PlacedUnitSchema } from '@/lib/actualData/schema';
+import {
+  toPlacedChampion as actualToPlaced,
+  fromPlacedChampion,
+} from '@/lib/actualData/unitAdapter';
+import { toNRunInput } from '@/lib/validation/schemaAdapter';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import {
+  createActualDragEndHandler,
+  type ActualDndContext,
+} from '@/components/actual-data/actualDndHandlers';
+import type {
+  PlacedUnit, PvPRound, TeamSnapshot, OpponentSnapshot,
+} from '@/lib/actualData/types';
+import type { RawItem, RawChampion, DragData, PlacedChampion } from '@/types';
+import type { DragEndEvent } from '@dnd-kit/core';
+
+// ─── PR8 1/4: getItemCategory split ──────────────────────────────────────────
+
+const animaSquadItem = (): RawItem => ({
+  apiName: 'TFT17_AnimaSquadItem_NovaShield',
+  name: 'mock', desc: '', icon: '',
+  effects: { ApBonus: 30 },
+  composition: [],
+} as unknown as RawItem);
+
+const psyOpsItem = (): RawItem => ({
+  apiName: 'TFT17_Item_PsyOps_Mock',
+  name: 'mock', desc: '', icon: '',
+  effects: { AdBonus: 30 },
+  composition: [],
+} as unknown as RawItem);
+
+describe('PR8 1/4 — item category split (AnimaSquad / PsyOps)', () => {
+  it('TFT17_AnimaSquadItem_* → animasquad', () => {
+    expect(getItemCategory(animaSquadItem())).toBe('animasquad');
+  });
+
+  it('TFT17_Item_PsyOps_* → psyops', () => {
+    expect(getItemCategory(psyOpsItem())).toBe('psyops');
+  });
+});
+
+// ─── PR8 2/4: PlacedUnitSchema novaStrikeSelector ────────────────────────────
+
+describe('PR8 2/4 — PlacedUnitSchema novaStrikeSelector', () => {
+  const baseUnit = {
+    championId: 'TFT17_Aatrox',
+    hex: { q: 0, r: 0 },
+    starLevel: 2 as const,
+    items: [undefined, undefined, undefined],
+  };
+
+  it('novaStrikeSelector: true 를 허용한다', () => {
+    const res = PlacedUnitSchema.safeParse({ ...baseUnit, novaStrikeSelector: true });
+    expect(res.success).toBe(true);
+  });
+
+  it('novaStrikeSelector 미지정도 허용한다 (기존 JSON 호환)', () => {
+    const res = PlacedUnitSchema.safeParse(baseUnit);
+    expect(res.success).toBe(true);
+  });
+
+  it('novaStrikeSelector 비-boolean 은 거부한다', () => {
+    const res = PlacedUnitSchema.safeParse({ ...baseUnit, novaStrikeSelector: 'yes' });
+    expect(res.success).toBe(false);
+  });
+});
+
+// ─── PR8 2/4: unitAdapter 양방향 매핑 ─────────────────────────────────────────
+
+describe('PR8 2/4 — unitAdapter novaStrikeSelector 양방향 매핑', () => {
+  const aatrox: RawChampion = {
+    name: 'Aatrox', apiName: 'TFT17_Aatrox', cost: 5,
+    traits: ['DRX'],
+    role: 'ADFighter' as RawChampion['role'],
+    stats: {
+      hp: 1000, armor: 60, magicResist: 60,
+      damage: 80, attackSpeed: 0.7, range: 1,
+      critChance: 0.25, critMultiplier: 1.4,
+      initialMana: 0, mana: 100,
+    },
+    ability: { name: '', desc: '', icon: '', variables: [] },
+  };
+  const champCatalog = new Map<string, RawChampion>([[aatrox.apiName, aatrox]]);
+  const itemCatalog = new Map<string, RawItem>();
+
+  it('toPlacedChampion 이 boolean 을 전파한다', () => {
+    const u: PlacedUnit = {
+      championId: 'TFT17_Aatrox',
+      hex: { q: 0, r: 0 }, starLevel: 2,
+      items: [undefined, undefined, undefined],
+      novaStrikeSelector: true,
+    };
+    const p = actualToPlaced(u, champCatalog, itemCatalog);
+    expect(p?.novaStrikeSelector).toBe(true);
+  });
+
+  it('fromPlacedChampion 이 boolean 을 전파한다', () => {
+    const p: PlacedChampion = {
+      champion: aatrox, position: { q: 0, r: 0 }, starLevel: 2, items: [],
+      novaStrikeSelector: true,
+    };
+    const u = fromPlacedChampion(p);
+    expect(u.novaStrikeSelector).toBe(true);
+  });
+});
+
+// ─── PR8 2/4: schemaAdapter.toNRunInput → simulate options 도출 ──────────────
+
+describe('PR8 2/4 — toNRunInput derives playerNovaStrikeSelectorUnit', () => {
+  it('playerTeam 의 novaStrikeSelector=true unit 의 apiName 을 옵션에 담는다', () => {
+    const catalogs = loadServerCatalogs();
+    // Aatrox 가 catalog 에 존재해야 toPlacedChampion 이 통과.
+    expect(catalogs.champions.some(c => c.apiName === 'TFT17_Aatrox')).toBe(true);
+
+    const round: PvPRound = {
+      type: 'pvp',
+      roundName: '4-1',
+      videoStartTime: 0,
+      playerTeam: {
+        units: [
+          {
+            championId: 'TFT17_Aatrox',
+            hex: { q: 0, r: 0 }, starLevel: 2,
+            items: [undefined, undefined, undefined],
+            novaStrikeSelector: true,
+          },
+        ],
+        augments: [undefined, undefined, undefined, undefined],
+        level: 8, hp: 100, hexModifiers: [],
+      },
+      opponent: {
+        units: [],
+        augments: [undefined, undefined, undefined, undefined],
+        level: 8, hp: 100, hexModifiers: [],
+      },
+      winner: 'player',
+    };
+
+    const { input } = toNRunInput(round, catalogs);
+    expect(input.simulateOptions.playerNovaStrikeSelectorUnit).toBe('TFT17_Aatrox');
+    expect(input.simulateOptions.enemyNovaStrikeSelectorUnit).toBeUndefined();
+  });
+});
+
+// ─── PR8 3/4: DragData 'nova-selector' toolKind fingerprint ──────────────────
+
+describe('PR8 3/4 — DragData type fingerprint', () => {
+  it("DragData 가 toolKind: 'nova-selector' 를 허용한다 (compile-time + runtime)", () => {
+    // 컴파일 타임 검사: DragData 의 'nova-selector' literal 이 사라지면 typecheck 실패.
+    const data: DragData = { type: 'tool', toolKind: 'nova-selector' };
+    expect(data.type).toBe('tool');
+    if (data.type === 'tool') {
+      expect(data.toolKind).toBe('nova-selector');
+    }
+  });
+});
+
+// ─── PR8 3/4: createActualDragEndHandler 'nova-selector' 분기 ────────────────
+
+const baseTeam = (units: PlacedUnit[]): TeamSnapshot => ({
+  units,
+  augments: [undefined, undefined, undefined, undefined],
+  level: 6, hp: 100, hexModifiers: [],
+});
+const baseOpp = (units: PlacedUnit[]): OpponentSnapshot => ({ ...baseTeam(units) });
+const makeRound = (player: PlacedUnit[], enemy: PlacedUnit[] = []): PvPRound => ({
+  type: 'pvp', roundName: '2-1', videoStartTime: 0,
+  playerTeam: baseTeam(player),
+  opponent: baseOpp(enemy),
+  winner: 'player',
+});
+const makeEvent = (data: unknown, overId: string | null): DragEndEvent =>
+  ({
+    active: { data: { current: data }, id: 'a' },
+    over: overId ? { id: overId } : null,
+  } as unknown as DragEndEvent);
+
+describe("PR8 3/4 — 'nova-selector' drop 핸들러", () => {
+  it('NOVA 5종(Aatrox) unit 에 drop 하면 novaStrikeSelector=true', () => {
+    const aatrox: PlacedUnit = {
+      championId: 'TFT17_Aatrox', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: [undefined, undefined, undefined],
+    };
+    let player: PlacedUnit[] = [aatrox];
+    const ctx: ActualDndContext = {
+      round: makeRound(player), roundIndex: 0,
+      updatePlayerTeam: (_i, p) => { player = p.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    // Aatrox at q=0,r=3 → display row = 4 + dataRow(3) = 7, col = q + floor(r/2) = 0 + 1 = 1
+    handler(makeEvent({ type: 'tool', toolKind: 'nova-selector' }, 'cell-7-1'));
+    expect(player[0].novaStrikeSelector).toBe(true);
+  });
+
+  it('비-NOVA(Ahri) unit 에 drop 하면 변화 없음', () => {
+    const ahri: PlacedUnit = {
+      championId: 'TFT17_Ahri', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: [undefined, undefined, undefined],
+    };
+    let player: PlacedUnit[] = [ahri];
+    const ctx: ActualDndContext = {
+      round: makeRound(player), roundIndex: 0,
+      updatePlayerTeam: (_i, p) => { player = p.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    handler(makeEvent({ type: 'tool', toolKind: 'nova-selector' }, 'cell-7-1'));
+    expect(player[0].novaStrikeSelector).toBeUndefined();
+  });
+
+  it('같은 팀 단일성: 기존 보유자 false + 신규 target true', () => {
+    const aatrox: PlacedUnit = {
+      championId: 'TFT17_Aatrox', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: [undefined, undefined, undefined],
+      novaStrikeSelector: true,
+    };
+    const akali: PlacedUnit = {
+      championId: 'TFT17_Akali', hex: { q: 1, r: 3 }, starLevel: 2,
+      items: [undefined, undefined, undefined],
+    };
+    let player: PlacedUnit[] = [aatrox, akali];
+    const ctx: ActualDndContext = {
+      round: makeRound(player), roundIndex: 0,
+      updatePlayerTeam: (_i, p) => { player = p.units; },
+      updateOpponent: () => {},
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    // Akali at q=1,r=3 → display row=7, col=1+1=2 → cell-7-2
+    handler(makeEvent({ type: 'tool', toolKind: 'nova-selector' }, 'cell-7-2'));
+    const a = player.find(u => u.championId === 'TFT17_Aatrox');
+    const k = player.find(u => u.championId === 'TFT17_Akali');
+    expect(a?.novaStrikeSelector).toBe(false);
+    expect(k?.novaStrikeSelector).toBe(true);
+  });
+});

--- a/tests/unit/actualData/novaSelector.test.ts
+++ b/tests/unit/actualData/novaSelector.test.ts
@@ -285,6 +285,42 @@ describe("PR8 3/4 — 'nova-selector' drop 핸들러", () => {
     expect(player[0].novaStrikeSelector).toBeUndefined();
   });
 
+  it('cross-team placed-unit move 시 novaStrikeSelector 자동 해제 (codex P2)', () => {
+    // player 팀에 selector 보유한 NOVA(Aatrox), opponent 팀에 다른 NOVA(Akali) 가
+    // selector 보유. player Aatrox 를 opponent 팀으로 이동 → Aatrox flag 해제되어
+    // opponent 팀에 selector 보유자가 1명(Akali) 으로 유지되어야 함.
+    const playerAatrox: PlacedUnit = {
+      championId: 'TFT17_Aatrox', hex: { q: 0, r: 3 }, starLevel: 2,
+      items: [undefined, undefined, undefined],
+      novaStrikeSelector: true,
+    };
+    const oppAkali: PlacedUnit = {
+      championId: 'TFT17_Akali', hex: { q: 0, r: 1 }, starLevel: 2,
+      items: [undefined, undefined, undefined],
+      novaStrikeSelector: true,
+    };
+    let player: PlacedUnit[] = [playerAatrox];
+    let opponent: PlacedUnit[] = [oppAkali];
+    const ctx: ActualDndContext = {
+      round: makeRound(player, opponent), roundIndex: 0,
+      updatePlayerTeam: (_i, p) => { player = p.units; },
+      updateOpponent: (_i, p) => { opponent = p.units; },
+    };
+    const handler = createActualDragEndHandler(() => ctx);
+    // player Aatrox(q=0,r=3 → cell-7-1) 를 opponent 팀의 빈 hex(q=2,r=2 → cell-2-3) 로 이동
+    handler(makeEvent(
+      { type: 'placed-unit', team: 'player', position: { q: 0, r: 3 } },
+      'cell-2-3',
+    ));
+    // Aatrox 가 opponent 로 이동 + novaStrikeSelector 해제됨
+    const movedAatrox = opponent.find(u => u.championId === 'TFT17_Aatrox');
+    expect(movedAatrox).toBeDefined();
+    expect(movedAatrox?.novaStrikeSelector).toBeFalsy();
+    // Akali 는 그대로 selector 보유
+    const akali = opponent.find(u => u.championId === 'TFT17_Akali');
+    expect(akali?.novaStrikeSelector).toBe(true);
+  });
+
   it('같은 팀 단일성: 기존 보유자 false + 신규 target true', () => {
     const aatrox: PlacedUnit = {
       championId: 'TFT17_Aatrox', hex: { q: 0, r: 3 }, starLevel: 2,

--- a/tests/unit/actualData/novaSelector.test.ts
+++ b/tests/unit/actualData/novaSelector.test.ts
@@ -4,8 +4,9 @@ import { PlacedUnitSchema } from '@/lib/actualData/schema';
 import {
   NOVA_SELECTOR_APIS,
   NOVA_TRAIT_API,
+  NOVA_STRIKE_SELECTOR_MIN_UNITS,
   isNovaSelectorTarget,
-  isNovaTraitActive,
+  isNovaStrikeSelectorActive,
 } from '@/lib/simulator/novaSelector';
 import {
   toPlacedChampion as actualToPlaced,
@@ -47,25 +48,43 @@ describe('PR8 5/5 — novaSelector 공유 모듈', () => {
     expect(NOVA_TRAIT_API).toBe('TFT17_DRX');
   });
 
-  it('isNovaTraitActive: TFT17_DRX trait 가 activeEffect 있으면 true', () => {
-    expect(isNovaTraitActive([
-      { trait: { apiName: 'TFT17_DRX' }, activeEffect: { variables: {} } },
+  it('NOVA_STRIKE_SELECTOR_MIN_UNITS === 5 (타격 선택기 부여 tier)', () => {
+    expect(NOVA_STRIKE_SELECTOR_MIN_UNITS).toBe(5);
+  });
+
+  it('isNovaStrikeSelectorActive: minUnits >= 5 tier 활성 시 true', () => {
+    expect(isNovaStrikeSelectorActive([
+      { trait: { apiName: 'TFT17_DRX' }, activeEffect: { minUnits: 5 } },
+    ])).toBe(true);
+    // 6마리 (emblem 포함) — 같은 tier
+    expect(isNovaStrikeSelectorActive([
+      { trait: { apiName: 'TFT17_DRX' }, activeEffect: { minUnits: 5 } },
     ])).toBe(true);
   });
 
-  it('isNovaTraitActive: TFT17_DRX 가 있어도 activeEffect 없으면 false', () => {
-    expect(isNovaTraitActive([
+  it('isNovaStrikeSelectorActive: minUnits < 5 tier(2~4) 활성 시 false (회귀)', () => {
+    // NOVA(2~4) tier — 힘의 고조만 부여하고 타격 선택기는 미부여
+    expect(isNovaStrikeSelectorActive([
+      { trait: { apiName: 'TFT17_DRX' }, activeEffect: { minUnits: 2 } },
+    ])).toBe(false);
+    expect(isNovaStrikeSelectorActive([
+      { trait: { apiName: 'TFT17_DRX' }, activeEffect: { minUnits: 4 } },
+    ])).toBe(false);
+  });
+
+  it('isNovaStrikeSelectorActive: TFT17_DRX 있어도 activeEffect 없으면 false', () => {
+    expect(isNovaStrikeSelectorActive([
       { trait: { apiName: 'TFT17_DRX' }, activeEffect: null },
     ])).toBe(false);
-    expect(isNovaTraitActive([
+    expect(isNovaStrikeSelectorActive([
       { trait: { apiName: 'TFT17_DRX' } },
     ])).toBe(false);
   });
 
-  it('isNovaTraitActive: 빈 배열이거나 다른 trait 만 있으면 false', () => {
-    expect(isNovaTraitActive([])).toBe(false);
-    expect(isNovaTraitActive([
-      { trait: { apiName: 'TFT17_AnimaSquad' }, activeEffect: { variables: {} } },
+  it('isNovaStrikeSelectorActive: 빈 배열이거나 다른 trait 만 있으면 false', () => {
+    expect(isNovaStrikeSelectorActive([])).toBe(false);
+    expect(isNovaStrikeSelectorActive([
+      { trait: { apiName: 'TFT17_AnimaSquad' }, activeEffect: { minUnits: 5 } },
     ])).toBe(false);
   });
 });

--- a/tests/unit/actualData/novaSelector.test.ts
+++ b/tests/unit/actualData/novaSelector.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { getItemCategory } from '@/lib/simulator/systems/item';
 import { PlacedUnitSchema } from '@/lib/actualData/schema';
-import { NOVA_SELECTOR_APIS, isNovaSelectorTarget } from '@/lib/simulator/novaSelector';
+import {
+  NOVA_SELECTOR_APIS,
+  NOVA_TRAIT_API,
+  isNovaSelectorTarget,
+  isNovaTraitActive,
+} from '@/lib/simulator/novaSelector';
 import {
   toPlacedChampion as actualToPlaced,
   fromPlacedChampion,
@@ -36,6 +41,32 @@ describe('PR8 5/5 — novaSelector 공유 모듈', () => {
     expect(isNovaSelectorTarget('TFT17_Ahri')).toBe(false);
     expect(isNovaSelectorTarget('TFT17_MissFortune')).toBe(false);
     expect(isNovaSelectorTarget('')).toBe(false);
+  });
+
+  it('NOVA_TRAIT_API 가 TFT17_DRX 와 일치 (game data 기준)', () => {
+    expect(NOVA_TRAIT_API).toBe('TFT17_DRX');
+  });
+
+  it('isNovaTraitActive: TFT17_DRX trait 가 activeEffect 있으면 true', () => {
+    expect(isNovaTraitActive([
+      { trait: { apiName: 'TFT17_DRX' }, activeEffect: { variables: {} } },
+    ])).toBe(true);
+  });
+
+  it('isNovaTraitActive: TFT17_DRX 가 있어도 activeEffect 없으면 false', () => {
+    expect(isNovaTraitActive([
+      { trait: { apiName: 'TFT17_DRX' }, activeEffect: null },
+    ])).toBe(false);
+    expect(isNovaTraitActive([
+      { trait: { apiName: 'TFT17_DRX' } },
+    ])).toBe(false);
+  });
+
+  it('isNovaTraitActive: 빈 배열이거나 다른 trait 만 있으면 false', () => {
+    expect(isNovaTraitActive([])).toBe(false);
+    expect(isNovaTraitActive([
+      { trait: { apiName: 'TFT17_AnimaSquad' }, activeEffect: { variables: {} } },
+    ])).toBe(false);
   });
 });
 

--- a/tests/unit/actualData/novaSelector.test.ts
+++ b/tests/unit/actualData/novaSelector.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { getItemCategory } from '@/lib/simulator/systems/item';
 import { PlacedUnitSchema } from '@/lib/actualData/schema';
+import { NOVA_SELECTOR_APIS, isNovaSelectorTarget } from '@/lib/simulator/novaSelector';
 import {
   toPlacedChampion as actualToPlaced,
   fromPlacedChampion,
@@ -16,6 +17,27 @@ import type {
 } from '@/lib/actualData/types';
 import type { RawItem, RawChampion, DragData, PlacedChampion } from '@/types';
 import type { DragEndEvent } from '@dnd-kit/core';
+
+// ─── PR8 5/5: 공유 NOVA selector 모듈 (actual-data + simulator 공용) ─────────
+
+describe('PR8 5/5 — novaSelector 공유 모듈', () => {
+  it('NOVA_SELECTOR_APIS 가 NOVA 5종을 정확히 포함', () => {
+    expect(NOVA_SELECTOR_APIS.size).toBe(5);
+    for (const api of [
+      'TFT17_Aatrox', 'TFT17_Caitlyn', 'TFT17_Akali', 'TFT17_Maokai', 'TFT17_Kindred',
+    ]) {
+      expect(NOVA_SELECTOR_APIS.has(api)).toBe(true);
+    }
+  });
+
+  it('isNovaSelectorTarget: NOVA 5종 true / 그 외 false', () => {
+    expect(isNovaSelectorTarget('TFT17_Aatrox')).toBe(true);
+    expect(isNovaSelectorTarget('TFT17_Kindred')).toBe(true);
+    expect(isNovaSelectorTarget('TFT17_Ahri')).toBe(false);
+    expect(isNovaSelectorTarget('TFT17_MissFortune')).toBe(false);
+    expect(isNovaSelectorTarget('')).toBe(false);
+  });
+});
 
 // ─── PR8 1/4: getItemCategory split ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

PR #85 (PR7-C.8) 의 N.O.V.A. 타격 선택기 raw data + 자동 할당에 이은 후속 PR. 사용자가 actual-data 보드 + /simulator builder 양쪽에서 NOVA 5종 중 한 명에게 직접 타격 선택기를 적용할 수 있는 UI 를 추가하고, ItemGrid 에 동물특공대/초능력 trait 전용 아이템 탭을 추가합니다.

핵심 변경:
- **ItemGrid 신규 탭**: 동물특공대(`animasquad`) / 초능력(`psyops`) 전용 카테고리 분기. 기존 "완성템" 탭에는 그대로 포함되도록 itemRecommender / ChampionItemSidebar / SimulatorLayoutDesktop / ItemPoolContent 의 필터 호환성 보존.
- **수동 NOVA 선택기 wiring**: `PlacedChampion.novaStrikeSelector?: boolean` + `PlacedUnitSchema` zod optional 필드 추가. unitAdapter / schemaAdapter 양방향 매핑. `toNRunInput()` 의 `simulateOptions.{player|enemy}NovaStrikeSelectorUnit` 에서 boolean → apiName 자동 도출. api/simulate route 와 useCombatAnalysis (runAnalysis + runWhatIf) 양 사이트에서 옵션 전달.
- **actual-data 드래그 도구**: `DraggableNovaSelectorTool.tsx` (DRX selector 아이콘, cyan hover) + actualDndHandlers `'nova-selector'` 분기 — 비-NOVA 타깃 무시, 같은 팀 단일성 강제.
- **simulator(builder) 토글 UI**: NOVA 5종 unit 선택 시 SelectedUnitPanel 에 'N.O.V.A. 타격 선택기' 토글 노출. `useTeamManagement.handleNovaStrikeSelectorChange` 가 같은 팀 단일성 강제. 3개 layout (Desktop/Tablet/Mobile) 콜백 wiring + `simulator/page.tsx` runSimulation/runMultiple 의 옵션 도출.
- **공유 모듈**: `src/lib/simulator/novaSelector.ts` 의 `NOVA_SELECTOR_APIS` 상수로 actual-data + simulator 영역의 NOVA 5종 식별 일원화.

명시 지정 없으면 기존 `autoAssignNovaSelector` fallback 그대로 동작 (호환성 보존).

## Commits

| | |
|---|---|
| `3b30b65` | feat(items): 동물특공대/초능력 카테고리 분기 + ItemGrid 전용 탭 (PR8 1/4) |
| `506123e` | feat(nova): PlacedChampion/PlacedUnit novaStrikeSelector + 시뮬 옵션 wiring (PR8 2/4) |
| `bd93c72` | feat(nova): DraggableNovaSelectorTool + actual-data drop 핸들러 (PR8 3/4) |
| `7b3aa95` | test(nova): PR8 회귀 가드 12건 + 검증 (PR8 4/4) |
| `9a1b6a3` | feat(nova): /simulator 영역 NOVA 타격 선택기 적용 (PR8 5/5) |

## Verification

- pnpm typecheck ✅ 0 errors
- pnpm lint ✅ 0 errors (warnings 14개 모두 pre-existing)
- pnpm vitest run ✅ 753 PASS / 0 FAIL (신규 14건 가드 포함)
- pnpm build ✅ 12 routes 정상 생성

## Test plan

### actual-data 영역
- [ ] ToolsSection 의 "타격 선택기" 도구가 cyan hover + DRX selector 아이콘으로 노출되는지 확인
- [ ] NOVA 5종(Aatrox/Caitlyn/Akali/Maokai/Kindred) 위에 드롭하면 unit 에 boolean=true 가 적용되는지 확인
- [ ] 비-NOVA 유닛 위에 드롭하면 무시되는지 확인
- [ ] 같은 팀에서 다른 NOVA unit 으로 옮기면 기존 보유자 자동 해제되는지 확인

### simulator(builder) 영역
- [ ] NOVA 5종 unit 클릭 시 SelectedUnitPanel 에 'N.O.V.A. 타격 선택기' 토글 버튼이 노출되는지 확인
- [ ] 비-NOVA unit 선택 시 토글이 노출되지 않는지 확인
- [ ] 토글 클릭으로 적용/해제되는지 확인 (cyan active 색)
- [ ] 같은 팀에서 다른 NOVA unit 토글 시 기존 보유자 자동 해제되는지 확인
- [ ] 시뮬 실행(단일/100회) 시 명시 지정된 NOVA unit 에 효과가 적용되는지 확인 (autoAssign fallback 비활성)
- [ ] 토글 미사용 시 기존 autoAssign 동작이 그대로 유지되는지 확인

### ItemGrid (builder)
- [ ] '동물특공대' / '초능력' 탭이 노출되고 클릭 시 해당 trait 아이템만 필터링되는지 확인
- [ ] '완성템' 탭에 동물특공대/초능력 아이템이 그대로 포함되는지 확인 (회귀)

## 후속 PR

- 드롭/적용된 unit 에 시각적 마커 (PlacedUnitTile / SetupBoardCore)
- NOVA 5 중 비-Aatrox 4명 효과 변환 (현재 carry Aatrox 만 cycle global + knockup; 나머지는 효과 미구현)

## Out of scope

- `actual-data/diff-game-20260423-001.json` calibration cache drift (PR #85 머지로 인한 자동 갱신, 별도 정리 commit 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)