### PR TITLE
fix(stat): legacy AS scaling 정규화 — winnerMatch +4.5pt, dmg err +12.5pt 개선

### DIFF
--- a/src/lib/simulator/systems/stat.ts
+++ b/src/lib/simulator/systems/stat.ts
@@ -63,12 +63,27 @@ function mergeStatPatch(target: ItemEffect, patch: Partial<ItemEffect>): void {
   }
 }
 
+/**
+ * data 가 integer percentage points 로 저장하는 키 (e.g., AS=40 = +40%) — sim 은 fraction
+ * (1.0 = +100%) 사용. legacy fallback 경로에서 변환 필요.
+ *
+ * 진단 (PR #93 follow-up): set 17 데이터 53 AS 보유 items 모두 integer pts (10~100 범위).
+ * 5 items 는 registry 에 등록되어 explicit fraction (예: as: 0.45) 사용 — 정상. 나머지
+ * 48 items 는 legacy fallback 으로 흐르면서 raw integer 가 fraction 으로 잘못 적용 → +4000% AS 등
+ * 광범위 over-buff. EvelynnArtifact 의 +30.75 AS (probe) 가 대표 사례.
+ *
+ * 정규화: legacy 경로에서 'AS' / 'BonusAS' / 'AttackSpeed' 키 값이 1 이상이면 /100 (fraction 으로).
+ */
+const LEGACY_AS_KEYS = new Set(['AS', 'BonusAS', 'AttackSpeed']);
+
 function mergeLegacy(target: ItemEffect, effects: Record<string, number>): void {
   const t = target as Record<string, number>;
   for (const [key, value] of Object.entries(effects)) {
     const mapped = ITEM_EFFECT_KEYS[key];
     if (mapped && typeof value === 'number') {
-      t[mapped] = (t[mapped] ?? 0) + value;
+      // AS family: data integer pts → sim fraction. value < 1 (이미 fraction) 인 경우 그대로.
+      const normalized = (LEGACY_AS_KEYS.has(key) && value >= 1) ? value / 100 : value;
+      t[mapped] = (t[mapped] ?? 0) + normalized;
     }
   }
 }

