### PR TITLE
docs: CLAUDE.md role-passive 룰 갱신 (lint findings 3건)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,10 @@ React Compiler의 자동 메모이제이션과 충돌하여 의도치 않은 동
 
 **2단계 — Role 타이브레이커** (동거리 유닛이 여러 명일 때):
 ```
-Tank (weight=3) > Fighter/Marksman/Caster/Specialist (weight=2) > Assassin (weight=1)
+Tank (weight=3) > Fighter/Assassin (weight=2) > Marksman/Caster/Specialist (weight=1)
 ```
+
+> 위 가중치는 `src/lib/simulator/systems/targeting.ts:TARGETING_WEIGHT` ground truth 기준. 자세한 흐름은 위키 `docs/meta/wiki/mechanics/role-passive.md` 참조.
 
 **타게팅 오버라이드 조건** (우선순위 높은 순):
 1. 도발(Taunt) 효과 → 강제 어그로 전환
@@ -160,9 +162,13 @@ Tank (weight=3) > Fighter/Marksman/Caster/Specialist (weight=2) > Assassin (weig
 | Marksman | 10 | 0 | ❌ |
 | Caster | 7 | 2 | ❌ |
 | Assassin | 10 | 0 | ❌ |
-| Specialist | 고유 | 고유 | 고유 |
+| Specialist | 10 | 0 | ❌ |
 
-Caster는 CC(스턴 등)로 공격이 막히면 마나 획득이 완전 중단됨에 주의.
+> Specialist는 위 표준값 (Fighter/Marksman/Assassin 와 동일) 으로 분기되며, 챔프별 고유 메커니즘은 ability 레벨에서 처리한다. ground truth: `src/lib/simulator/systems/mana.ts:ROLE_MANA_CONFIG`.
+
+**CC 상태 시 마나 차단** — 스턴 등 CC 가 적용되면 **모든 role**이 공격 마나 획득 중단 (`gainManaOnAttack` 의 `isStunned` 가드). Caster는 추가로 초당 마나(`gainManaPerTick`)도 차단되어 영향이 가장 큼.
+
+> 마나/타게팅 시스템 전체 흐름·아이템·trait 보너스는 위키 `docs/meta/wiki/mechanics/role-passive.md` 참조.
 
 ---
 


### PR DESCRIPTION
## Summary

[[role-passive]] 위키 ingest (PR #111) 중 검출된 **CLAUDE.md vs 코드 stale 3건** 을 CLAUDE.md 측에 반영. sim 동작은 코드 기준이므로 CLAUDE.md 를 ground truth 에 맞춤.

## Lint findings 3건 — 갱신 내역

### 1. Targeting weight 5/6 role mismatch (`타게팅 시스템 핵심 원칙`)

**before** (CLAUDE.md L141):
```
Tank (weight=3) > Fighter/Marksman/Caster/Specialist (weight=2) > Assassin (weight=1)
```

**after**:
```
Tank (weight=3) > Fighter/Assassin (weight=2) > Marksman/Caster/Specialist (weight=1)
```

ground truth: `src/lib/simulator/systems/targeting.ts:TARGETING_WEIGHT`
```ts
Tank: 3, Fighter: 2, Assassin: 2, Marksman: 1, Caster: 1, Specialist: 1
```

### 2. Specialist 마나 "고유" → 표준값 (`Role별 마나 획득 규칙`)

**before** (CLAUDE.md L163):
```
| Specialist | 고유 | 고유 | 고유 |
```

**after**:
```
| Specialist | 10 | 0 | ❌ |
```

+ 노트 추가: "Specialist는 표준값 (Fighter/Marksman/Assassin 동일)으로 분기되며, 챔프별 고유 메커니즘은 ability 레벨에서 처리한다."

ground truth: `src/lib/simulator/systems/mana.ts:ROLE_MANA_CONFIG.Specialist` = `{ manaPerAttack: 10, manaPerSecond: 0, manaFromDamage: false }`

### 3. CC-마나 차단 범위 (`Role별 마나 획득 규칙` 끝)

**before** (CLAUDE.md L165):
> Caster는 CC(스턴 등)로 공격이 막히면 마나 획득이 완전 중단됨에 주의.

**after**:
> **CC 상태 시 마나 차단** — 스턴 등 CC 가 적용되면 **모든 role**이 공격 마나 획득 중단 (`gainManaOnAttack` 의 `isStunned` 가드). Caster는 추가로 초당 마나(`gainManaPerTick`)도 차단되어 영향이 가장 큼.

ground truth: `src/lib/simulator/systems/mana.ts` 의 `isStunned` 가드는 모든 role 의 `gainManaOnAttack` / `gainManaPerTick` 진입점에 있음.

## 추가 사항

양 섹션 끝에 wiki 페이지 `docs/meta/wiki/mechanics/role-passive.md` (PR #111) 참조 추가. PR #111 머지 후 위키 페이지가 dev 에 들어오면 완전 동기.

## 변경 통계

- 1 파일 (CLAUDE.md), +9 / -3 lines
- 코드 변경 없음 — 문서만

## Review checklist

- [ ] 3 finding 각각이 코드 ground truth 와 일치하는지 재확인
- [ ] Patch 15.1 Riot spec 자체가 코드와 다를 가능성 (즉 "코드가 잘못된 거 아닌가?") 검토 — sim 정확도 이슈라면 별도 PR
- [ ] CLAUDE.md 외 다른 곳에 동일 stale 텍스트가 있는지 (없을 것이지만 안전 확인)

## 연관 PR

- PR #111 (`feat/llm-wiki-bootstrap` → `dev`) — `role-passive.md` 위키 페이지 ingest. 본 PR 의 갱신 근거 데이터 제공

🤖 Generated with [Claude Code](https://claude.com/claude-code)