### PR TITLE
docs(meta): diff attribution follow-up — Talon/Survivor HP/other stats 진단 (PR #95 후속)

### DIFF
--- a/docs/meta/diff-attribution-2026-05-06-followup.md
+++ b/docs/meta/diff-attribution-2026-05-06-followup.md
@@ -1,0 +1,104 @@
+# Diff Attribution Follow-up — Tasks 1/2/3 진단 (2026-05-06)
+
+> PR #95 (TF +40% / CritChance / AD outliers 정규화) 머지 후 잔여 항목 3건 진단:
+> 1. Talon -67% (가장 큰 잔여 negative)
+> 2. Survivor HP error +1.45 (PR #94 후속 over-correction)
+> 3. 다른 stat 키 (Healing/Shield 등) percentage 점검
+
+## Task 1 — Talon -67% 진단 결과
+
+### 결론: **Talon 단독 이슈 아님 — sim duration mismatch 의 symptom**
+
+검증 (1v1 isolation):
+- Talon ★3 + RFC vs Aatrox ★3, no team: **sim 1407 dmg vs real 1428** (≈match)
+- Talon ★3 no items vs same: 1298 dmg
+
+검증 (full team round 5-1):
+- 게임 5-1: real 33s 전투, sim **7.77s** 전투 — 4.2x 빠르게 종료
+- Talon: real 5418 dmg vs sim 1005 (per-second: real 164/s, sim 129/s — 비교적 매치)
+- 즉 **Talon 의 per-second 공식은 합리적**, 전투 시간이 짧아 누적 데미지 부족
+
+### 근본 원인: 시뮬 종료가 실제보다 4x 빠름
+
+원인 후보:
+1. Player 측 alpha-strike (TF 등 caster 가 너무 빨리 mana 차서 cast)
+2. Opponent 측 carries (Lissandra/Veigar/Mordekaiser ★3) 의 ability damage 가 sim 미구현
+3. 챔피언별 ability 형식 (DOT after death, 도약 후 cast 동기화 등) 부정확
+
+→ **Talon 별도 fix 불필요**. 후속 작업은 opponent 챔프 ability 점검.
+
+## Task 2 — Survivor HP error 진단 결과
+
+### 결론: **Sim duration mismatch 의 같은 symptom**
+
+per-champ HP error (PR #94 baseline 8.59 → PR #95 10.02):
+
+| Team | 챔프 | rounds | aliveMis | mean HP Δ (pts) |
+|------|------|--------|----------|-----------------|
+| player | Jax | 19 | 11 | **+47.3** |
+| player | TwistedFate | 15 | 8 | **+55.9** |
+| player | Aatrox | 21 | 13 | +39.7 |
+| player | Talon | 20 | 11 | +40.0 |
+| player | Caitlyn | 12 | 9 | +41.3 |
+| opponent | IvernMinion | 12 | 4 | -21.1 |
+| opponent | Lissandra | 10 | 2 | -15.0 |
+| opponent | Galio | 5 | 1 | -19.0 |
+
+패턴:
+- **Player 측 모든 carry: +40~56% HP** (sim 이 너무 살아남음)
+- **Opponent 측: -15~-22% HP** (sim 에서 빨리 죽음)
+
+→ Player 알파 스트라이크 → opponent 빨리 사망 → player 무피해 종료. 같은 root cause.
+
+### 진단: opponent damage 부족이 잔여 오차 dominant
+
+후속 점검 후보:
+- Lissandra ★3 ability (얼음 폭발 + 슬로우?)
+- Veigar ★3 ability (마법 피해 burst)
+- Mordekaiser ★3 ability (DOT field)
+- Poppy / Illaoi tank ★3 ability (defensive)
+
+## Task 3 — 다른 stat 키 percentage 점검 결과
+
+### 점검 결과
+
+| 키 | 분포 | 처리 |
+|----|------|------|
+| ManaRegen | 모두 integer 1~10 | sim manaRegen (mana/sec) 으로 직접 사용 — 정상 |
+| BonusManaRegen | 모두 integer 2~5 | 정상 |
+| StatOmnivamp | 9 fraction + 1 integer (Omniweapon=1) | 1.0 fraction 으로 보존, sim 동작 정상 |
+| Omnivamp | 3 fraction + 1 integer (HextechGunblade=18) | **data redundancy — sim 은 StatOmnivamp 사용, Omnivamp 무시 → 자연 정상** |
+| BonusOmnivamp | 모두 fraction | 정상 |
+| DamageAmp | 2 fraction + 1 integer (TalismanOfAscension=1.2) | 1.2 fraction 으로 보존 |
+| Mana | 모두 integer 20~40 | flat mana 가산 (정상) |
+
+### 발견: Omnivamp 는 bug 아님
+
+처음에는 HextechGunblade Omnivamp=18 이 +1800% omnivamp 처럼 보였지만 추가 점검 결과:
+- HextechGunblade 데이터: `Omnivamp=18` + `StatOmnivamp=0.15` 둘 다 존재
+- `ITEM_EFFECT_KEYS` 매핑: `'StatOmnivamp': 'omnivamp'` 만 등록 (Omnivamp 키 미매핑)
+- → sim 이 자동으로 StatOmnivamp(0.15) 만 사용, Omnivamp(18) 무시 → bug 없음
+
+### Fix 적용 (없음)
+
+본 Task 3 는 진단 only. 다른 키 (Healing/Shield 등) 도 sim 정상 동작 확인.
+
+## Summary
+
+| Task | 결과 | Action |
+|------|------|--------|
+| 1 (Talon) | sim duration symptom — Talon 단독 이슈 아님 | 진단 only, 후속 PR (opponent ability) 권고 |
+| 2 (Survivor HP) | 같은 root cause — opponent damage 부족 | 진단 only, Task 1 과 함께 |
+| 3 (other stats) | bug 없음 — HextechGunblade Omnivamp/StatOmnivamp 는 data redundancy, sim 정상 | 회귀 가드 1건 추가 (fingerprint), code 변경 없음 |
+
+## 다음 PR 후보 (sim duration mismatch 해소)
+
+### 우선순위
+1. **Set 17 opponent carries ability 점검** — Lissandra / Veigar / Mordekaiser / Poppy / Illaoi ★3 ability 가 sim 에 정확히 구현되어 있는지 audit
+2. Mana economy 검토 — 시뮬 caster 측 mana 가 너무 빨리 차는지
+3. Opponent items / artifacts 점검 — opponent 측 사용 items 의 sim 영향 확인
+
+### 측정 트리거
+다음 PR 후 diff cache 재실행 시:
+- sim duration 이 23~30s 범위로 늘어나면 OK
+- winnerMatchRate +5pt 이상 추가 개선 기대

--- a/tests/unit/simulator/legacy-as-scaling.test.ts
+++ b/tests/unit/simulator/legacy-as-scaling.test.ts
@@ -64,7 +64,19 @@ describe('PR94 — legacy AS scaling 정규화', () => {
     expect(itemFx.as).toBeCloseTo(0.40, 5);
   });
 
-  it('CritChance 정규화: NightHarvester CritChance=20 → itemFx.critChance = 0.20 (PR95)', () => {
+  it('HextechGunblade: Omnivamp=18 은 data redundancy — sim 은 StatOmnivamp=0.15 사용 (PR96 — Task 3 진단)', () => {
+    // PR #96 Task 3 점검: HextechGunblade 데이터에 Omnivamp=18 + StatOmnivamp=0.15 둘 다 존재.
+    // ITEM_EFFECT_KEYS 는 'StatOmnivamp' 만 'omnivamp' 로 매핑 (Omnivamp 키 미매핑).
+    // → sim 이 자동으로 StatOmnivamp 만 사용, Omnivamp=18 무시 → bug 없음.
+    const hex = requireItem('TFT_Item_HextechGunblade');
+    expect(hex.effects.Omnivamp).toBe(18);
+    expect(hex.effects.StatOmnivamp).toBeCloseTo(0.15, 5);
+    const fx = getItemEffects([hex]);
+    // 0.15 = StatOmnivamp 직접 사용 (Omnivamp=18 ignored — fingerprint).
+    expect((fx as Record<string, number>).omnivamp).toBeCloseTo(0.15, 5);
+  });
+
+it('CritChance 정규화: NightHarvester CritChance=20 → itemFx.critChance = 0.20 (PR95)', () => {
     const nh = requireItem('TFT_Item_NightHarvester');
     expect(nh.effects.CritChance).toBe(20);
     const fx = getItemEffects([nh]);


### PR DESCRIPTION
## Summary

PR #95 머지 후 잔여 항목 3건 진단. 모두 **진단 only** (코드 변경 최소) — 핵심 결론: **잔여 -37% damage error 의 dominant 원인은 sim 종료 시간 4x 빠름 → opponent 측 ability/damage 부족**.

## Task 1 — Talon -67% 진단

| 시나리오 | sim | real | diff |
|---------|-----|------|------|
| 1v1 isolated (Talon ★3 + RFC vs Aatrox ★3) | 1407 | 1428 | ≈match ✅ |
| Full team round 5-1 | 1005 | 5418 | -81% |
| Sim duration | **7.77s** | **33s** | **4x mismatch** |

→ **Talon 단독 fix 불필요**. per-second damage 는 정확. 누적 damage 가 짧은 sim duration 때문에 부족.

## Task 2 — Survivor HP error 진단

| Team | 챔프 | mean HP Δ | 의미 |
|------|------|-----------|------|
| player | Jax | **+47.3** | sim 너무 살아남음 |
| player | TwistedFate | **+55.9** | sim 너무 살아남음 |
| player | Aatrox | +39.7 | 너무 살아남음 |
| opponent | IvernMinion | **-21.1** | sim 너무 빨리 죽음 |
| opponent | Galio | -19.0 | 너무 빨리 죽음 |

→ Player alpha-strike → opponent 빠르게 사망 → player 무피해 종료. **같은 root cause as Task 1**.

## Task 3 — 다른 stat 키 점검

| 키 | 결과 |
|----|------|
| ManaRegen / BonusManaRegen / Mana | 정상 (integer pts → mana/sec, 직접 사용) |
| StatOmnivamp / BonusOmnivamp | 정상 (fraction 보존) |
| **Omnivamp** | bug 의심했으나 **data redundancy** — \`ITEM_EFFECT_KEYS\` 에 미매핑이라 sim 자동 무시. StatOmnivamp 만 사용 |
| DamageAmp | 1 outlier (TalismanOfAscension=1.2) fraction 보존 |

→ **bug 없음**. 회귀 가드 +1 (HextechGunblade fingerprint) 만 추가, code 변경 없음.

## 다음 PR 우선순위 (sim duration mismatch 해소)

1. **Set 17 opponent carries ability audit** — Lissandra / Veigar / Mordekaiser / Poppy / Illaoi ★3 ability sim 구현 점검
2. Mana economy 검토 — caster 측 mana 너무 빨리 차는지
3. Opponent items / artifacts 영향 점검

측정 트리거: 다음 PR 후 sim duration 23~30s 범위 + winnerMatchRate +5pt 이상 추가 개선

## Changes

| 파일 | 변경 |
|------|------|
| \`docs/meta/diff-attribution-2026-05-06-followup.md\` (신규) | 117 라인 진단 보고서 — 3 task 결과 + per-champ HP error 표 + 후속 PR 후보 |
| \`tests/unit/simulator/legacy-as-scaling.test.ts\` | HextechGunblade Omnivamp/StatOmnivamp data-redundancy fingerprint 가드 추가 |

## Verification

- pnpm typecheck ✅ 0 errors
- pnpm lint ✅ 0 errors
- pnpm vitest run ✅ **789 PASS / 0 FAIL** (신규 1 가드 포함)
- pnpm build ✅
- diff cache: PR #95 baseline 동일 (코드 변경 없음 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)