### PR TITLE
fix(stat): legacy CritChance / AD outliers 정규화 (TF +40% 진단 후속)

### DIFF
--- a/src/lib/simulator/systems/stat.ts
+++ b/src/lib/simulator/systems/stat.ts
@@ -67,23 +67,35 @@ function mergeStatPatch(target: ItemEffect, patch: Partial<ItemEffect>): void {
  * data 가 integer percentage points 로 저장하는 키 (e.g., AS=40 = +40%) — sim 은 fraction
  * (1.0 = +100%) 사용. legacy fallback 경로에서 변환 필요.
  *
- * 진단 (PR #93 follow-up): set 17 데이터 53 AS 보유 items 모두 integer pts (10~100 범위).
- * 5 items 는 registry 에 등록되어 explicit fraction (예: as: 0.45) 사용 — 정상. 나머지
- * 48 items 는 legacy fallback 으로 흐르면서 raw integer 가 fraction 으로 잘못 적용 → +4000% AS 등
- * 광범위 over-buff. EvelynnArtifact 의 +30.75 AS (probe) 가 대표 사례.
+ * 키별 threshold (key=값, threshold 이상이면 /100 정규화):
+ *   - AS family (모두 integer pts): threshold=1
+ *   - CritChance / CritDamageBonusPercent (모두 integer pts): threshold=1
+ *   - AD family (mixed: 대부분 fraction<1, integer outliers ≥15): threshold=2
+ *     → 1.0/1.4 같은 fraction 보존, 15/30 같은 integer pts 정규화
  *
- * 정규화: legacy 경로에서 'AS' / 'BonusAS' / 'AttackSpeed' 키 값이 1 이상이면 /100 (fraction 으로).
+ * 진단 (PR #94 + 후속): set 17 데이터 ~70+ items 가 legacy fallback 으로 over-buff.
+ *   - AS: 48 items (+1000~10000% AS)
+ *   - CritChance: 19 items (cap=1 로 부분 완화되지만 정확도 손상)
+ *   - AD outliers: 4 items (FreeDeathblade=30, FreeBFSword=15 등 → +1500~3000% AD)
  */
-const LEGACY_AS_KEYS = new Set(['AS', 'BonusAS', 'AttackSpeed']);
+const LEGACY_PCT_NORM_THRESHOLDS: Record<string, number> = {
+  AS: 1, BonusAS: 1, AttackSpeed: 1,
+  CritChance: 1, CritDamageBonusPercent: 1,
+  AD: 2, BonusAD: 2,
+};
+
+function normalizeLegacyPct(key: string, value: number): number {
+  const threshold = LEGACY_PCT_NORM_THRESHOLDS[key];
+  if (threshold !== undefined && value >= threshold) return value / 100;
+  return value;
+}
 
 function mergeLegacy(target: ItemEffect, effects: Record<string, number>): void {
   const t = target as Record<string, number>;
   for (const [key, value] of Object.entries(effects)) {
     const mapped = ITEM_EFFECT_KEYS[key];
     if (mapped && typeof value === 'number') {
-      // AS family: data integer pts → sim fraction. value < 1 (이미 fraction) 인 경우 그대로.
-      const normalized = (LEGACY_AS_KEYS.has(key) && value >= 1) ? value / 100 : value;
-      t[mapped] = (t[mapped] ?? 0) + normalized;
+      t[mapped] = (t[mapped] ?? 0) + normalizeLegacyPct(key, value);
     }
   }
 }

--- a/tests/unit/simulator/legacy-as-scaling.test.ts
+++ b/tests/unit/simulator/legacy-as-scaling.test.ts
@@ -64,6 +64,30 @@ describe('PR94 — legacy AS scaling 정규화', () => {
     expect(itemFx.as).toBeCloseTo(0.40, 5);
   });
 
+  it('CritChance 정규화: NightHarvester CritChance=20 → itemFx.critChance = 0.20 (PR95)', () => {
+    const nh = requireItem('TFT_Item_NightHarvester');
+    expect(nh.effects.CritChance).toBe(20);
+    const fx = getItemEffects([nh]);
+    // fix 후: 0.20. fix 전: 20 (하지만 stat.ts cap=Math.min(1, ...) 로 +100% 로 잘림 → 부분 정확).
+    expect(fx.critChance).toBeCloseTo(0.20, 5);
+  });
+
+  it('AD 정규화: FreeBFSword AD=15 → itemFx.ad = 0.15 (PR95 — integer outlier)', () => {
+    const fbf = requireItem('TFT_Item_FreeBFSword');
+    expect(fbf.effects.AD).toBe(15);
+    const fx = getItemEffects([fbf]);
+    // fix 후: 0.15 (= +15% AD). fix 전: 15 (+1500% AD 잘못).
+    expect(fx.ad).toBeCloseTo(0.15, 5);
+  });
+
+  it('AD 정규화: SilvermereDawn AD=1.4 → itemFx.ad = 1.4 보존 (fraction <2 threshold)', () => {
+    const sd = requireItem('TFT_Item_Artifact_SilvermereDawn');
+    expect(sd.effects.AD).toBeCloseTo(1.4, 5);
+    const fx = getItemEffects([sd]);
+    // SilvermereDawn AD=1.4 는 fraction 으로 추정 (=+140% AD), 보존.
+    expect(fx.ad).toBeCloseTo(1.4, 5);
+  });
+
   it('simulateCombat: EvelynnArtifact 보유 unit AS 가 합리적 범위 (×1.40 정도)', () => {
     const evelynn = requireItem('TFT17_Item_Artifact_EvelynnArtifact');
     const aatrox = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;


### PR DESCRIPTION
## Summary

PR #94 (AS scaling fix) 후 TwistedFate +40% 진단 결과:
- **PR #94 의 AS fix 가 TF over-estimate 의 주원인** — TF +40% → **+7.3%** 으로 정상화 (AS bug 가 base AS 까지 over-buff 해서 TF 의 시뮬 데미지 inflated)
- 잔여 점검 중 비슷한 widespread bug 2건 추가 발견 → 본 PR 일괄 수정

## 추가 발견

### 1. CritChance 같은 패턴 (24 set 17 items, 모두 integer pts 20~75)
- Registry: 5 items (InfinityEdge, JeweledGauntlet, ThiefsGloves, Quicksilver, CorruptedJeweledGauntlet, CorruptedInfinityEdge) — 정상
- Legacy: **19 items** (NightHarvester, Leviathan, LastWhisper, PowerGauntlet, Vengeance, ProwlersClaw 등) — \`+2000~7500%\` crit chance (\`Math.min(1, ...)\` cap 으로 부분 완화)

### 2. AD integer outliers (4 items)
- \`FreeDeathblade=30\`, \`FreeBFSword=15\` — 명백히 integer pts → +1500~3000% AD 잘못
- \`Omniweapon=1\`, \`SilvermereDawn=1.4\` — fraction 으로 추정 (각각 +100%/+140% AD) → **보존 필요**

## Fix (stat.ts)

PR #94 의 \`LEGACY_AS_KEYS\` Set 을 키별 threshold 테이블로 확장:

\`\`\`ts
const LEGACY_PCT_NORM_THRESHOLDS: Record<string, number> = {
  // 모두 integer pts → 1 이상이면 /100
  AS: 1, BonusAS: 1, AttackSpeed: 1,
  CritChance: 1, CritDamageBonusPercent: 1,
  // mixed (대부분 fraction<1, integer outliers ≥15) → 2 이상이면 /100
  AD: 2, BonusAD: 2,
};
\`\`\`

→ AS/CritChance: 모든 integer pts 정규화. AD: 1.0/1.4 fraction 보존, 15/30 정규화.

## 회귀 가드 (+3)

기존 PR #94 4 가드에 추가:
1. \`NightHarvester\` CritChance=20 → itemFx.critChance = 0.20
2. \`FreeBFSword\` AD=15 → itemFx.ad = 0.15 (integer outlier 정규화)
3. \`SilvermereDawn\` AD=1.4 → itemFx.ad = 1.4 보존 (fraction <2 threshold)

## 영향 (\`game-20260423-001\` N=10)

| 메트릭 | After PR #94 | After PR #95 (this) | Δ |
|--------|---|---|---|
| winnerMatchRate | 54.5% | 54.5% | 0 (이미 high) |
| avgPlayerDamageErrorPct | -37.2% | -37.2% | ≈ |
| weakSignalRoundCount | 0 | 0 | 0 |
| avgSurvivorHpErrorPts | 10.04 | 10.02 | -0.02 |

이 게임에서 metric 변동 작은 이유:
- **CritChance cap=1** 이 이미 over-buff 부분 mitigation
- **AD outlier items (FreeDeathblade 등) 미보유** 본 게임 — fix 영향 없음
- 정확성 자체 회복 + 향후 다른 게임 / 아이템 보유 시 누적 임팩트

## TF +40% 진단 결과

PR #94 AS fix 단독으로 TF over-estimate 거의 해소 — **별도 TF 전용 fix 불필요**.

| Metric | 직전 (PR #93) | After AS fix (PR #94) |
|---|---|---|
| TwistedFate mean diff% | +40.2% | **+7.3%** |
| 모든 carry mean diff% | -52~-93% | -32~-83% (개선) |

## Verification

- pnpm typecheck ✅ 0 errors
- pnpm lint ✅ 0 errors
- pnpm vitest run ✅ **793 PASS / 0 FAIL** (신규 3 가드 + 기존 모두)
- pnpm build ✅
- diff cache 재측정: PR #94 baseline 거의 유지 (정확도 회복 — game-20260423-001 영향 작음)

## 후속 작업 후보

- **Talon -67% 진단** — assassin 타게팅 / 스킬 / 트레잇 점검 (가장 큰 잔여 negative)
- **Survivor HP error +1.45 진단** — 어떤 unit 이 sim 에서 오래 사는지
- 다른 stat 키 (Healing, Shield 등) percentage 점검

🤖 Generated with [Claude Code](https://claude.com/claude-code)