### PR TITLE
feat(artifact): EvelynnArtifact 12% 처형 + Set 17 artifacts 기본 스탯 검증

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -323,6 +323,28 @@ function applyPermanentStacks(unit: CombatUnit, placed: PlacedChampion): void {
   }
 }
 
+/**
+ * 아이템에서 비-stat per-unit 필드 (execute threshold 등) 를 추출해 unit 에 적용.
+ * StatPatch (AD/AP/HP/AS) 는 이미 getItemEffects 에서 처리됨. 본 헬퍼는 trigger / threshold 류만.
+ *
+ * 현재 처리 대상:
+ *   - EvelynnArtifact (TFT17_Item_Artifact_EvelynnArtifact): ExecuteThresholdForTarget=0.12
+ *     장착 unit 의 기본 공격/스킬이 체력 12% 이하 적 처형. 기존 augmentExecuteThreshold 필드
+ *     재활용 (per-unit execute 임계값 합집합).
+ *
+ * 향후 다른 artifact / item 의 per-unit threshold 추가 시 본 함수에 분기 추가.
+ */
+function applyItemStaticEffects(unit: CombatUnit, placed: PlacedChampion): void {
+  for (const item of placed.items) {
+    if (item.apiName === 'TFT17_Item_Artifact_EvelynnArtifact') {
+      const threshold = item.effects['ExecuteThresholdForTarget'];
+      if (typeof threshold === 'number' && threshold > 0) {
+        unit.augmentExecuteThreshold = Math.max(unit.augmentExecuteThreshold, threshold);
+      }
+    }
+  }
+}
+
 /** 전투 시작 패시브 적용 (진 AS→AD 등) */
 function applyStartPassives(unit: CombatUnit): void {
   const sc = getChampionScaling(unit.champion.apiName);
@@ -3950,6 +3972,7 @@ export function simulateCombat(
     applyPermanentStacks(unit, swapped);
     applyCarryAugmentRange(unit, playerAugApiNames);
     applyStartPassives(unit);
+    applyItemStaticEffects(unit, swapped);
     return unit;
   });
   const enemies = enemyTeamFiltered.map((p, i) => {
@@ -3963,6 +3986,7 @@ export function simulateCombat(
     applyPermanentStacks(unit, swapped);
     applyCarryAugmentRange(unit, enemyAugApiNames);
     applyStartPassives(unit);
+    applyItemStaticEffects(unit, swapped);
     return unit;
   });
 

--- a/tests/unit/simulator/artifact-stats-applied.test.ts
+++ b/tests/unit/simulator/artifact-stats-applied.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Artifact 미구현 항목 확인 테스트 (PR #92 attribution 분석 후속).
+ *
+ * PR #90 분석에서 missing 으로 잡혔던 artifacts 의 실제 sim 적용 상태 검증.
+ * stat.ts 의 mergeLegacy + ITEM_EFFECT_KEYS 매핑으로 기본 스탯은 자동 적용됨.
+ * 본 테스트는 어느 stat 이 적용/미적용 인지 명시.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion, RawItem } from '@/types';
+
+const { champions, traits, items } = loadServerCatalogs();
+
+function findItem(api: string): RawItem | undefined {
+  return items.find((i) => i.apiName === api);
+}
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2, equips: RawItem[] = []): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: equips };
+}
+
+describe('PR93 — Artifact 기본 스탯 적용 검증 (legacy fallback)', () => {
+  const aatrox = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
+
+  it('EvelynnArtifact: AD/AP/AS/StatOmnivamp 기본 스탯이 mergeLegacy 로 적용', () => {
+    const evelynn = findItem('TFT17_Item_Artifact_EvelynnArtifact');
+    if (!evelynn) {
+      // Set 17 데이터에 없으면 skip — 본 테스트는 데이터 존재 시만 의미.
+      return;
+    }
+    expect(evelynn.effects.AD).toBeDefined();
+    expect(evelynn.effects.AP).toBeDefined();
+    expect(evelynn.effects.AS).toBeDefined();
+    expect(evelynn.effects.StatOmnivamp).toBeDefined();
+
+    const ally: PlacedChampion[] = [placed(aatrox, 0, 0, 2, [evelynn])];
+    const enemy: PlacedChampion[] = [placed(aatrox, 6, 3)];
+
+    const withItem = simulateCombat(ally, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+    const withoutItem = simulateCombat([placed(aatrox, 0, 0, 2)], enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+
+    const a = withItem.playerUnits[0];
+    const b = withoutItem.playerUnits[0];
+    // AD=0.10 (10% multiplier), AS=40 (pts? — AttackSpeed=40 is unclear; some items use frac)
+    // 어느 쪽이든 stats 가 base 보다 큰 지만 검증 (legacy fallback 동작 fingerprint).
+    expect(a.stats.damage).toBeGreaterThan(b.stats.damage);
+    expect(a.stats.attackSpeed).toBeGreaterThan(b.stats.attackSpeed);
+  });
+
+  it('AegisOfDusk: Health=400 + MagicResist=70 기본 스탯 적용', () => {
+    const aegis = findItem('TFT_Item_Artifact_AegisOfDusk');
+    if (!aegis) return;
+    expect(aegis.effects.Health).toBe(400);
+    expect(aegis.effects.MagicResist).toBe(70);
+
+    const ally: PlacedChampion[] = [placed(aatrox, 0, 0, 2, [aegis])];
+    const enemy: PlacedChampion[] = [placed(aatrox, 6, 3)];
+    const withItem = simulateCombat(ally, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+    const withoutItem = simulateCombat([placed(aatrox, 0, 0, 2)], enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+    const a = withItem.playerUnits[0];
+    const b = withoutItem.playerUnits[0];
+    // Health +400 → maxHp delta ≥ 400
+    expect(a.maxHp - b.maxHp).toBeGreaterThanOrEqual(400);
+    // MagicResist +70 → magicResist delta ≥ 70 (다른 source 없을 때 정확)
+    expect(a.stats.magicResist - b.stats.magicResist).toBeGreaterThanOrEqual(70);
+  });
+
+  it('EvelynnArtifact: ExecuteThresholdForTarget=0.12 → 12% HP 이하 적 처형 (PR93 신규)', () => {
+    const evelynn = findItem('TFT17_Item_Artifact_EvelynnArtifact');
+    if (!evelynn) return;
+    expect(evelynn.effects.ExecuteThresholdForTarget).toBeCloseTo(0.12, 5);
+
+    // 처형 가능한 시나리오 — 적 1명에 high-base-HP unit 장착자 vs 약한 enemy.
+    // Talon ★3 + EvelynnArtifact 가 최약 적을 빠르게 처형하는지 비교.
+    const talon = champions.find((c) => c.apiName === 'TFT17_Talon')!;
+    const dummyEnemy = champions.find((c) => c.apiName === 'TFT17_Talon')!;
+
+    const ally: PlacedChampion[] = [placed(talon, 0, 0, 3, [evelynn])];
+    const enemy: PlacedChampion[] = [placed(dummyEnemy, 6, 3, 1)]; // 약한 ★1 enemy
+
+    const withItem = simulateCombat(ally, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+    const withoutItem = simulateCombat([placed(talon, 0, 0, 3)], enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+
+    // EvelynnArtifact 보유 시 enemy 가 12% HP 이하에서 처형 → 더 빨리 죽음 = 전투 더 짧음.
+    // duration 비교로 검증 (정확한 tick 차이는 시뮬 변동성 있어 부등호로).
+    expect(withItem.duration).toBeLessThanOrEqual(withoutItem.duration);
+  });
+
+  it("SeekersArmguard: AP=25 + Armor=10 + MagicResist=10 기본 스탯 적용", () => {
+    const sa = findItem('TFT_Item_Artifact_SeekersArmguard');
+    if (!sa) return;
+    expect(sa.effects.AP).toBe(25);
+    expect(sa.effects.Armor).toBe(10);
+    expect(sa.effects.MagicResist).toBe(10);
+
+    const ally: PlacedChampion[] = [placed(aatrox, 0, 0, 2, [sa])];
+    const enemy: PlacedChampion[] = [placed(aatrox, 6, 3)];
+    const withItem = simulateCombat(ally, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+    const withoutItem = simulateCombat([placed(aatrox, 0, 0, 2)], enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+    const a = withItem.playerUnits[0];
+    const b = withoutItem.playerUnits[0];
+    expect(a.stats.armor - b.stats.armor).toBeGreaterThanOrEqual(10);
+    expect(a.stats.magicResist - b.stats.magicResist).toBeGreaterThanOrEqual(10);
+    expect(a.stats.ap - b.stats.ap).toBeGreaterThanOrEqual(25);
+  });
+});

--- a/tests/unit/simulator/artifact-stats-applied.test.ts
+++ b/tests/unit/simulator/artifact-stats-applied.test.ts
@@ -12,8 +12,14 @@ import type { PlacedChampion, RawChampion, RawItem } from '@/types';
 
 const { champions, traits, items } = loadServerCatalogs();
 
-function findItem(api: string): RawItem | undefined {
-  return items.find((i) => i.apiName === api);
+/**
+ * 카탈로그에서 itemApiName 검색. 데이터에서 사라지거나 rename 되면 명시적으로 fail
+ * (silent skip 회피 — codex P2 PR #93 회귀 가드).
+ */
+function requireItem(api: string): RawItem {
+  const item = items.find((i) => i.apiName === api);
+  if (!item) throw new Error(`required item missing from catalog: ${api}`);
+  return item;
 }
 
 function placed(c: RawChampion, q: number, r: number, starLevel = 2, equips: RawItem[] = []): PlacedChampion {
@@ -24,11 +30,7 @@ describe('PR93 — Artifact 기본 스탯 적용 검증 (legacy fallback)', () =
   const aatrox = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
 
   it('EvelynnArtifact: AD/AP/AS/StatOmnivamp 기본 스탯이 mergeLegacy 로 적용', () => {
-    const evelynn = findItem('TFT17_Item_Artifact_EvelynnArtifact');
-    if (!evelynn) {
-      // Set 17 데이터에 없으면 skip — 본 테스트는 데이터 존재 시만 의미.
-      return;
-    }
+    const evelynn = requireItem('TFT17_Item_Artifact_EvelynnArtifact');
     expect(evelynn.effects.AD).toBeDefined();
     expect(evelynn.effects.AP).toBeDefined();
     expect(evelynn.effects.AS).toBeDefined();
@@ -53,8 +55,7 @@ describe('PR93 — Artifact 기본 스탯 적용 검증 (legacy fallback)', () =
   });
 
   it('AegisOfDusk: Health=400 + MagicResist=70 기본 스탯 적용', () => {
-    const aegis = findItem('TFT_Item_Artifact_AegisOfDusk');
-    if (!aegis) return;
+    const aegis = requireItem('TFT_Item_Artifact_AegisOfDusk');
     expect(aegis.effects.Health).toBe(400);
     expect(aegis.effects.MagicResist).toBe(70);
 
@@ -75,17 +76,15 @@ describe('PR93 — Artifact 기본 스탯 적용 검증 (legacy fallback)', () =
   });
 
   it('EvelynnArtifact: ExecuteThresholdForTarget=0.12 → 12% HP 이하 적 처형 (PR93 신규)', () => {
-    const evelynn = findItem('TFT17_Item_Artifact_EvelynnArtifact');
-    if (!evelynn) return;
+    const evelynn = requireItem('TFT17_Item_Artifact_EvelynnArtifact');
     expect(evelynn.effects.ExecuteThresholdForTarget).toBeCloseTo(0.12, 5);
 
-    // 처형 가능한 시나리오 — 적 1명에 high-base-HP unit 장착자 vs 약한 enemy.
-    // Talon ★3 + EvelynnArtifact 가 최약 적을 빠르게 처형하는지 비교.
+    // 처형 가능한 시나리오 — Talon ★3 + EvelynnArtifact 가 약한 ★1 enemy 를 처형.
     const talon = champions.find((c) => c.apiName === 'TFT17_Talon')!;
     const dummyEnemy = champions.find((c) => c.apiName === 'TFT17_Talon')!;
 
     const ally: PlacedChampion[] = [placed(talon, 0, 0, 3, [evelynn])];
-    const enemy: PlacedChampion[] = [placed(dummyEnemy, 6, 3, 1)]; // 약한 ★1 enemy
+    const enemy: PlacedChampion[] = [placed(dummyEnemy, 6, 3, 1)];
 
     const withItem = simulateCombat(ally, enemy, {
       seed: 0, allTraits: traits, skipMirror: true,
@@ -94,14 +93,16 @@ describe('PR93 — Artifact 기본 스탯 적용 검증 (legacy fallback)', () =
       seed: 0, allTraits: traits, skipMirror: true,
     });
 
-    // EvelynnArtifact 보유 시 enemy 가 12% HP 이하에서 처형 → 더 빨리 죽음 = 전투 더 짧음.
-    // duration 비교로 검증 (정확한 tick 차이는 시뮬 변동성 있어 부등호로).
-    expect(withItem.duration).toBeLessThanOrEqual(withoutItem.duration);
+    // 결정론적 시드 (seed: 0). EvelynnArtifact 보유 시 enemy 가 처형으로 더 빨리 죽음 →
+    // 전투 duration 이 strictly 더 짧아야 한다 (codex P2 — 'toBeLessThanOrEqual' 은
+    // 동일 duration 도 통과시켜 회귀를 못 잡음).
+    expect(withItem.duration).toBeLessThan(withoutItem.duration);
+    // 전투 player 측 승리 (Talon ★3 vs ★1) — 결과 일관성 확인.
+    expect(withItem.winner).toBe('player');
   });
 
   it("SeekersArmguard: AP=25 + Armor=10 + MagicResist=10 기본 스탯 적용", () => {
-    const sa = findItem('TFT_Item_Artifact_SeekersArmguard');
-    if (!sa) return;
+    const sa = requireItem('TFT_Item_Artifact_SeekersArmguard');
     expect(sa.effects.AP).toBe(25);
     expect(sa.effects.Armor).toBe(10);
     expect(sa.effects.MagicResist).toBe(10);


### PR DESCRIPTION
## Summary

PR #90 attribution 분석 Tier 1 #3 (set 17 artifacts 인프라). 조사 결과:
- **기본 스탯 (AD/AP/AS/HP/Armor/MR/Omnivamp)** 은 stat.ts 의 \`mergeLegacy\` + \`ITEM_EFFECT_KEYS\` 매핑으로 **이미 자동 적용 중**
- **EvelynnArtifact 의 12% 처형 mechanic** (\`ExecuteThresholdForTarget=0.12\`) 만 별도 구현 필요 — 본 PR 대상

## 구현 (combatLoop.ts)

\`applyItemStaticEffects(unit, placed)\` 신규 헬퍼:
- items 에서 비-stat per-unit 필드 (execute threshold 등) 추출
- unit 생성 후 \`augmentExecuteThreshold\` 에 병합 (max 합집합)
- player/enemy unit 생성 루프에 호출 추가

EvelynnArtifact 보유 unit 의 기본 공격/스킬이 체력 12% 이하 적 처형 (기존 \`effectiveExecuteThreshold\` 로직과 통합).

## 회귀 가드 (artifact-stats-applied.test.ts, 4 건)

1. **EvelynnArtifact** AD/AP/AS/StatOmnivamp 자동 적용 (mergeLegacy fingerprint)
2. **AegisOfDusk** Health=400 + MagicResist=70 자동 적용
3. **EvelynnArtifact 12% 처형** — Talon ★3 + EvelynnArtifact vs ★1 적 → 처형으로 duration 단축
4. **SeekersArmguard** AP/Armor/MagicResist 자동 적용

## 영향 (game-20260423-001 N=10)

| 메트릭 | Before (PR #92) | After | Δ |
|--------|---|---|---|
| winnerMatchRate | 50% | 50% | (유지) |
| avgPlayerDamageErrorPct | -49.7% | -49.7% | ≈ |
| weakSignalRoundCount | 2 | 1 | -1 (한 라운드 confidence 상승) |

본 게임에서 EvelynnArtifact 보유 라운드 = Talon 6-2 단일 라운드 → 메트릭 변동 작음. **향후 보유 게임 늘어나면 임팩트 누적**. 패턴은 다른 artifact / item 의 per-unit 효과 (SeekersArmguard StatsPerTakedown 등) 에 재사용 가능.

## False negative 발견

PR #90 분석 시 \`grep apiName\` → 0 hits → "미구현" 추정. 실제로는:
- 기본 스탯 = generic key matching (legacy fallback) 으로 자동 동작
- Unique mechanic (12% 처형) 만 미구현

분석 보고서 (\`docs/meta/diff-attribution-2026-05-06.md\`) 의 false negative 회피 가이드 (PR #92 추가) 와 일치.

## Verification

- pnpm typecheck ✅ 0 errors
- pnpm lint ✅ 0 errors
- pnpm vitest run ✅ **781 PASS / 0 FAIL** (신규 4 가드 포함)
- pnpm build ✅
- diff cache 재측정: weakSignalRoundCount 2 → 1

## Test plan

- [ ] 시뮬레이터에서 Talon 또는 다른 unit 에 EvelynnArtifact 장착 후 적 HP 12% 이하일 때 처형 발동 확인
- [ ] 다른 artifacts (AegisOfDusk, SeekersArmguard) 의 기본 스탯이 sim 적용되는지 인게임 비교
- [ ] applyItemStaticEffects 패턴 — 추후 다른 per-unit item 효과 (StatsPerTakedown 등) 추가 시 재사용 가능

## 후속 작업 후보

- **TwistedFate +40% 과대평가 진단** — mana / Mountain double-count 의심 (PR #90 Tier 2)
- **SeekersArmguard StatsPerTakedown** — kill bonus stack
- **AegisOfDusk active mechanic** — MR steal + magic damage tick
- **SeraphimsStaff + ArchangelsStaff 상호작용** — 90% AP threshold 마나 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)