### PR TITLE
feat(item): 쇼진의 창 FlatManaRestore=5 (caster economy fix)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -343,15 +343,14 @@ function applyItemStaticEffects(unit: CombatUnit, placed: PlacedChampion): void 
         unit.augmentExecuteThreshold = Math.max(unit.augmentExecuteThreshold, threshold);
       }
     }
-    // 쇼진의 창 (TFT_Item_SpearOfShojin): 기본 공격당 +FlatManaRestore mana.
-    // set 17 데이터 FlatManaRestore=5 → role 기본 manaPerAttack 위에 +5 가산.
+    // FlatManaRestore: 기본 공격당 추가 마나 (쇼진의 창 + 변종 / 향후 신규 아이템).
+    // apiName 분기 대신 effect key 기반 generic 처리 — 'TFT_Item_SpearOfShojin' +
+    // 'TFT_Item_CorruptedSpearOfShojin' (찬란한 변종) 모두 FlatManaRestore=5 보유 (set 17.1).
     // gainManaOnAttack 에서 unit.itemFlatManaPerAttack 합산 사용.
-    // 같은 unit 이 Shojin 여러 개 보유 시 누적 (real game stack 동작).
-    if (item.apiName === 'TFT_Item_SpearOfShojin') {
-      const fmr = item.effects['FlatManaRestore'];
-      if (typeof fmr === 'number' && fmr > 0) {
-        unit.itemFlatManaPerAttack += fmr;
-      }
+    // 같은 unit 이 여러 Shojin/Corrupted Shojin 보유 시 누적 (real game stack 동작).
+    const fmr = item.effects['FlatManaRestore'];
+    if (typeof fmr === 'number' && fmr > 0) {
+      unit.itemFlatManaPerAttack += fmr;
     }
   }
 }

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -189,6 +189,7 @@ function createCombatUnit(
     augmentGrievousWounds: 0,
     augmentExecuteThreshold: 0,
     augmentBurnPercent: 0,
+    itemFlatManaPerAttack: 0,
     inventionTankDamageAmp: 0,
     healAmp: itemFx.healAmp ?? 0,
     darkStarExecuteThreshold: 0,
@@ -340,6 +341,16 @@ function applyItemStaticEffects(unit: CombatUnit, placed: PlacedChampion): void 
       const threshold = item.effects['ExecuteThresholdForTarget'];
       if (typeof threshold === 'number' && threshold > 0) {
         unit.augmentExecuteThreshold = Math.max(unit.augmentExecuteThreshold, threshold);
+      }
+    }
+    // 쇼진의 창 (TFT_Item_SpearOfShojin): 기본 공격당 +FlatManaRestore mana.
+    // set 17 데이터 FlatManaRestore=5 → role 기본 manaPerAttack 위에 +5 가산.
+    // gainManaOnAttack 에서 unit.itemFlatManaPerAttack 합산 사용.
+    // 같은 unit 이 Shojin 여러 개 보유 시 누적 (real game stack 동작).
+    if (item.apiName === 'TFT_Item_SpearOfShojin') {
+      const fmr = item.effects['FlatManaRestore'];
+      if (typeof fmr === 'number' && fmr > 0) {
+        unit.itemFlatManaPerAttack += fmr;
       }
     }
   }