--- a/tests/unit/simulator/legacy-as-scaling.test.ts
+++ b/tests/unit/simulator/legacy-as-scaling.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Legacy AS scaling 정규화 회귀 가드 (PR #94 fix).
+ *
+ * 진단:
+ *   - Set 17 데이터의 53 AS 보유 items 모두 integer percentage pts (10~100).
+ *   - sim 의 stat.ts 는 fraction 가정 (baseAs × (1 + itemFx.as))
+ *   - 5 items 는 registry (combined/stacking 등) 에서 explicit fraction 사용 (정상)
+ *   - 나머지 48 items (대부분 artifacts, anima squad, psyops, emblems) 는 legacy
+ *     fallback 으로 raw integer 가 fraction 으로 잘못 적용 → +4000% AS 등 over-buff.
+ *
+ * Fix: stat.ts mergeLegacy 가 AS / BonusAS / AttackSpeed 키 값이 >=1 이면 /100 정규화.
+ *
+ * 본 테스트는 fix 동작 검증 + EvelynnArtifact (AS=40) 표본으로 회귀 catch.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import { getItemEffects } from '@/lib/simulator/systems/stat';
+import type { PlacedChampion, RawChampion, RawItem } from '@/types';
+
+const { champions, traits, items } = loadServerCatalogs();
+
+function requireItem(api: string): RawItem {
+  const item = items.find((i) => i.apiName === api);
+  if (!item) throw new Error(`required item missing: ${api}`);
+  return item;
+}
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2, equips: RawItem[] = []): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: equips };
+}
+
+describe('PR94 — legacy AS scaling 정규화', () => {
+  it('getItemEffects: legacy item AS=40 → itemFx.as = 0.40 (정규화)', () => {
+    // EvelynnArtifact 는 registry 미등록 → legacy fallback. AS=40 (integer pts).
+    const evelynn = requireItem('TFT17_Item_Artifact_EvelynnArtifact');
+    expect(evelynn.effects.AS).toBe(40);
+    const itemFx = getItemEffects([evelynn]);
+    // fix 후: 0.40 (= 40/100). fix 전: 40 (그대로 — sim 에서 +4000% AS 발생).
+    expect(itemFx.as).toBeCloseTo(0.40, 5);
+  });
+
+  it('getItemEffects: 여러 legacy item AS 합산도 정규화', () => {
+    // RecurveBow (AS=10) + GuardianAngel (AS=15) → 0.10 + 0.15 = 0.25
+    const rec = requireItem('TFT_Item_RecurveBow');
+    const ga = requireItem('TFT_Item_GuardianAngel');
+    expect(rec.effects.AS).toBe(10);
+    expect(ga.effects.AS).toBe(15);
+    const itemFx = getItemEffects([rec, ga]);
+    expect(itemFx.as).toBeCloseTo(0.25, 5);
+  });
+
+  it('getItemEffects: AS < 1 (이미 fraction 인 데이터) 는 변경 없음', () => {
+    // 임의 fraction AS 를 가진 가상 RawItem 으로 검증 (실제 데이터 없을 수 있음)
+    const fakeItem: RawItem = {
+      apiName: 'fake_test_item',
+      name: 'fake',
+      desc: '',
+      icon: '',
+      composition: [],
+      effects: { AS: 0.40 },  // 이미 fraction
+    };
+    const itemFx = getItemEffects([fakeItem]);
+    expect(itemFx.as).toBeCloseTo(0.40, 5);
+  });
+
+  it('simulateCombat: EvelynnArtifact 보유 unit AS 가 합리적 범위 (×1.40 정도)', () => {
+    const evelynn = requireItem('TFT17_Item_Artifact_EvelynnArtifact');
+    const aatrox = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
+
+    const ally: PlacedChampion[] = [placed(aatrox, 0, 0, 2, [evelynn])];
+    const enemy: PlacedChampion[] = [placed(aatrox, 6, 3)];
+
+    const withItem = simulateCombat(ally, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+    const withoutItem = simulateCombat([placed(aatrox, 0, 0, 2)], enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+
+    const a = withItem.playerUnits[0];
+    const b = withoutItem.playerUnits[0];
+    const ratio = a.stats.attackSpeed / b.stats.attackSpeed;
+    // fix 전: ratio ≈ 41 (4000% over-buff). fix 후: ratio ≈ 1.40 (+40% AS).
+    // 다른 stat source 가 0 가정 시 정확히 1.40. 약간 여유두고 1.30~1.55 범위 검증.
+    expect(ratio).toBeGreaterThanOrEqual(1.30);
+    expect(ratio).toBeLessThanOrEqual(1.55);
+  });
+});


### PR DESCRIPTION
## Summary

PR #93 probe 에서 발견한 광범위 sim accuracy bug 수정. \`mergeLegacy\` 경로에서 legacy AS 값이 integer percentage points (40 = +40%) 인데 sim 은 fraction (1.0 = +100%) 으로 가정하고 있어, **48 items 가 +1000~10000% AS over-buff** 적용 중이었음.

## 진단 (set 17 데이터)

| 카테고리 | 개수 | 처리 |
|----------|------|------|
| 전체 AS 보유 items | 53 | (모두 integer pts: 10~100) |
| Registry 등록 (explicit fraction 0.45 등) | 5 | ✅ 정상 |
| Legacy fallback | **48** | ❌ +100x over-buff |

영향받는 items: artifacts 대부분 (Mittens/Fishbones/RFC artifact 등), Anima Squad Tier 2-4, PsyOps, emblems, 및 일반 items (RecurveBow, GuardianAngel, RapidFireCannon, LastWhisper, Leviathan 등).

## Fix

\`stat.ts mergeLegacy\` 에 normalize 로직:

\`\`\`ts
const LEGACY_AS_KEYS = new Set(['AS', 'BonusAS', 'AttackSpeed']);

function mergeLegacy(target: ItemEffect, effects: Record<string, number>): void {
  for (const [key, value] of Object.entries(effects)) {
    const mapped = ITEM_EFFECT_KEYS[key];
    if (mapped && typeof value === 'number') {
      // AS family: data integer pts → sim fraction (value >= 1 일 때 /100)
      const normalized = (LEGACY_AS_KEYS.has(key) && value >= 1) ? value / 100 : value;
      t[mapped] = (t[mapped] ?? 0) + normalized;
    }
  }
}
\`\`\`

이미 fraction (< 1) 인 데이터는 보존 (다른 set 호환).

## 영향 (\`game-20260423-001\` N=10)

| 메트릭 | Before (PR #93) | After | Δ |
|--------|---|---|---|
| **winnerMatchRate** | 50.0% | **54.5%** | **+4.5pt** ✅ |
| **avgPlayerDamageErrorPct** | -49.7% | **-37.2%** | **+12.5pt** ✅ |
| weakSignalRoundCount | 1 | **0** | -1 (모든 라운드 confidence high) |
| avgSurvivorHpErrorPts | 8.59 | 10.04 | +1.45 (over-correction, 후속 진단) |

→ Damage 정확도 큰 폭 개선. 모든 carry 가 잘못 over-buffed AS 받던 게 정상화.

## 회귀 가드 (legacy-as-scaling.test.ts, 4 건)

1. \`getItemEffects\` EvelynnArtifact AS=40 → itemFx.as = 0.40 (정규화 fingerprint)
2. 여러 legacy item AS 합산 (RecurveBow 10 + GuardianAngel 15 = 0.25)
3. AS < 1 (이미 fraction) 보존 — 가상 fakeItem 검증
4. simulateCombat: EvelynnArtifact 보유 unit AS ratio ≈ 1.40 (fix 전 ~41)

## Verification

- pnpm typecheck ✅ 0 errors
- pnpm lint ✅ 0 errors
- pnpm vitest run ✅ **785 PASS / 0 FAIL** (신규 4 가드 + 기존 모두)
- pnpm build ✅
- diff cache 재측정: winnerMatchRate +4.5pt / dmg err +12.5pt 개선

## 후속 작업

- Survivor HP error 증가 (+1.45) 진단 — 어떤 unit 이 너무 오래 사는지
- 다른 percentage-vs-fraction 키 (BonusAD, BonusAP 등) 점검 필요 시 동일 패턴 확장
- Anima Squad Tier 4 Omniweapon 등 AS=100 items 의 \`AD: 1\` (integer 인지 fraction 인지) 추가 점검

## Test plan

- [ ] simulator 에서 RFC/RecurveBow/GuardianAngel 등 AS-bearing item 장착 시 AS 가 합리적 범위 (×1.10~1.65 정도) 인지 확인
- [ ] EvelynnArtifact 장착 unit AS ratio ≈ 1.40 확인 (fix 전 41)
- [ ] 모든 챔프의 sim damage 가 baseline 대비 작아진 (over-buff 제거) 트렌드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)