### PR TITLE
feat(augment): 바루스의 은총 (BoonOfStars) 구현 — winnerMatch 50% 달성

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -3878,8 +3878,12 @@ export function simulateCombat(
     stackCount: options.enemyAugmentStacks?.[aug.apiName] ?? 1,
   }));
 
-  const playerAugmentEffects = resolveAugmentEffects(playerAugsWithStacks);
-  const enemyAugmentEffects = resolveAugmentEffects(enemyAugsWithStacks);
+  // 팀별 starLevel 합 — 바루스의 은총(BoonOfStars) 등 별 레벨 합 기반 augment 입력.
+  const playerStarLevelSum = allyTeam.reduce((s, p) => s + (p.starLevel ?? 0), 0);
+  const enemyStarLevelSum = enemyTeam.reduce((s, p) => s + (p.starLevel ?? 0), 0);
+
+  const playerAugmentEffects = resolveAugmentEffects(playerAugsWithStacks, playerStarLevelSum);
+  const enemyAugmentEffects = resolveAugmentEffects(enemyAugsWithStacks, enemyStarLevelSum);
 
   const playerInCombatEffects = resolveInCombatAugmentEffects(playerAugsWithStacks);
   const enemyInCombatEffects = resolveInCombatAugmentEffects(enemyAugsWithStacks);

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -3878,9 +3878,16 @@ export function simulateCombat(
     stackCount: options.enemyAugmentStacks?.[aug.apiName] ?? 1,
   }));
 
+  // 갈리오는 필드에 배치되지만 전투 시작 시 보드에 없음 (데마시아 결집 시 소환).
+  // BoonOfStars star sum 에 포함되면 over-buff 발생 (codex P2 PR #91) → 미리 제외 필터.
+  const isGalioPlaceholder = (p: PlacedChampion) => p.champion.apiName === 'TFT16_Galio';
+  const playerCombatRoster = allyTeam.filter(p => !isGalioPlaceholder(p));
+  const enemyCombatRoster = enemyTeam.filter(p => !isGalioPlaceholder(p));
+
   // 팀별 starLevel 합 — 바루스의 은총(BoonOfStars) 등 별 레벨 합 기반 augment 입력.
-  const playerStarLevelSum = allyTeam.reduce((s, p) => s + (p.starLevel ?? 0), 0);
-  const enemyStarLevelSum = enemyTeam.reduce((s, p) => s + (p.starLevel ?? 0), 0);
+  // Galio placeholder 는 전투 시작 시 보드에 없으므로 제외 (combat roster 기준).
+  const playerStarLevelSum = playerCombatRoster.reduce((s, p) => s + (p.starLevel ?? 0), 0);
+  const enemyStarLevelSum = enemyCombatRoster.reduce((s, p) => s + (p.starLevel ?? 0), 0);
 
   const playerAugmentEffects = resolveAugmentEffects(playerAugsWithStacks, playerStarLevelSum);
   const enemyAugmentEffects = resolveAugmentEffects(enemyAugsWithStacks, enemyStarLevelSum);
