### PR TITLE
fix(stargazer): A팀/B팀 강화 칸 매핑 — display + combat 양쪽 spec 정합 (PR10)

### DIFF
--- a/docs/meta/sim-accuracy-followups.md
+++ b/docs/meta/sim-accuracy-followups.md
@@ -72,7 +72,18 @@ warning 경로 (schemaAdapter) 가 missing 값을 graceful 처리. UI 추가 비
 
 ---
 
-## 후속 — Set 17 trait 시스템 미구현 (2026-04-27 발견)
+## 후속 — Set 17 trait 시스템 미구현 (2026-04-27 발견 → 2026-05-06 종결)
+
+> **2026-05-06 업데이트**: 본 섹션의 4개 trait 우선순위 (별돌보미 / 운명술사 / N.O.V.A. capstone /
+> 정령족) **모두 17.2b PR 시리즈(PR #67-85) 진행 중 구현 완료**. 검증 위치:
+> - 별돌보미 7 별자리 → `combatLoop.ts:2716+`
+> - 운명술사 → `combatLoop.ts:1305+`, `applyFateweaverEffects`
+> - N.O.V.A. capstone (Caitlyn mark+headshot) → `combatLoop.ts:960+` (PR7-C.6)
+> - 정령족 (Astronaut Meeps) → `combatLoop.ts:1483+`, `spiritEffectPerStack`
+>
+> 그러나 PR9 commit (`72ad060`) 기준 game-20260423-001 (N=10) 재측정 결과 여전히
+> winnerMatchRate **45.5%** (50% 목표 미달), avgPlayerDamageErrorPct **-52.2%** (악화).
+> trait 구현만으로는 부족한 잔여 오차 — 챔프별 ability/타겟팅/마나 획득 등 다른 축 진단 필요.
 
 v1 측정 도구로 game-20260423-001 (N=10) 돌려본 결과 **모든 player 챔프가
 sim 에서 -50% ~ -94% 데미지** (TwistedFate 만 +28% 예외). 이 systemic 적자의

--- a/src/app/simulator/layout/shared/DroppableOverlay.tsx
+++ b/src/app/simulator/layout/shared/DroppableOverlay.tsx
@@ -3,6 +3,10 @@
 import { MouseEvent, useState } from 'react';
 import { BOARD_COLS } from '@/lib/simulator/models/constants';
 import { axialToOffset, offsetToAxial, HexCoord } from '@/types';
+// 강화 칸 표시 매핑 (PR10):
+//  - A팀 (player, 화면 아래): display.row = 4 + pattern.row, display.col = pattern.col
+//  - B팀 (enemy,  화면 위):    display = 보드 중심 180° 회전 = (3 - pattern.row, BOARD_COLS-1 - pattern.col)
+// 사용자 입력 좌표(예: 산 A팀 7.0, 7.1, ..., 4.5) 기준 명시적 매핑.
 import DroppableHexCell from '@/components/battle/DroppableHexCell';
 import { createHexLayout, DEFAULT_HEX_R } from '@/components/battle/HexBoard';
 import { formatStargazerEffectSummary } from '@/lib/actualData/stargazerMapping';
@@ -41,16 +45,16 @@ export default function DroppableOverlay({
   const { playerTeam, enemyTeam } = tm;
   const { player: playerHexBuffs, enemy: enemyHexBuffs, moving, setMoving, setOverrides } = hexBuffs;
 
-  // 강화 칸 zoneKey 별 팀 매핑 (player tiles 는 보드 r=7-data_r mirror).
+  // 강화 칸 zoneKey 별 팀 매핑 (PR10 — display 매핑 변경, 위 주석 참조).
   const playerStargazerTileSet = new Set<string>();
   const enemyStargazerTileSet = new Set<string>();
   for (const t of playerStargazerTiles) {
     const off = axialToOffset(t);
-    playerStargazerTileSet.add(`${7 - off.row}-${off.col}`);
+    playerStargazerTileSet.add(`${4 + off.row}-${off.col}`);
   }
   for (const t of enemyStargazerTiles) {
     const off = axialToOffset(t);
-    enemyStargazerTileSet.add(`${off.row}-${off.col}`);
+    enemyStargazerTileSet.add(`${3 - off.row}-${BOARD_COLS - 1 - off.col}`);
   }
 
   // hover 강화 칸 — tooltip 표시용. cell pixel center (cx, cy) + team 보관.

--- a/src/components/battle/ReplayBoard.tsx
+++ b/src/components/battle/ReplayBoard.tsx
@@ -93,20 +93,18 @@ export default function ReplayBoard({
   }
 
   // 강화 칸 (별돌보미 별자리) — 보라색 테두리.
-  // CONSTELLATION_TILE_PATTERN 은 player half (data row 0-3) 만 정의.
-  // combat 의 applyStargazerEffects 는 r>=4 unit 을 mirrorPosition 으로 r=0..3 변환 후
-  // 패턴 체크 (mirrorPosition: r → 7-r, offset col 보존).
-  // 따라서 player tiles 는 보드 r=7-data_r 위치에 표시해야 실제 효과 적용 위치와 일치.
-  // hover tooltip 위해 player/enemy 별 분리 — 클릭/hover 시 어느 별자리 효과인지 식별.
+  // 표시 매핑 (PR10 — SetupBoardCore 와 동일):
+  //  - A팀: display = (4 + pattern.row, pattern.col)
+  //  - B팀: display = (3 - pattern.row, BOARD_COLS-1 - pattern.col) — 보드 중심 180° 회전
   const playerStargazerTileSet = new Set<string>();
   const enemyStargazerTileSet = new Set<string>();
   for (const t of playerStargazerTiles) {
     const off = axialToOffset(t);
-    playerStargazerTileSet.add(`${7 - off.row}-${off.col}`);
+    playerStargazerTileSet.add(`${4 + off.row}-${off.col}`);
   }
   for (const t of enemyStargazerTiles) {
     const off = axialToOffset(t);
-    enemyStargazerTileSet.add(`${off.row}-${off.col}`);
+    enemyStargazerTileSet.add(`${3 - off.row}-${BOARD_COLS - 1 - off.col}`);
   }
   const stargazerTileSet = new Set([...playerStargazerTileSet, ...enemyStargazerTileSet]);
 

--- a/src/components/battle/SetupBoardCore.tsx
+++ b/src/components/battle/SetupBoardCore.tsx
@@ -181,22 +181,22 @@ export default function SetupBoardCore({
   }
 
   // 강화 칸 (별돌보미 별자리) — 보라색 테두리.
-  // CONSTELLATION_TILE_PATTERN 은 player half (data row 0-3) 만 정의.
-  // combat 의 applyStargazerEffects 는 r>=4 unit 을 mirrorPosition 으로 r=0..3 변환 후
-  // 패턴 체크 (mirrorPosition: r → 7-r, offset col 보존).
-  // 따라서 player tiles 는 보드 r=7-data_r 위치에 표시해야 실제 효과 적용 위치와 일치.
-  // (예: 패턴 data r=0 → 보드 r=7 표시 → unit 이 r=7 에 있으면 mirror back r=0 → 패턴 r=0 매칭).
-  // enemy 는 mirror 안 거치므로 data row 그대로 표시.
+  // CONSTELLATION_TILE_PATTERN 은 axial r=0..3 의 player half pattern.
+  // 표시 매핑 (PR10 — 사용자 명시 spec):
+  //  - A팀 (player, 화면 아래): display = (4 + pattern.row, pattern.col)
+  //  - B팀 (enemy,  화면 위):    display = (3 - pattern.row, BOARD_COLS-1 - pattern.col) — 보드 중심 180° 회전
+  // 예: 산(Mountain) 별자리 + A팀이면 패턴 r=0 (··XXXX·) 가 display row 4,
+  //     B팀이면 동일 패턴 r=0 가 display row 3 에 좌우 flip 되어 표시.
   // hover tooltip 위해 player/enemy 별 분리 — 클릭/hover 시 어느 별자리 효과인지 식별.
   const playerStargazerTileSet = new Set<string>();
   const enemyStargazerTileSet = new Set<string>();
   for (const t of playerStargazerTiles) {
     const off = axialToOffset(t);
-    playerStargazerTileSet.add(`${7 - off.row}-${off.col}`);
+    playerStargazerTileSet.add(`${4 + off.row}-${off.col}`);
   }
   for (const t of enemyStargazerTiles) {
     const off = axialToOffset(t);
-    enemyStargazerTileSet.add(`${off.row}-${off.col}`);
+    enemyStargazerTileSet.add(`${3 - off.row}-${BOARD_COLS - 1 - off.col}`);
   }
   const stargazerTileSet = new Set([...playerStargazerTileSet, ...enemyStargazerTileSet]);
 

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -12,7 +12,8 @@ import { getAbilityDamage, getAbilityShield, findAbilityTargets, CHAMPION_ABILIT
 import type { AbilityConfig } from '@/lib/simulator/systems/ability';
 import { canAttack, getMoveTicks, findBestMoveToward, coordKey, getNeighbors, hexDistance } from '@/lib/simulator/systems/movement';
 import { getHexesInRadius } from '@/lib/simulator/models/hex';
-import { TICK_DURATION, MAX_TICKS, TICKS_PER_SECOND, CAST_TICKS, SELF_BUFF_CAST_TICKS, INITIAL_ATTACK_DELAY } from '@/lib/simulator/models/constants';
+import { TICK_DURATION, MAX_TICKS, TICKS_PER_SECOND, CAST_TICKS, SELF_BUFF_CAST_TICKS, INITIAL_ATTACK_DELAY, BOARD_COLS } from '@/lib/simulator/models/constants';
+import { axialToOffset } from '@/types';
 import { createRNG, SeededRNG } from '@/lib/simulator/engine/rng';
 import { captureSnapshot } from '@/lib/simulator/engine/replayEngine';
 import { findTarget } from '@/lib/simulator/systems/targeting';
@@ -2666,6 +2667,7 @@ function applyStargazerEffects(
   units: CombatUnit[],
   opposingUnits: CombatUnit[],
   constellation: StargazerConstellationId | undefined,
+  isPlayerTeam: boolean,
 ): void {
   const stargazer = traits.find((t) => t.trait.name === '별돌보미');
   if (!stargazer || !stargazer.activeEffect || stargazer.style === 0) return;
@@ -2676,13 +2678,30 @@ function applyStargazerEffects(
 
   const eff = stargazer.activeEffect.variables;
   const empoweredTiles = CONSTELLATION_TILE_PATTERN[constellation];
+  // 패턴 좌표(offset) 의 lookup set 을 미리 구축. 빠른 매칭.
+  const patternOffsetSet = new Set<string>(
+    empoweredTiles.map((t) => {
+      const off = axialToOffset(t);
+      return `${off.row}-${off.col}`;
+    }),
+  );
   const isStargazerUnit = (u: CombatUnit): boolean => unitHasTrait(u, '별돌보미');
-  // CONSTELLATION_TILE_PATTERN 은 player half (r=0..3) 만 정의. enemy 팀이
-  // mirror 된 보드 (r=4..7) 에 있을 때 (skipMirror=false 또는 simulator 직접 호출)
-  // 단순 좌표 비교는 항상 false → enemy 측이 효과 없음. mirror back 해서 검사.
+  // 매핑 (PR10 — display 와 일관, 사용자 명시 spec):
+  //  - A팀 (player): pattern.row = own-frame.row, pattern.col = own-frame.col (직접 매칭)
+  //  - B팀 (enemy):  pattern.row = 3 - own-frame.row, pattern.col = BOARD_COLS-1 - own-frame.col (보드 중심 180° 회전)
+  // own-frame 복원 (combat row → 0..3 own-frame row):
+  //  - simulator path: player toEightRowCoords 후 r=4..7 → own=combat-4. enemy r=0..3 → own=combat.
+  //  - default path A (skipMirror=false): player r=0..3 → own=combat. enemy mirrored r=4..7 → own=7-combat.
+  //  - gameDiffer path (skipMirror=true, no pre-shift): 둘 다 r=0..3 → own=combat.
   const isOnTile = (u: CombatUnit): boolean => {
-    const checkPos = u.position.r >= 4 ? mirrorPosition(u.position) : u.position;
-    return empoweredTiles.some((t) => t.q === checkPos.q && t.r === checkPos.r);
+    const off = axialToOffset(u.position);
+    const ownRow = isPlayerTeam
+      ? (off.row >= 4 ? off.row - 4 : off.row)
+      : (off.row >= 4 ? 7 - off.row : off.row);
+    const ownCol = off.col;
+    const patternRow = isPlayerTeam ? ownRow : 3 - ownRow;
+    const patternCol = isPlayerTeam ? ownCol : BOARD_COLS - 1 - ownCol;
+    return patternOffsetSet.has(`${patternRow}-${patternCol}`);
   };
 
   // 한 변종에 두 패스 — 강화 칸 모든 아군 + 강화 칸 별돌보미.
@@ -4041,8 +4060,8 @@ export function simulateCombat(
   // 정령족+싸움꾼 동시 보유 챔프 없어 corner case 영향 없음.
   applyBrawlerEffects(playerActiveTraits, playerUnits);
   applyBrawlerEffects(enemyActiveTraits, enemies);
-  applyStargazerEffects(playerActiveTraits, playerUnits, enemies, options.playerStargazerConstellation);
-  applyStargazerEffects(enemyActiveTraits, enemies, playerUnits, options.enemyStargazerConstellation);
+  applyStargazerEffects(playerActiveTraits, playerUnits, enemies, options.playerStargazerConstellation, true);
+  applyStargazerEffects(enemyActiveTraits, enemies, playerUnits, options.enemyStargazerConstellation, false);
   applyMorganaDarklight(playerActiveTraits, playerUnits);
   applyMorganaDarklight(enemyActiveTraits, enemies);
   applyFateweaverEffects(playerActiveTraits, playerUnits);

--- a/tests/unit/simulator/stargazer-team-split.test.ts
+++ b/tests/unit/simulator/stargazer-team-split.test.ts
@@ -13,13 +13,16 @@ function findChamp(api: string): RawChampion {
 }
 
 function makeStargazerTeam(team: 'player' | 'enemy'): PlacedChampion[] {
-  // 별돌보미 챔프 3명 — mountain 패턴 row 0 col 2,3,4 (강화 칸 위) 배치.
-  // player 데이터 row 는 0-3 → 보드 row+4 매핑이지만 PlacedChampion.position 은 데이터 좌표.
-  const baseRow = team === 'player' ? 0 : 0;
+  // PR10 spec — A팀 / B팀 각자 own-frame 에서 Mountain 강화 칸에 배치.
+  // Mountain 패턴 r=0 cols {2,3,4,5} (A팀 own-frame).
+  // 180° 회전 → B팀 own-frame tiles: r=3 cols {1,2,3,4}.
+  // 별돌보미 챔프 3명 배치.
+  const cols = team === 'player' ? [2, 3, 4] : [1, 2, 3];
+  const row = team === 'player' ? 0 : 3;
   return [
-    { champion: findChamp('TFT17_TwistedFate'), position: offsetToAxial({ row: baseRow, col: 2 }), starLevel: 2, items: [] },
-    { champion: findChamp('TFT17_Talon'), position: offsetToAxial({ row: baseRow, col: 3 }), starLevel: 2, items: [] },
-    { champion: findChamp('TFT17_Jax'), position: offsetToAxial({ row: baseRow, col: 4 }), starLevel: 2, items: [] },
+    { champion: findChamp('TFT17_TwistedFate'), position: offsetToAxial({ row, col: cols[0] }), starLevel: 2, items: [] },
+    { champion: findChamp('TFT17_Talon'), position: offsetToAxial({ row, col: cols[1] }), starLevel: 2, items: [] },
+    { champion: findChamp('TFT17_Jax'), position: offsetToAxial({ row, col: cols[2] }), starLevel: 2, items: [] },
   ];
 }
 

--- a/tests/unit/simulator/stargazer-tile-display-mapping.test.ts
+++ b/tests/unit/simulator/stargazer-tile-display-mapping.test.ts
@@ -1,84 +1,105 @@
 /**
- * UI 강화 칸 표시 좌표 ↔ combat 효과 적용 좌표 round-trip 검증.
+ * UI 강화 칸 표시 좌표 ↔ combat 효과 적용 좌표 일관성 (PR10 spec).
  *
- * 배경:
- *   - CONSTELLATION_TILE_PATTERN 은 player half (data row 0..3) 만 정의
- *   - simulator 의 toEightRowCoords 가 player unit 을 boards row 4..7 로 shift
- *   - applyStargazerEffects.isOnTile 은 r>=4 unit 을 mirrorPosition 으로 r=0..3
- *     변환 후 패턴 체크 (mirrorPosition: r → 7-r, offset col 보존)
+ * 사용자 명시 spec:
+ *  - A팀 (player, 화면 아래): display = (4 + pattern.row, pattern.col)
+ *  - B팀 (enemy,  화면 위):    display = (3 - pattern.row, BOARD_COLS-1 - pattern.col) — 보드 중심 180° 회전
  *
- * 따라서 UI 가 player 강화 칸을 표시할 때:
- *   pattern data (q, r) → 보드 offset (col=qOff, row=7-r) 위치에 표시해야
- *   해당 위치 unit 이 실제 effect 받는 위치와 일치 (codex P1 회귀 가드).
- *
- * 본 테스트는 UI 컴포넌트 직접 렌더 없이 매핑 공식 자체를 verify.
- * SetupBoardCore + ReplayBoard 모두 동일 공식 사용.
+ * 본 테스트는 spec 자체 + 산(Mountain) 별자리에 대한 명시 좌표 fingerprint 를
+ * 잠근다 (사용자가 검증한 정확한 12 좌표).
  */
 import { describe, it, expect } from 'vitest';
 import { CONSTELLATION_TILE_PATTERN } from '@/lib/actualData/stargazerMapping';
-import { axialToOffset, offsetToAxial } from '@/types';
-import type { HexCoord } from '@/types';
+import { axialToOffset } from '@/types';
+import { BOARD_COLS } from '@/lib/simulator/models/constants';
 
-/** UI display row for player tile (보드 좌표). data row r → 7-r. */
-function playerTileDisplayRow(dataRow: number): number {
-  return 7 - dataRow;
+/** A팀 강화 칸 display 좌표 (PR10 spec). */
+function playerTileDisplay(patternRow: number, patternCol: number): { row: number; col: number } {
+  return { row: 4 + patternRow, col: patternCol };
 }
 
-/** Combat 의 mirror back 시뮬레이션. boards r>=4 → mirror back to r=0..3. */
-function mirrorBackForCombat(pos: HexCoord): HexCoord {
-  if (pos.r < 4) return pos;
-  const mirroredR = 7 - pos.r;
-  const originalCol = pos.q + Math.floor(pos.r / 2);
-  const newQ = originalCol - Math.floor(mirroredR / 2);
-  return { q: newQ, r: mirroredR };
+/** B팀 강화 칸 display 좌표 — 보드 중심 180° 회전. */
+function enemyTileDisplay(patternRow: number, patternCol: number): { row: number; col: number } {
+  return { row: 3 - patternRow, col: BOARD_COLS - 1 - patternCol };
 }
 
-describe('Player 강화 칸 UI 표시 ↔ combat lookup round-trip', () => {
-  it('각 별자리의 모든 패턴 tile: 표시 위치 unit → mirror back → 원본 패턴과 일치', () => {
-    const constellations = Object.keys(CONSTELLATION_TILE_PATTERN) as Array<keyof typeof CONSTELLATION_TILE_PATTERN>;
-    for (const id of constellations) {
+describe('PR10 — 강화 칸 display 매핑 spec', () => {
+  it('A팀: display.row 가 4..7 범위 (player half)', () => {
+    for (const id of Object.keys(CONSTELLATION_TILE_PATTERN) as Array<keyof typeof CONSTELLATION_TILE_PATTERN>) {
       for (const tile of CONSTELLATION_TILE_PATTERN[id]) {
         const off = axialToOffset(tile);
-
-        // UI 가 표시하는 보드 위치 (현재 fix 의 공식)
-        const displayRow = playerTileDisplayRow(off.row);
-        const displayPos = offsetToAxial({ row: displayRow, col: off.col });
-
-        // 만약 player unit 이 이 표시 위치에 있다면 (toEightRowCoords 후 r=4..7),
-        // combat 가 mirror back 으로 어떤 pattern 좌표를 체크하는지
-        const checkPos = mirrorBackForCombat(displayPos);
-
-        // round-trip: mirror back 결과가 원본 pattern tile 과 일치해야 한다.
-        expect(checkPos).toEqual(tile);
+        const disp = playerTileDisplay(off.row, off.col);
+        expect(disp.row).toBeGreaterThanOrEqual(4);
+        expect(disp.row).toBeLessThanOrEqual(7);
       }
     }
   });
 
-  it('display row 가 항상 4..7 범위 (player half) 안에 들어가야 한다', () => {
-    const constellations = Object.keys(CONSTELLATION_TILE_PATTERN) as Array<keyof typeof CONSTELLATION_TILE_PATTERN>;
-    for (const id of constellations) {
+  it('B팀: display.row 가 0..3 범위 (enemy half)', () => {
+    for (const id of Object.keys(CONSTELLATION_TILE_PATTERN) as Array<keyof typeof CONSTELLATION_TILE_PATTERN>) {
       for (const tile of CONSTELLATION_TILE_PATTERN[id]) {
         const off = axialToOffset(tile);
-        const displayRow = playerTileDisplayRow(off.row);
-        expect(displayRow).toBeGreaterThanOrEqual(4);
-        expect(displayRow).toBeLessThanOrEqual(7);
+        const disp = enemyTileDisplay(off.row, off.col);
+        expect(disp.row).toBeGreaterThanOrEqual(0);
+        expect(disp.row).toBeLessThanOrEqual(3);
       }
     }
   });
 
-  it('회귀 가드: 잘못된 공식 (off.row + 4) 은 mirror back round-trip 실패', () => {
-    // 본 테스트는 codex P1 이 catch 한 버그가 다시 나타나면 fail 한다.
-    const tile = CONSTELLATION_TILE_PATTERN.mountain[0]; // 첫 mountain 타일
-    const off = axialToOffset(tile);
-
-    // 잘못된 공식 (이전 코드)
-    const wrongDisplayRow = off.row + 4;
-    const wrongDisplayPos = offsetToAxial({ row: wrongDisplayRow, col: off.col });
-    const wrongCheck = mirrorBackForCombat(wrongDisplayPos);
-
-    // data row=0 일 때 (mountain 첫 타일), wrong=4 → mirror→r=3 → tile.r=0 과 불일치
-    if (off.row === 0) {
-      expect(wrongCheck.r).not.toBe(tile.r);
+  it('A팀 / B팀 display 는 보드 중심 (3.5, 3) 기준 180° 회전 관계', () => {
+    for (const id of Object.keys(CONSTELLATION_TILE_PATTERN) as Array<keyof typeof CONSTELLATION_TILE_PATTERN>) {
+      for (const tile of CONSTELLATION_TILE_PATTERN[id]) {
+        const off = axialToOffset(tile);
+        const a = playerTileDisplay(off.row, off.col);
+        const b = enemyTileDisplay(off.row, off.col);
+        // 180° 회전: (r, c) ↔ (7-r, BOARD_COLS-1-c)
+        expect(b.row).toBe(7 - a.row);
+        expect(b.col).toBe(BOARD_COLS - 1 - a.col);
+      }
     }
+  });
+});
+
+describe('PR10 — Mountain(산) 별자리 명시 좌표 fingerprint (사용자 검증)', () => {
+  /** 사용자가 검증한 A팀 Mountain 강화 칸 12 좌표 (display row.col). */
+  const EXPECTED_A_MOUNTAIN: ReadonlyArray<readonly [row: number, col: number]> = [
+    [4, 2], [4, 3], [4, 4], [4, 5],
+    [5, 1], [5, 5],
+    [6, 1], [6, 6],
+    [7, 0], [7, 1], [7, 5], [7, 6],
+  ];
+
+  /** B팀 Mountain — A팀 좌표를 180° 회전. */
+  const EXPECTED_B_MOUNTAIN: ReadonlyArray<readonly [row: number, col: number]> = [
+    [3, 1], [3, 2], [3, 3], [3, 4],
+    [2, 1], [2, 5],
+    [1, 0], [1, 5],
+    [0, 0], [0, 1], [0, 5], [0, 6],
+  ];
+
+  function patternMountainDisplay(side: 'A' | 'B'): Set<string> {
+    const set = new Set<string>();
+    for (const tile of CONSTELLATION_TILE_PATTERN.mountain) {
+      const off = axialToOffset(tile);
+      const disp = side === 'A'
+        ? playerTileDisplay(off.row, off.col)
+        : enemyTileDisplay(off.row, off.col);
+      set.add(`${disp.row}-${disp.col}`);
+    }
+    return set;
+  }
+
+  it('A팀 Mountain: 12 강화 칸이 사용자 검증 좌표와 정확히 일치', () => {
+    const computed = patternMountainDisplay('A');
+    const expected = new Set(EXPECTED_A_MOUNTAIN.map(([r, c]) => `${r}-${c}`));
+    expect(computed).toEqual(expected);
+    expect(computed.size).toBe(12);
+  });
+
+  it('B팀 Mountain: 12 강화 칸이 A팀 180° 회전과 정확히 일치', () => {
+    const computed = patternMountainDisplay('B');
+    const expected = new Set(EXPECTED_B_MOUNTAIN.map(([r, c]) => `${r}-${c}`));
+    expect(computed).toEqual(expected);
+    expect(computed.size).toBe(12);
   });
 });

--- a/tests/unit/simulator/stargazer-variants-effects.test.ts
+++ b/tests/unit/simulator/stargazer-variants-effects.test.ts
@@ -130,19 +130,18 @@ describe.skip('Fountain 변종 — Teamwide ManaRegen + 별돌보미 추가 (17.
 });
 
 describe('Enemy 팀 (mirror r=4..7) 도 강화 칸 효과 받음', () => {
-  it('skipMirror=false 패턴에서 enemy 별돌보미 unit 도 buff 적용 (codex P1 회귀 가드)', () => {
-    // enemy 팀 별돌보미 6명 — Mountain pattern 의 player-half 좌표를 mirror 해서 배치.
-    // mirrorPosition: r → 7-r, q 도 col 보존하며 재계산.
-    // Mountain 첫 6 tile: (2,0)(3,0)(4,0)(5,0)(1,1)(5,1) → mirrored:
-    //   (2,7) (3,7) (4,7) (5,7) (1,6) (5,6) (q=col-floor(r/2) 재계산 후)
-    // simulator 직접 호출 (skipMirror=false 시 enemy 가 placed 시점에 mirror 적용)
+  it('skipMirror=false 패턴에서 enemy 별돌보미 unit 도 buff 적용 (PR10 spec — 180° 회전)', () => {
+    // PR10 spec: B팀 own-frame 의 Mountain 강화 칸 = A팀 패턴의 180° 회전 (3-r, 6-c).
+    // Mountain pattern.r=3 cols {0,1,5,6} → B own-frame r=0 cols {6,5,1,0} (B 등록 4칸).
+    // Mountain pattern.r=2 cols {1,6}      → B own-frame r=1 cols {5,0}        (B 등록 2칸).
+    // 별돌보미 6명 배치 — q = offset col - floor(r/2). enemy own-frame r=0..1 → q=col.
     const enemyAlly: PlacedChampion[] = [
-      placed(apTwistedFate, 2, 0),
-      placed(apTalon, 3, 0),
-      placed(apJax, 4, 0),
-      placed(apAatrox, 5, 0, [STARGAZER_EMBLEM]),
-      placed(apMilio, 1, 1, [STARGAZER_EMBLEM]),
-      placed(apCorki, 5, 1, [STARGAZER_EMBLEM]),
+      placed(apTwistedFate, 0, 0),  // own (0, 0) → pattern (3, 6) ✓ Mountain r=3 col=6
+      placed(apTalon, 1, 0),         // own (0, 1) → pattern (3, 5) ✓
+      placed(apJax, 5, 0),           // own (0, 5) → pattern (3, 1) ✓
+      placed(apAatrox, 6, 0, [STARGAZER_EMBLEM]),  // own (0, 6) → pattern (3, 0) ✓
+      placed(apMilio, 0, 1, [STARGAZER_EMBLEM]),   // own (1, 0) → pattern (2, 6) ✓ Mountain r=2 col=6
+      placed(apCorki, 5, 1, [STARGAZER_EMBLEM]),   // own (1, 5) → pattern (2, 1) ✓
     ];
     const playerDummy: PlacedChampion[] = [placed(dummyEnemy, 0, 3)];
     // skipMirror 미지정 → 기본 false → enemy 자동 mirror 됨 (r=4..7 위치)


### PR DESCRIPTION
## Summary

별돌보미 7개 별자리 강화 칸이 display + combat 양쪽에서 잘못 매핑되어 있었음. 사용자 검증 좌표(예: 산 별자리 A팀 \`7.0, 7.1, 6.1, 5.1, 4.2, 4.3, 4.4, 4.5, 5.5, 6.6, 7.6, 7.5\`; B팀 \`3.1, 3.2, 3.3, 3.4, ...\` — 180° 회전) 기준 정정.

## Spec (사용자 명시)

- **A팀** (player, 화면 아래): \`display = (4 + pattern.row, pattern.col)\`
- **B팀** (enemy, 화면 위): \`display = (3 - pattern.row, BOARD_COLS-1 - pattern.col)\` — 보드 중심 (3.5, 3) 기준 180° 회전

## Changes

### Display 매핑 (3 파일 동일 패턴)
- \`src/app/simulator/layout/shared/DroppableOverlay.tsx\`
- \`src/components/battle/SetupBoardCore.tsx\`
- \`src/components/battle/ReplayBoard.tsx\`

### Combat 매핑
- \`src/lib/simulator/engine/combatLoop.ts\` \`applyStargazerEffects\`:
  - \`isPlayerTeam\` 파라미터 추가 (호출 측에서 명시)
  - own-frame 복원 로직 — 3가지 호출 mode 모두 정상 처리:
    - \`/simulator\` path (toEightRowCoords + skipMirror=true)
    - default mirror path (skipMirror=false)
    - gameDiffer path (skipMirror=true 무 pre-shift)

### 테스트 업데이트 + 회귀 가드
- \`stargazer-team-split.test.ts\`: 양 팀 own-frame Mountain 좌표 (180° 반영)
- \`stargazer-variants-effects.test.ts\`: enemy 6 tile B-own-frame 좌표
- \`stargazer-tile-display-mapping.test.ts\` (재작성):
  - **A팀 Mountain 12 좌표 fingerprint** = 사용자 검증과 정확히 일치
  - **B팀 Mountain 12 좌표 fingerprint** = A팀의 180° 회전과 정확히 일치
  - A/B 가 항상 (3.5, 3) 기준 180° rotation 관계

## Verification

- pnpm typecheck ✅ 0 errors
- pnpm lint ✅ 0 errors
- pnpm vitest run ✅ **767 PASS / 0 FAIL** (신규 5 fingerprint 가드 포함)
- pnpm build ✅
- diff cache (game-20260423-001) 재측정:
  - winnerMatchRate: 45.5% (변동 없음)
  - stargazer-mountain-applied 단위 테스트 통과 — +15% HP 정상 적용
  - 잔여 sim 오차는 별돌보미 외 다른 정확도 요인이 dominant → 향후 task A (diff attribution) 진단 대상

## Test plan

### Display 영역
- [x] \`/simulator\` 산 별자리 선택 → A팀 강화 칸 12개가 display \`7.0, 7.1, 6.1, 5.1, 4.2-5, 5.5, 6.6, 7.5-6\` 위치에 표시
- [x] \`/simulator\` B팀 산 별자리 → display \`3.1-4, 2.1, 2.5, 1.0, 1.5, 0.0-1, 0.5-6\` (180° 회전)
- [x] 다른 별자리 (멧돼지/메달/여사냥꾼/뱀/제단/우물) — 좌우 비대칭 패턴에서 A/B 가 보드 중심 180° 회전인지 시각 확인 (특히 여사냥꾼/뱀)
- [x] \`/actual-data\` round editor 에서 동일 매핑 확인

### Combat 영역
- [x] simulator 에서 별돌보미 5명 + 산 별자리 → 강화 칸 unit 만 +12% HP/AS 등 효과 적용
- [x] B팀에 별돌보미 + 산 별자리 → B팀 강화 칸 unit 도 동일 효과 적용
- [x] 양 팀 다른 별자리 시 각자 자기 별자리 효과만 받는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)