### PR TITLE
feat(home+actual-data): 관리자 진입점 + 별돌보미 강화 칸 표시 (UX bundle)

### DIFF
--- a/src/app/actual-data/[gameId]/compare/page.tsx
+++ b/src/app/actual-data/[gameId]/compare/page.tsx
@@ -6,9 +6,18 @@ import GameDiffSummaryCard from '@/components/validation/GameDiffSummaryCard';
 import RoundDiffTable from '@/components/validation/RoundDiffTable';
 import RoundDiffDetailPanel from '@/components/validation/RoundDiffDetailPanel';
 import RunCompareButton from '@/components/validation/RunCompareButton';
+import AdminGuard from '@/components/AdminGuard';
 
 export default function ComparePage({ params }: { params: Promise<{ gameId: string }> }) {
   const { gameId } = use(params);
+  return (
+    <AdminGuard>
+      <CompareContent gameId={gameId} />
+    </AdminGuard>
+  );
+}
+
+function CompareContent({ gameId }: { gameId: string }) {
   const { state, run } = useCompareDiff(gameId);
   const [selectedRoundName, setSelectedRoundName] = useState<string | null>(null);
 

--- a/src/app/actual-data/[gameId]/page.tsx
+++ b/src/app/actual-data/[gameId]/page.tsx
@@ -1,8 +1,13 @@
 'use client';
 import { use } from 'react';
 import ActualDataEditor from '@/components/actual-data/ActualDataEditor';
+import AdminGuard from '@/components/AdminGuard';
 
 export default function ActualDataEditPage({ params }: { params: Promise<{ gameId: string }> }) {
   const { gameId } = use(params);
-  return <ActualDataEditor gameId={gameId} />;
+  return (
+    <AdminGuard>
+      <ActualDataEditor gameId={gameId} />
+    </AdminGuard>
+  );
 }

--- a/src/app/actual-data/page.tsx
+++ b/src/app/actual-data/page.tsx
@@ -3,8 +3,17 @@ import { useEffect, useState } from 'react';
 import { useActualDataStore } from '@/store/actualDataSlice';
 import GameListTable from '@/components/actual-data/GameListTable';
 import NewGameDialog from '@/components/actual-data/NewGameDialog';
+import AdminGuard from '@/components/AdminGuard';
 
 export default function ActualDataListPage() {
+  return (
+    <AdminGuard>
+      <ActualDataListContent />
+    </AdminGuard>
+  );
+}
+
+function ActualDataListContent() {
   const games = useActualDataStore(s => s.gameListCache);
   const refresh = useActualDataStore(s => s.refreshGameList);
   const [dialogOpen, setDialogOpen] = useState(false);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from 'react';
 import Link from 'next/link';
 import { useActiveSet } from '@/hooks/useActiveSet';
 import { SET_CONFIGS } from '@/data/setConfig';
+import { useIsAdmin } from '@/hooks/useIsAdmin';
 
 export default function HomePage() {
   return (
@@ -17,6 +18,7 @@ function HomeContent() {
   const activeSet = useActiveSet();
   const cfg = SET_CONFIGS[activeSet];
   const isPbe = cfg.status === 'pbe';
+  const isAdmin = useIsAdmin();
 
   const features = isPbe
     ? [
@@ -58,15 +60,18 @@ function HomeContent() {
           borderColor: 'border-emerald-500/30',
           disabled: false,
         },
-        {
-          title: '실측 데이터',
-          desc: 'PvP 라운드별 팀·아이템 기록 → 시뮬 정확도 비교 (별돌보미·중재자 등 게임 메타 편집)',
-          href: '/actual-data',
-          icon: '📊',
-          color: 'from-rose-600/20 to-pink-600/20',
-          borderColor: 'border-rose-500/30',
-          disabled: false,
-        },
+        // 관리자 전용 — useIsAdmin() 결과에 따라 노출. 비-관리자에게는 미노출.
+        ...(isAdmin
+          ? [{
+              title: '실측 데이터',
+              desc: 'PvP 라운드별 팀·아이템 기록 → 시뮬 정확도 비교 (별돌보미·중재자 등 게임 메타 편집)',
+              href: '/actual-data',
+              icon: '📊',
+              color: 'from-rose-600/20 to-pink-600/20',
+              borderColor: 'border-rose-500/30',
+              disabled: false,
+            }]
+          : []),
       ];
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,6 +58,15 @@ function HomeContent() {
           borderColor: 'border-emerald-500/30',
           disabled: false,
         },
+        {
+          title: '실측 데이터',
+          desc: 'PvP 라운드별 팀·아이템 기록 → 시뮬 정확도 비교 (별돌보미·중재자 등 게임 메타 편집)',
+          href: '/actual-data',
+          icon: '📊',
+          color: 'from-rose-600/20 to-pink-600/20',
+          borderColor: 'border-rose-500/30',
+          disabled: false,
+        },
       ];
 
   return (

--- a/src/components/AdminGuard.tsx
+++ b/src/components/AdminGuard.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { ReactNode } from 'react';
+import Link from 'next/link';
+import { useAdminGate } from '@/hooks/useIsAdmin';
+
+/**
+ * 관리자 전용 페이지 라우트 가드.
+ * - 'pending' (로딩): 빈 영역 (SSR 후 짧은 hydration 지연 — flash 회피)
+ * - 'allowed': children 렌더
+ * - 'denied': 접근 거부 UI + 홈 복귀 링크
+ *
+ * 비-관리자 직접 URL 진입 (예: /actual-data) 차단.
+ */
+export default function AdminGuard({ children }: { children: ReactNode }) {
+  const gate = useAdminGate();
+
+  if (gate === 'denied') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[70vh] text-gray-300 gap-4">
+        <div className="text-5xl">🔒</div>
+        <h1 className="text-2xl font-bold">접근 권한 없음</h1>
+        <p className="text-sm text-gray-400 text-center max-w-md">
+          관리자 전용 페이지입니다. 활성화하려면 DevTools 콘솔에서<br />
+          <code className="px-2 py-1 mt-2 inline-block bg-gray-800 border border-gray-700 rounded text-xs text-gray-200">
+            localStorage.setItem(&apos;tft-admin&apos;, &apos;true&apos;)
+          </code>
+          <br />입력 후 새로고침.
+        </p>
+        <Link
+          href="/"
+          className="px-3 py-1.5 border border-gray-700 text-gray-200 hover:bg-gray-700 rounded text-sm"
+        >
+          ← 홈으로
+        </Link>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/actual-data/ActualBoard.tsx
+++ b/src/components/actual-data/ActualBoard.tsx
@@ -1,20 +1,26 @@
 'use client';
 
 import { useMemo, MouseEvent } from 'react';
-import type { RawChampion, RawItem, PlacedChampion } from '@/types';
+import type { RawChampion, RawItem, RawTrait, PlacedChampion } from '@/types';
 import { axialToOffset } from '@/types';
 import { BOARD_COLS } from '@/lib/simulator/models/constants';
 import SetupBoardCore from '@/components/battle/SetupBoardCore';
 import DroppableHexCell from '@/components/battle/DroppableHexCell';
 import { useActualDataStore } from '@/store/actualDataSlice';
 import { toPlacedChampion } from '@/lib/actualData/unitAdapter';
-import type { PlacedUnit, TeamSnapshot, OpponentSnapshot } from '@/lib/actualData/types';
+import type { PlacedUnit, TeamSnapshot, OpponentSnapshot, StargazerConstellationId } from '@/lib/actualData/types';
+import { resolveTraits } from '@/lib/simulator/systems/trait';
+import { CONSTELLATION_TILE_PATTERN } from '@/lib/actualData/stargazerMapping';
 import ActualItemSlotsOverlay from './ActualItemSlotsOverlay';
 
 interface ActualBoardProps {
   roundIndex: number;
   champions: RawChampion[];
   items: RawItem[];
+  /** 트레잇 활성 검사용 — 별돌보미(3+) 시너지 발동 여부 판정. */
+  traits: RawTrait[];
+  /** 게임-level 별자리 (각 팀에 동일 적용). 미설정 또는 별돌보미 미활성 팀은 강화 칸 미표시. */
+  stargazerConstellation: StargazerConstellationId | null;
   cellSize?: number;
 }
 
@@ -29,7 +35,7 @@ interface ActualBoardProps {
  * to be re-wired via prop drilling. Emits changes through updatePlayerTeam /
  * updateOpponent.
  */
-export default function ActualBoard({ roundIndex, champions, items, cellSize = 44 }: ActualBoardProps) {
+export default function ActualBoard({ roundIndex, champions, items, traits, stargazerConstellation, cellSize = 44 }: ActualBoardProps) {
   const round = useActualDataStore(s => {
     const r = s.currentGame?.rounds[roundIndex];
     return r && r.type === 'pvp' ? r : null;
@@ -53,6 +59,36 @@ export default function ActualBoard({ roundIndex, champions, items, cellSize = 4
       .map(u => toPlacedChampion(u, championCatalog, itemCatalog))
       .filter((p): p is PlacedChampion => p !== null);
   }, [round, championCatalog, itemCatalog]);
+
+  // 별돌보미(3+) 활성 시 강화 칸 표시 (게임-level 별자리 + 팀별 활성 검사).
+  // resolveTraits 에 stargazerConstellation 옵션을 넘기면 base 'TFT17_Stargazer' 가 변종
+  // (TFT17_Stargazer_Wolf 등) 으로 mapping 되어 activeEffect.variables 에 별자리별 수치 포함.
+  const playerStargazerActive = useMemo(() => {
+    if (!stargazerConstellation || traits.length === 0 || playerPlaced.length === 0) return null;
+    const active = resolveTraits(playerPlaced, traits, { stargazerConstellation });
+    const sg = active.find(t => t.trait.name === '별돌보미' && t.style > 0);
+    return sg && sg.count >= 3 ? sg : null;
+  }, [stargazerConstellation, traits, playerPlaced]);
+
+  const enemyStargazerActive = useMemo(() => {
+    if (!stargazerConstellation || traits.length === 0 || enemyPlaced.length === 0) return null;
+    const active = resolveTraits(enemyPlaced, traits, { stargazerConstellation });
+    const sg = active.find(t => t.trait.name === '별돌보미' && t.style > 0);
+    return sg && sg.count >= 3 ? sg : null;
+  }, [stargazerConstellation, traits, enemyPlaced]);
+
+  const playerStargazerTiles = useMemo(
+    () => (playerStargazerActive && stargazerConstellation
+      ? CONSTELLATION_TILE_PATTERN[stargazerConstellation]
+      : []),
+    [playerStargazerActive, stargazerConstellation],
+  );
+  const enemyStargazerTiles = useMemo(
+    () => (enemyStargazerActive && stargazerConstellation
+      ? CONSTELLATION_TILE_PATTERN[stargazerConstellation]
+      : []),
+    [enemyStargazerActive, stargazerConstellation],
+  );
 
   if (!round) return null;
 
@@ -100,6 +136,14 @@ export default function ActualBoard({ roundIndex, champions, items, cellSize = 4
         onUnitClick={handleRemoveUnit}
         onUnitRightClick={handleRemoveUnit}
         onUnitCycleStars={handleCycleStars}
+        playerStargazerTiles={playerStargazerTiles}
+        enemyStargazerTiles={enemyStargazerTiles}
+        playerStargazerConstellation={playerStargazerActive ? stargazerConstellation : null}
+        enemyStargazerConstellation={enemyStargazerActive ? stargazerConstellation : null}
+        playerStargazerEffectVariables={playerStargazerActive?.activeEffect?.variables ?? null}
+        enemyStargazerEffectVariables={enemyStargazerActive?.activeEffect?.variables ?? null}
+        playerStargazerCount={playerStargazerActive?.count ?? 0}
+        enemyStargazerCount={enemyStargazerActive?.count ?? 0}
         cellSize={cellSize}
       />
 

--- a/src/components/actual-data/PvPRoundEditor.tsx
+++ b/src/components/actual-data/PvPRoundEditor.tsx
@@ -29,6 +29,7 @@ export default function PvPRoundEditor({ index, round }: { index: number; round:
   const updatePlayerTeam = useActualDataStore(s => s.updatePlayerTeam);
   const updateOpponent = useActualDataStore(s => s.updateOpponent);
   const gameId = useActualDataStore(s => s.currentGame?.gameId);
+  const stargazerConstellation = useActualDataStore(s => s.currentGame?.stargazerConstellation ?? null);
   const { champions, items, traits, loading } = useGameData();
 
   // NOVA(5) 시너지 활성 검사 — 어느 한 팀이라도 활성이면 ToolsSection 의 NOVA 도구 노출.
@@ -194,6 +195,8 @@ export default function PvPRoundEditor({ index, round }: { index: number; round:
                 roundIndex={index}
                 champions={champions}
                 items={items}
+                traits={traits}
+                stargazerConstellation={stargazerConstellation ?? null}
               />
             )}
           </div>

--- a/src/hooks/useIsAdmin.ts
+++ b/src/hooks/useIsAdmin.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+/**
+ * 관리자 전용 진입점 게이팅 hook (React Compiler 친화 — useSyncExternalStore).
+ *
+ * 활성화: 브라우저 DevTools 콘솔에서
+ *   localStorage.setItem('tft-admin', 'true')
+ * 후 새로고침. 비활성화는 동일 키 'false' 또는 removeItem.
+ *
+ * SSR: getServerSnapshot 가 항상 false 반환 → 서버는 admin=false 로 HTML 생성.
+ * 클라이언트 hydration 직후 localStorage 값 사용. React 가 mismatch 가
+ * 아닌 정상 흐름으로 처리.
+ *
+ * 보안 한계: localStorage 는 client-side flag — 서버 API 가 별도 인증을
+ * 요구하지 않으므로 직접 fetch 로는 데이터 접근 가능. 1인 분석 도구의
+ * UI 게이팅 용도. 진짜 보안이 필요하면 서버 측 auth 도입 필요.
+ */
+const ADMIN_KEY = 'tft-admin';
+
+function getClientSnapshot(): boolean {
+  try {
+    return typeof window !== 'undefined'
+      && window.localStorage.getItem(ADMIN_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+function subscribe(onChange: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  // 같은 탭 내 다른 코드의 변경은 잡지 않지만 (storage 이벤트는 cross-tab 만 동작),
+  // 콘솔에서 setItem 후 새로고침 시 page mount 에서 읽으면 됨. 충분.
+  window.addEventListener('storage', onChange);
+  return () => window.removeEventListener('storage', onChange);
+}
+
+export function useIsAdmin(): boolean {
+  return useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+}
+
+/**
+ * 페이지 라우트 가드용 wrapper. SSR 시점 'denied' (admin=false 로 시작),
+ * 클라이언트 hydration 후 localStorage 결과로 'allowed'/'denied' 확정.
+ * pending 상태가 별도로 필요 없도록 단순화 — admin 의 짧은 flash 는 허용.
+ */
+export function useAdminGate(): 'allowed' | 'denied' {
+  const isAdmin = useIsAdmin();
+  return isAdmin ? 'allowed' : 'denied';
+}


### PR DESCRIPTION
## Summary

actual-data UX 3가지를 한 번에 묶음:
1. 홈에 \`/actual-data\` 진입 카드 \"실측 데이터\" 추가
2. 관리자 전용 게이팅 (\`localStorage('tft-admin')\` 기반) + hydration error fix
3. actual-data 보드에 별돌보미(3+) 활성 시 강화 칸 표시 (PR #88 매핑 spec 기반)

## 1. 홈 카드 추가

| 속성 | 값 |
|------|------|
| title | 실측 데이터 |
| desc | PvP 라운드별 팀·아이템 기록 → 시뮬 정확도 비교 (별돌보미·중재자 등 게임 메타 편집) |
| href | /actual-data |
| icon | 📊 |
| color | rose → pink 그라디언트 |

## 2. 관리자 전용 + hydration fix

| 이슈 | 해결 |
|------|------|
| Hydration error (서버 2-card vs 클라이언트 3-card) | \`useSyncExternalStore\` (SSR=false, client=localStorage) — React Compiler 친화 |
| /actual-data 공개 노출 | \`AdminGuard\` 컴포넌트로 4 라우트(home 카드 + list + per-game + compare) 게이팅 |

**활성화**: 브라우저 DevTools 콘솔에서 \`localStorage.setItem('tft-admin', 'true')\` 후 새로고침.

새 파일:
- \`src/hooks/useIsAdmin.ts\` — \`useSyncExternalStore\` 기반, getServerSnapshot=false 로 hydration mismatch 회피
- \`src/components/AdminGuard.tsx\` — denied 시 🔒 접근 거부 UI + 활성화 가이드

## 3. 별돌보미 강화 칸 표시 (actual-data)

\`actual-data\` 보드는 \`SetupBoardCore\` 사용하지만 stargazer props 가 미전달되어 활성 시너지에도 강화 칸이 보이지 않았음. wiring 추가:

**조건 (둘 다 만족 시 강화 칸 노출)**:
1. 게임 메타에 \`stargazerConstellation\` 설정됨 (\`GameMetaEditor\` dropdown)
2. 해당 팀에 별돌보미 trait count >= 3 (\`style > 0\`)

**구현**:
- \`ActualBoard.tsx\`: \`traits\` + \`stargazerConstellation\` props 추가, 팀별 \`resolveTraits\` 호출 → \`SetupBoardCore\` 의 stargazer props 모두 wiring
- \`PvPRoundEditor.tsx\`: \`currentGame.stargazerConstellation\` selector 추가, props 전달

**매핑 정합 (PR #88 머지 spec)**:
- A팀: \`display = (4 + pattern.row, pattern.col)\`
- B팀: \`display = (3 - pattern.row, BOARD_COLS-1 - pattern.col)\` — 보드 중심 180° 회전

## Verification

- pnpm typecheck ✅ 0 errors
- pnpm lint ✅ 0 errors (React Compiler \`set-state-in-effect\` 통과)
- pnpm vitest run ✅ 765 PASS / 0 FAIL
- pnpm build ✅

## Test plan

### 관리자 게이팅
- [ ] 비-관리자: 홈 카드 2개만, \`/actual-data\` 접근 시 거부 UI
- [ ] \`localStorage.setItem('tft-admin', 'true')\` 후 새로고침: 홈 3개 카드 + 정상 진입
- [ ] hydration error 콘솔에서 사라짐

### actual-data 별돌보미
- [ ] 게임 메타 편집 → 별자리 (산 등) 선택 후 라운드로 돌아감
- [ ] 별돌보미 3명 미만 팀: 강화 칸 미노출
- [ ] 별돌보미 3명+ 팀: 보드에 보라색 강화 칸 12~18개 노출
- [ ] 별자리 변경 시 강화 칸 패턴이 즉시 갱신
- [ ] 강화 칸 hover 시 별자리 효과 tooltip 노출
- [ ] A팀(아래) / B팀(위) 강화 칸이 보드 중심 180° 회전 관계 유지
- [ ] PBE 모드 또는 미관리자 — 카드 미노출 (기존 features 배열 유지)

## 보안 한계

\`localStorage\` 는 client-side flag — 서버 API 직접 fetch 로는 접근 가능. 1인 분석 도구의 UI 게이팅 용도. 진짜 보안 필요 시 별도 PR (Supabase Auth 도입).

🤖 Generated with [Claude Code](https://claude.com/claude-code)