@@ -3912,12 +3919,13 @@ export function simulateCombat(
   const rng: SeededRNG = createRNG(seed);
   const eventBus = new EventBus();
 
-  // 갈리오는 필드에 배치되지만 전투 시작 시 제외 → 데마시아 결집 시 소환
-  const isGalio = (p: PlacedChampion) => p.champion.apiName === 'TFT16_Galio';
+  // 갈리오는 필드에 배치되지만 전투 시작 시 제외 → 데마시아 결집 시 소환.
+  // (위에서 이미 필터링한 playerCombatRoster/enemyCombatRoster 와 동일 — 이름만 다른 alias.)
+  const isGalio = isGalioPlaceholder;
   const playerGalioPlaced = allyTeam.find(isGalio);
   const enemyGalioPlaced = enemyTeam.find(isGalio);
-  const playerTeamFiltered = allyTeam.filter(p => !isGalio(p));
-  const enemyTeamFiltered = enemyTeam.filter(p => !isGalio(p));
+  const playerTeamFiltered = playerCombatRoster;
+  const enemyTeamFiltered = enemyCombatRoster;
 
   // options에서 전달된 갈리오보다 필드 배치된 갈리오 우선
   const effectivePlayerGalio = playerGalioPlaced

--- a/src/lib/simulator/systems/augment.ts
+++ b/src/lib/simulator/systems/augment.ts
@@ -174,7 +174,18 @@ function ef(effects: Record<string, number>, key: string): number | null {
 
 // === Global stat resolution (applied to all units via ItemEffect) ===
 
-export function resolveAugmentEffects(augments: AugmentWithStacks[]): ItemEffect {
+/**
+ * Augment 의 team-wide stat bonus 를 ItemEffect 형태로 변환.
+ *
+ * @param augments  팀에 적용된 augment 배열 (with stacks)
+ * @param starLevelSum 팀 전체 unit 의 starLevel 합. 일부 augment (바루스의 은총
+ *   = BoonOfStars) 가 "아군 총 별 레벨당 stat" 룰을 사용하므로 호출 측에서 미리 계산해서 전달.
+ *   미지정 시 0 (해당 augment 효과 무효).
+ */
+export function resolveAugmentEffects(
+  augments: AugmentWithStacks[],
+  starLevelSum: number = 0,
+): ItemEffect {
   const result: ItemEffect = {};
 
   for (const { augment, stackCount } of augments) {
@@ -256,8 +267,13 @@ export function resolveAugmentEffects(augments: AugmentWithStacks[]): ItemEffect
     if (teamAS != null) result.as = (result.as ?? 0) + teamAS;
 
     // === HP ===
+    // 일부 augment 는 'Health' key 를 special semantic 으로 사용 → generic 가산 skip.
+    // 예: BoonOfStars 는 Health=18 이 starLevelSum 곱셈자 (per ally) 로만 동작.
+    const HEALTH_OVERRIDE_AUGS = new Set([
+      'TFT17_Augment_VarusGodAugment_BoonOfStars',
+    ]);
     const health = ef(e, 'Health');
-    if (health != null) {
+    if (health != null && !HEALTH_OVERRIDE_AUGS.has(augment.apiName)) {
       // Glass Cannon: Health < 1 is a multiplier (0.8 = -20%), handled in per-unit
       if (health >= 1) result.hp = (result.hp ?? 0) + health;
     }
@@ -328,6 +344,16 @@ export function resolveAugmentEffects(augments: AugmentWithStacks[]): ItemEffect
         const pct = (xpPct / 100) * stacks;
         result.ad = (result.ad ?? 0) + pct;
         result.ap = (result.ap ?? 0) + pct;
+      }
+    }
+
+    // 바루스의 은총 (VarusGodAugment_BoonOfStars): 아군이 (팀 총 별 레벨 합) 당 체력 +Health.
+    // PercentIncrease (5단계 등장 확률) 는 게임-외부 효과 — 시뮬 무관.
+    // 예: starLevelSum=17, Health=18 → 각 아군 +306 flat HP.
+    if (augment.apiName === 'TFT17_Augment_VarusGodAugment_BoonOfStars') {
+      const health = ef(e, 'Health');
+      if (health != null && starLevelSum > 0) {
+        result.hp = (result.hp ?? 0) + health * starLevelSum;
       }
     }
 

--- a/tests/unit/simulator/boon-of-stars-augment.test.ts
+++ b/tests/unit/simulator/boon-of-stars-augment.test.ts
@@ -73,6 +73,39 @@ describe('PR91 — 바루스의 은총 (BoonOfStars) 효과', () => {
     expect(aatroxWith.maxHp - aatroxBase.maxHp).toBe(108);
   });
 
+  it('simulateCombat: TFT16_Galio placeholder 는 starLevelSum 에서 제외 (codex P2 회귀 가드 — PR #91)', () => {
+    // Galio 는 데마시아 결집 시 소환되는 placeholder — 전투 시작 시 보드에 없음.
+    // BoonOfStars star sum 에 포함하면 over-buff 발생.
+    const galio = champions.find((c) => c.apiName === 'TFT16_Galio');
+    if (!galio) {
+      // Galio 데이터 없으면 skip — 본 테스트는 Galio 가 catalog 에 있을 때만 의미있음.
+      return;
+    }
+    const ally: PlacedChampion[] = [
+      placed(champions.find((c) => c.apiName === 'TFT17_Aatrox')!, 0, 0, 2),
+      placed(galio, 1, 0, 3),  // Galio ★3 — 기여 안 해야
+    ];
+    const enemy: PlacedChampion[] = [
+      placed(champions.find((c) => c.apiName === 'TFT17_Aatrox')!, 6, 3),
+    ];
+    const withBoon = simulateCombat(ally, enemy, {
+      seed: 0,
+      allTraits: traits,
+      skipMirror: true,
+      playerAugments: [BOON_AUG] as RawAugment[],
+    });
+    const without = simulateCombat(ally, enemy, {
+      seed: 0,
+      allTraits: traits,
+      skipMirror: true,
+    });
+    const aatroxWith = withBoon.playerUnits.find((u) => u.champion.apiName === 'TFT17_Aatrox')!;
+    const aatroxBase = without.playerUnits.find((u) => u.champion.apiName === 'TFT17_Aatrox')!;
+    // Galio (★3) 제외하면 sum=2 (Aatrox ★2) → 18 × 2 = +36 HP.
+    // Galio 포함 잘못된 sum=5 → +90 HP. 회귀 시 90 이 나옴.
+    expect(aatroxWith.maxHp - aatroxBase.maxHp).toBe(36);
+  });
+
   it('simulateCombat: 팀이 비어있으면 BoonOfStars 효과 없음 (degenerate guard)', () => {
     // 1명만 있는 팀: starLevelSum = 1 → +18 HP
     const ally: PlacedChampion[] = [

--- a/tests/unit/simulator/boon-of-stars-augment.test.ts
+++ b/tests/unit/simulator/boon-of-stars-augment.test.ts
@@ -1,0 +1,97 @@
+/**
+ * 바루스의 은총 (TFT17_Augment_VarusGodAugment_BoonOfStars) 회귀 가드.
+ *
+ * 효과: 아군이 (팀 총 별 레벨 합) 당 체력 +Health 획득.
+ *   - effects.Health = 18 (set 17.1 데이터 기준)
+ *   - PercentIncrease (5단계 등장 확률) 는 게임-외부 — 시뮬 무관.
+ *
+ * 예: 팀에 ★3 4명 + ★2 2명 + ★1 1명 = 17 별 레벨 합.
+ *   → 각 아군 +306 flat HP (18 × 17).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveAugmentEffects, AugmentWithStacks } from '@/lib/simulator/systems/augment';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion, RawAugment } from '@/types';
+
+const { champions, traits, augments } = loadServerCatalogs();
+
+const BOON_AUG = augments.find((a) => a.apiName === 'TFT17_Augment_VarusGodAugment_BoonOfStars')!;
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: [] };
+}
+
+describe('PR91 — 바루스의 은총 (BoonOfStars) 효과', () => {
+  it('augment 데이터 존재 + Health=18, PercentIncrease=2 (set 17.1)', () => {
+    expect(BOON_AUG).toBeDefined();
+    expect(BOON_AUG.effects.Health).toBe(18);
+    expect(BOON_AUG.effects.PercentIncrease).toBe(2);
+  });
+
+  it('resolveAugmentEffects: starLevelSum=10 일 때 result.hp = 180 (18 × 10)', () => {
+    const augs: AugmentWithStacks[] = [{ augment: BOON_AUG, stackCount: 1 }];
+    const eff = resolveAugmentEffects(augs, 10);
+    expect(eff.hp).toBe(180);
+  });
+
+  it('resolveAugmentEffects: starLevelSum=0 (팀 비어있음) 일 때 hp 효과 없음', () => {
+    const augs: AugmentWithStacks[] = [{ augment: BOON_AUG, stackCount: 1 }];
+    const eff = resolveAugmentEffects(augs, 0);
+    expect(eff.hp ?? 0).toBe(0);
+  });
+
+  it('resolveAugmentEffects: starLevelSum 기본값(미전달) → hp 효과 없음', () => {
+    const augs: AugmentWithStacks[] = [{ augment: BOON_AUG, stackCount: 1 }];
+    const eff = resolveAugmentEffects(augs);
+    expect(eff.hp ?? 0).toBe(0);
+  });
+
+  it('simulateCombat: BoonOfStars 보유 팀 unit maxHp 가 baseline 대비 증가', () => {
+    const ally: PlacedChampion[] = [
+      placed(champions.find((c) => c.apiName === 'TFT17_Aatrox')!, 0, 0, 3),
+      placed(champions.find((c) => c.apiName === 'TFT17_Talon')!, 1, 0, 3),
+    ];
+    const enemy: PlacedChampion[] = [
+      placed(champions.find((c) => c.apiName === 'TFT17_Aatrox')!, 6, 3),
+    ];
+    // starLevelSum = 3 + 3 = 6 → 18 × 6 = 108 flat HP per ally
+    const withBoon = simulateCombat(ally, enemy, {
+      seed: 0,
+      allTraits: traits,
+      skipMirror: true,
+      playerAugments: [BOON_AUG] as RawAugment[],
+    });
+    const without = simulateCombat(ally, enemy, {
+      seed: 0,
+      allTraits: traits,
+      skipMirror: true,
+    });
+    const aatroxWith = withBoon.playerUnits.find((u) => u.champion.apiName === 'TFT17_Aatrox')!;
+    const aatroxBase = without.playerUnits.find((u) => u.champion.apiName === 'TFT17_Aatrox')!;
+    // +108 flat HP — 정확한 값은 다른 stat 영향 없으므로 직접 검증
+    expect(aatroxWith.maxHp - aatroxBase.maxHp).toBe(108);
+  });
+
+  it('simulateCombat: 팀이 비어있으면 BoonOfStars 효과 없음 (degenerate guard)', () => {
+    // 1명만 있는 팀: starLevelSum = 1 → +18 HP
+    const ally: PlacedChampion[] = [
+      placed(champions.find((c) => c.apiName === 'TFT17_Aatrox')!, 0, 0, 1),
+    ];
+    const enemy: PlacedChampion[] = [
+      placed(champions.find((c) => c.apiName === 'TFT17_Aatrox')!, 6, 3),
+    ];
+    const withBoon = simulateCombat(ally, enemy, {
+      seed: 0,
+      allTraits: traits,
+      skipMirror: true,
+      playerAugments: [BOON_AUG] as RawAugment[],
+    });
+    const without = simulateCombat(ally, enemy, {
+      seed: 0,
+      allTraits: traits,
+      skipMirror: true,
+    });
+    expect(withBoon.playerUnits[0].maxHp - without.playerUnits[0].maxHp).toBe(18);
+  });
+});


### PR DESCRIPTION
## Summary

PR #90 attribution 분석 Tier 1 #1 — \`TFT17_Augment_VarusGodAugment_BoonOfStars\` 구현. \`game-20260423-001\` baseline 에서 player 팀이 7 라운드 보유한 augment 인데 sim 미구현으로 stage 5+ 5/5 라운드를 잘못 예측하던 원인.

## 효과 (set 17.1)

> 아군이 아군 총합 별 레벨당 체력을 **18** 얻고, 5단계 등장 확률이 **2%** 증가합니다.

- effects: \`{ Health: 18, PercentIncrease: 2 }\`
- **Health** (전투 영향): 각 아군 +Health × (팀 별 레벨 합) flat HP
- **PercentIncrease** (게임-외부): 5단계 등장 확률, 시뮬 무관

예: ★3 4명 + ★2 2명 + ★1 1명 = 17 별 합 → 각 아군 +306 HP.

## Changes (3 파일)

| 파일 | 변경 |
|------|------|
| \`src/lib/simulator/systems/augment.ts\` | \`resolveAugmentEffects(augments, starLevelSum?)\` 시그니처 확장 + BoonOfStars 분기 + \`HEALTH_OVERRIDE_AUGS\` Set (generic 'Health' 가산 충돌 회피) |
| \`src/lib/simulator/engine/combatLoop.ts\` | playerStarLevelSum / enemyStarLevelSum 계산 → resolveAugmentEffects 에 전달 |
| \`tests/unit/simulator/boon-of-stars-augment.test.ts\` (신규) | 6 회귀 가드 |

## 영향 (\`game-20260423-001\` N=10)

| 메트릭 | Before (PR #90 baseline) | After | Δ |
|--------|---|---|---|
| winnerMatchRate | 45.5% | **50.0%** | **+4.5pt** ✅ trigger 도달 |
| avgPlayerDamageErrorPct | -52.2% | **-49.7%** | +2.5pt 개선 |
| avgSurvivorHpErrorPts | 5.77 | 8.47 | +2.7 (over-correction — 후속 진단) |

→ sim-accuracy-followups 의 \"50% trigger\" 충족. 다음 trait/augment 진행 가능.

## Verification

- pnpm typecheck ✅ 0 errors
- pnpm lint ✅ 0 errors
- pnpm vitest run ✅ 773 PASS / 0 FAIL (신규 6 가드 포함)
- pnpm build ✅
- diff cache 재측정 완료 (위 표)

## 회귀 가드 (boon-of-stars-augment.test.ts)

1. augment 데이터 — Health=18, PercentIncrease=2
2. resolveAugmentEffects starLevelSum=10 → result.hp=180
3. starLevelSum=0 → hp 효과 없음 (degenerate guard)
4. starLevelSum 미전달 (기본값 0) → hp 효과 없음
5. simulateCombat: ★3×2 (sum=6) → +108 HP per ally
6. 1 unit ★1 (sum=1) → +18 HP

## 후속 권고 (PR #90 Tier 1 잔여)

- **\`Augment_GiantAndMighty\` 구현** (player ×11) — FlatHealth + PercentHealth, tank 강화
- **\`Item_Artifact_EvelynnArtifact\` 구현** — Talon 6-2 carry slot, Talon -83% 의 일부 회복
- TwistedFate +40% 과대평가 진단 (Tier 2)

## Test plan

- [ ] 시뮬레이터에서 player 팀 augment 슬롯에 \"바루스의 은총\" 배치 후 unit maxHp 가 +Health × starLevelSum 만큼 증가 확인
- [ ] 양 팀 모두 보유 시 각자 starLevelSum 기반 독립 적용 확인 (deterministic)
- [ ] TFT17 PercentIncrease=2 는 시뮬 무관 (게임-외부 효과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)