@@ -3108,6 +3119,7 @@ function spawnFreljordTurrets(
             augmentGrievousWounds: 0,
             augmentExecuteThreshold: 0,
             augmentBurnPercent: 0,
+            itemFlatManaPerAttack: 0,
             inventionTankDamageAmp: 0,
             healAmp: 0,
             darkStarExecuteThreshold: 0,
@@ -3308,6 +3320,7 @@ function trySpawnGalio(
     augmentGrievousWounds: 0,
     augmentExecuteThreshold: 0,
     augmentBurnPercent: 0,
+    itemFlatManaPerAttack: 0,
     inventionTankDamageAmp: 0,
     healAmp: 0,
     darkStarExecuteThreshold: 0,

--- a/src/lib/simulator/systems/mana.ts
+++ b/src/lib/simulator/systems/mana.ts
@@ -50,7 +50,10 @@ export function gainManaOnAttack(unit: CombatUnit): void {
   if (isStunned) return;
 
   const config = getManaConfig(unit.role);
-  const gain = config.manaPerAttack * channelerMultiplier(unit);
+  // 쇼진의 창 등 아이템 보너스 (FlatManaRestore) 누적 — applyItemStaticEffects 에서
+  // 미리 unit.itemFlatManaPerAttack 으로 집계해둠. role 기본값 + item 보너스, channeler 곱셈자.
+  const baseGain = config.manaPerAttack + (unit.itemFlatManaPerAttack ?? 0);
+  const gain = baseGain * channelerMultiplier(unit);
   unit.currentMana = Math.min(unit.maxMana, unit.currentMana + gain);
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -501,6 +501,11 @@ export interface CombatUnit {
   augmentGrievousWounds: number;
   augmentExecuteThreshold: number;
   augmentBurnPercent: number;
+  /**
+   * 아이템에서 부여되는 공격당 추가 마나 (집계). 쇼진의 창 FlatManaRestore=5 등.
+   * gainManaOnAttack 에서 role 기본값에 더해진다. 기본 0.
+   */
+  itemFlatManaPerAttack: number;
   /** 발명품 탱커 대상 추가 피해증폭 (ArmorNullifier) */
   inventionTankDamageAmp: number;
   /**

--- a/tests/unit/simulator/shojin-mana-restore.test.ts
+++ b/tests/unit/simulator/shojin-mana-restore.test.ts
@@ -55,6 +55,21 @@ describe('PR97 — 쇼진의 창 FlatManaRestore', () => {
     expect(lissWith.totalDamageDealt).toBeGreaterThanOrEqual(lissWithout.totalDamageDealt);
   });
 
+  it('Corrupted Shojin 도 FlatManaRestore=5 동일 처리 (codex P2 PR #97 회귀 가드)', () => {
+    // apiName-specific 분기는 변종 누락 위험 — effect key (FlatManaRestore) 기반 generic 처리.
+    const corrupted = requireItem('TFT_Item_CorruptedSpearOfShojin');
+    expect(corrupted.effects.FlatManaRestore).toBe(5);
+    const liss = champions.find((c) => c.apiName === 'TFT17_Lissandra')!;
+    const aatrox = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
+    const r = simulateCombat(
+      [placed(liss, 0, 0, 3, [corrupted])],
+      [placed(aatrox, 6, 3, 3)],
+      { seed: 0, allTraits: traits, skipMirror: true },
+    );
+    // 정상 Shojin 과 동일하게 +5 mana per attack 적용되어 itemFlatManaPerAttack 누적.
+    expect(r.playerUnits[0].itemFlatManaPerAttack).toBe(5);
+  });
+
   it('itemFlatManaPerAttack 필드: Shojin × 2 = 10 (누적 stack)', () => {
     // 같은 unit 이 Shojin 2개 (real game 가능) → mana per attack +10.
     const liss = champions.find((c) => c.apiName === 'TFT17_Lissandra')!;

--- a/tests/unit/simulator/shojin-mana-restore.test.ts
+++ b/tests/unit/simulator/shojin-mana-restore.test.ts
@@ -1,0 +1,70 @@
+/**
+ * 쇼진의 창 (TFT_Item_SpearOfShojin) FlatManaRestore=5 회귀 가드 (PR97).
+ *
+ * PR #96 진단: caster carry (Lissandra/Veigar) 가 Shojin 보유 시 real 게임 mana
+ * 빠르게 차서 자주 cast. sim 미구현으로 cast 빈도 부족 → opponent damage 부족 →
+ * sim duration 4x 빠름.
+ *
+ * Fix: applyItemStaticEffects 가 Shojin 의 FlatManaRestore=5 를 unit.itemFlatManaPerAttack
+ * 에 누적 → gainManaOnAttack 에서 role manaPerAttack + 아이템 보너스.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion, RawItem } from '@/types';
+
+const { champions, traits, items } = loadServerCatalogs();
+
+function requireItem(api: string): RawItem {
+  const item = items.find((i) => i.apiName === api);
+  if (!item) throw new Error(`required item missing: ${api}`);
+  return item;
+}
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2, equips: RawItem[] = []): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: equips };
+}
+
+describe('PR97 — 쇼진의 창 FlatManaRestore', () => {
+  it('Shojin 데이터 FlatManaRestore=5 (set 17.1)', () => {
+    const shojin = requireItem('TFT_Item_SpearOfShojin');
+    expect(shojin.effects.FlatManaRestore).toBe(5);
+  });
+
+  it('simulateCombat: Shojin 보유 caster 가 더 자주 cast', () => {
+    // Lissandra ★3 (caster, mana=30) Shojin 1 vs no item — castCount 비교.
+    const liss = champions.find((c) => c.apiName === 'TFT17_Lissandra')!;
+    const aatrox = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
+    const shojin = requireItem('TFT_Item_SpearOfShojin');
+    // 충분히 긴 baseline 시간 확보 위해 ★3 tank 적
+    const enemy = [placed(aatrox, 6, 3, 3)];
+
+    const withShojin = simulateCombat([placed(liss, 0, 0, 3, [shojin])], enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+    const withoutShojin = simulateCombat([placed(liss, 0, 0, 3)], enemy, {
+      seed: 0, allTraits: traits, skipMirror: true,
+    });
+
+    const lissWith = withShojin.playerUnits[0];
+    const lissWithout = withoutShojin.playerUnits[0];
+
+    // Shojin 보유 시 castCount 더 많아야 한다 (또는 같음 — 이미 짧은 sim 에서 1회 cast 라면).
+    // strict 비교 어려운 경우 totalDamageDealt 가 더 큼 fingerprint 사용.
+    expect(lissWith.castCount).toBeGreaterThanOrEqual(lissWithout.castCount);
+    expect(lissWith.totalDamageDealt).toBeGreaterThanOrEqual(lissWithout.totalDamageDealt);
+  });
+
+  it('itemFlatManaPerAttack 필드: Shojin × 2 = 10 (누적 stack)', () => {
+    // 같은 unit 이 Shojin 2개 (real game 가능) → mana per attack +10.
+    const liss = champions.find((c) => c.apiName === 'TFT17_Lissandra')!;
+    const aatrox = champions.find((c) => c.apiName === 'TFT17_Aatrox')!;
+    const shojin = requireItem('TFT_Item_SpearOfShojin');
+    const r = simulateCombat(
+      [placed(liss, 0, 0, 3, [shojin, shojin])],
+      [placed(aatrox, 6, 3, 3)],
+      { seed: 0, allTraits: traits, skipMirror: true },
+    );
+    expect(r.playerUnits[0].itemFlatManaPerAttack).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary

PR #96 attribution 진단 결과 sim 종료 4x 빠름 root cause 의 한 부분: caster carries (Lissandra/Veigar) 가 Shojin 보유 시 real game 에서 mana 빠르게 차서 자주 cast — sim 에서는 Shojin 의 \`FlatManaRestore\` 미구현으로 mana 보너스 빠짐.

## 진단 (opponent carries audit)

| 챔프 | role | sim ★3 ability 데미지 | 비고 |
|------|------|---------------------|------|
| Lissandra | APCaster | Damage=600 (정상) | Shojin 보유, mana 부족 → cast 빈도 부족 |
| Veigar | APCaster | Damage=700 (정상) | Astronaut + 복제자 trait — 정상 |
| Mordekaiser | APTank | DamagePerProc=100 × 4s = 400 (정상) | dot 정상 |
| **Poppy** | APTank | **damageVar=Shield=575 잘못** ⚠️ | parseAbility 가 'Shield' 를 damage 로 사용 (real ability 데미지 0). 별도 PR 후보 |
| Illaoi | APTank | Damage=180 + dot 3s (≈정상) | health drain 미구현 (별도) |

→ **Lissandra/Veigar mana economy 가 dominant cause**. Shojin 미구현 fix 로 caster 빈도 회복.

## 구현

### 1. \`CombatUnit.itemFlatManaPerAttack\` 필드 추가 (types/index.ts)

\`\`\`ts
itemFlatManaPerAttack: number;  // Shojin FlatManaRestore=5 등 누적
\`\`\`

### 2. \`applyItemStaticEffects\` 확장 (combatLoop.ts)

\`\`\`ts
if (item.apiName === 'TFT_Item_SpearOfShojin') {
  const fmr = item.effects['FlatManaRestore'];
  if (typeof fmr === 'number' && fmr > 0) {
    unit.itemFlatManaPerAttack += fmr;
  }
}
\`\`\`

### 3. \`gainManaOnAttack\` 합산 (mana.ts)

\`\`\`ts
const baseGain = config.manaPerAttack + (unit.itemFlatManaPerAttack ?? 0);
const gain = baseGain * channelerMultiplier(unit);
\`\`\`

## 영향 (\`game-20260423-001\` N=10)

| 메트릭 | After PR #95 | After PR97 | Δ |
|--------|---|---|---|
| winnerMatchRate | 54.5% | 54.5% | 0 |
| avgPlayerDamageErrorPct | -37.2% | -37.3% | ≈ |
| **avgSurvivorHpErrorPts** | 10.04 | **9.82** | **-0.22 개선** |

→ opponent caster (Lissandra/Veigar) 가 자주 cast → player 측 더 많은 damage 받음 → 생존 HP 낮아져 actual 에 가까워짐. game-20260423-001 player team 이 Shojin 미보유라 player damage 변동 없음.

## 회귀 가드 (shojin-mana-restore.test.ts, 3 건)

1. Shojin 데이터 FlatManaRestore=5 (set 17.1)
2. simulateCombat: Shojin 보유 caster castCount + damage 증가
3. Shojin × 2 stack 누적 → itemFlatManaPerAttack=10

## 후속 작업 후보 (caster economy)

- **ArchangelsStaff APPerInterval=20** (5초마다 AP +20%) — 미구현
- **Poppy damageVar='Shield' 잘못 사용** — parseAbility 수정 또는 explicit damageVar='none'
- **Illaoi HealthDrain** — true damage drain mechanic 미구현
- Set 17 신규 caster 아이템들 점검 (BlueBuff ModifiedADAP 등)

## Verification

- pnpm typecheck ✅ 0 errors
- pnpm lint ✅ 0 errors
- pnpm vitest run ✅ **792 PASS / 0 FAIL**
- pnpm build ✅
- diff cache: survivor HP -0.22 개선

## Test plan

- [ ] simulator 에서 caster (Lissandra/Veigar) 에 Shojin 장착 시 cast 빈도 증가 확인
- [ ] Shojin × 2 stack 시 mana 누적 확인 (real game 동작)
- [ ] BlueBuff (ManaRegen=5) 와 Shojin 조합 시 시너지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)