### PR TITLE
fix(sim): carryAugments.ts 17.3 LIVE 정합 — Leona/Mord/Jax/Aatrox/IvernMinion 5건

### DIFF
--- a/src/data/carryAugments.ts
+++ b/src/data/carryAugments.ts
@@ -116,6 +116,8 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
     abilityOverride: { pattern: 'single' },
     damageTypeOverride: 'physical',
     scalingInput: { label: '처치 수', unit: '회', max: 999, effectPerStack: '피해량 +10' },
+    // TODO 17.3: 패치노트 "Bonk! Resists: 40 → 45" — augment grant 인지 champion baseline 변경인지 모호.
+    // statOverrides 채움 정책 (사용자 인게임 측정 후 적용) — 인게임 verify 후 statOverrides.armor/magicResist 설정 결정.
     abilityData: {
       name: '꽁!',
       desc: '대상에게 물리 피해를 입힙니다. 이 스킬로 적을 처치하면 스킬 피해량이 영구적으로 증가합니다.',
@@ -132,15 +134,15 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
     damageTypeOverride: 'physical',
     abilityData: {
       name: '별빛 연계',
-      desc: '세 가지 스킬을 번갈아 사용합니다.\n타격: 물리 피해\n휩쓸기: 원뿔 범위 물리 피해 + 방어력 감소\n찍기: 반경 1칸 피해 + 공중 띄움 (단독 적중 시 250%)\nN.O.V.A. 활성 시: 전장 가르고 모든 적 공중 띄움 + 추가 타격',
+      desc: '세 가지 스킬을 번갈아 사용합니다.\n타격: 물리 피해\n휩쓸기: 원뿔 범위 물리 피해 + 방어력 감소\n찍기: 반경 1칸 피해 + 공중 띄움 (단독 적중 시 200%)\nN.O.V.A. 활성 시: 전장 가르고 모든 적 공중 띄움 + 추가 타격',
       mana: '30/90',
       damage: [140, 210, 315], // 타격 (cycle 0)
-      secondaryDamage: [100, 150, 225], // 휩쓸기 (cycle 1)
-      slamDamage: [160, 240, 360], // 찍기 (cycle 2) — PR7-C 추가
+      secondaryDamage: [110, 165, 275], // 휩쓸기 (cycle 1) — 17.3: 100/150/225 → 110/165/275
+      slamDamage: [200, 300, 475], // 찍기 (cycle 2) — PR7-C 추가. 17.3: 160/240/360 → 200/300/475
       slamStunDuration: 1.0, // 찍기 공중 띄움 (knockup → stun) — PR7-C 추가
       armorReduction: 10, // 휩쓸기 armor 감소 (AP 스케일)
       novaDamage: [120, 180, 270], // N.O.V.A. 타격
-      singleTargetMultiplier: 2.5, // 찍기 단독 적중 시 250%
+      singleTargetMultiplier: 2.0, // 찍기 단독 적중 시 200% — 17.3: 2.5 → 2.0 (isolation multiplier nerf)
       damageType: 'physical',
       skillCycleLabels: ['타격', '휩쓸기', '찍기'] as const,
     },
@@ -149,6 +151,8 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
     augmentApiName: 'TFT17_Augment_PoppyCarry',
     targetChampionApiName: 'TFT17_Poppy',
     // 정령단 속도: ranged projectile (rangeOverride=4). dash 없음 — 사거리 증가가 핵심.
+    // TODO 17.3: 패치노트 "Termeepnal Velocity AS: 0.7 → 0.75" — augment 활성 시 Poppy AS 값.
+    // statOverrides.attackSpeed = 0.75 로 적용해야 하는지 vs base AS 곱셈자인지 모호. 인게임 verify 필요.
     abilityOverride: { pattern: 'single' },
     rangeOverride: 4,
     damageTypeOverride: 'physical',
@@ -170,14 +174,14 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
     damageTypeOverride: 'physical',
     abilityData: {
       name: '방패 여전사',
-      desc: '2초 동안 보호막. 최대 3칸 돌진해 적이 가장 많은 일직선 타격 (탱커 우선). 첫 적중: AD + 28% 최대체력 + 기절. 추가 대상: AD damage. (17.2b 너프)',
+      desc: '2초 동안 보호막. 최대 3칸 돌진해 적이 가장 많은 일직선 타격 (탱커 우선). 첫 적중: AD + 24% 최대체력 + 기절. 추가 대상: AD damage. (17.3: HP ratio 28%→24%, secondary 180/270/405→200/300/480)',
       mana: '50/110',
       damage: [90, 135, 225], // 17.2b: 110/165/250 → 90/135/225
       shield: [200, 240, 280],
       shieldDuration: 2,
-      baseDamageHpFrac: 0.28, // primary damage 에 maxHp 28% 가산
+      baseDamageHpFrac: 0.24, // primary damage 에 maxHp 24% 가산 — 17.3: 0.28 → 0.24
       stunDuration: [1.0, 1.25, 1.5],
-      secondaryDamage: [180, 270, 405],
+      secondaryDamage: [200, 300, 480], // 17.3: 180/270/405 → 200/300/480
       damageType: 'physical',
     },
   },
@@ -188,11 +192,11 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
     abilityOverride: { pattern: 'aoe_circle', radius: 3, dash: 'to_largest_cluster' },
     abilityData: {
       name: '빅뱅',
-      desc: '주문력 전사로 변환. 패시브: 기본 공격당 추가 magic damage (미프 시너지 잠재력 스케일). 사용: 2칸 내 가장 큰 적 무리에 도약, 반경 3칸 magic damage (1칸당 45% 감소), 가장 가까운 3명 1.25/1.5/1.75초 공중 띄움.',
+      desc: '주문력 전사로 변환. 패시브: 기본 공격당 추가 magic damage (미프 시너지 잠재력 스케일). 사용: 2칸 내 가장 큰 적 무리에 도약, 반경 3칸 magic damage (1칸당 35% 감소), 가장 가까운 3명 1.25/1.5/1.75초 공중 띄움.',
       mana: '50/100',
       damage: [240, 360, 560],
       onAttackBonus: [40, 60, 90],
-      hexReduction: 0.45,
+      hexReduction: 0.35, // 17.3: 0.45 → 0.35 (Big Bang falloff per hex)
       stunDuration: [1.25, 1.5, 1.75],
       spiritEffectPerStack: 0,
       damageType: 'magic',
@@ -206,7 +210,7 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
       name: '저 별을 향해',
       desc: '주문력 전사로 변환. 패시브: 기본 공격당 추가 magic damage. 사용: 대상 magic damage + 영구 AS/MS +15/15/20% (전투 종료까지 누적).',
       mana: '20/80',
-      damage: [155, 230, 375],
+      damage: [170, 250, 450], // 17.3: 155/230/375 → 170/250/450
       onAttackBonus: [45, 70, 105],
       asGain: [0.15, 0.15, 0.20],
       damageType: 'magic',
@@ -236,13 +240,13 @@ export const CARRY_AUGMENTS: CarryAugmentConfig[] = [
     abilityOverride: { pattern: 'aoe_circle', radius: 1 },
     abilityData: {
       name: '뜨거운 죽음',
-      desc: '주문력 전사로 변환. 패시브: 매초 반경 N칸 magic damage (시작 1, 6초마다 +1). 사용: 보호막 + 4초 동안 오라 damage 강화. (17.2b: shield 175/200/250 → 225/250/300)',
-      mana: '40/100',
+      desc: '주문력 전사로 변환. 패시브: 매초 반경 N칸 magic damage (시작 1, 6초마다 +1). 사용: 보호막 + 4초 동안 오라 damage 강화. (17.3: shield 225/250/300 → 175/200/400, mana 40/100 → 10/40)',
+      mana: '10/40',
       damage: [50, 75, 115], // 사용 시 오라 damage
       passiveDamage: [20, 30, 45], // 패시브 오라
       empoweredAuraDamage: [50, 75, 115],
       empoweredDuration: 4,
-      shield: [225, 250, 300], // 17.2b: 175/200/250 → 225/250/300
+      shield: [175, 200, 400], // 17.3: 225/250/300 → 175/200/400 (3성 대폭 buff, 1/2성 nerf)
       damageType: 'magic',
     },
   },

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -53,23 +53,25 @@ describe('CARRY_AUGMENTS 카탈로그 — 8 영웅 증강 abilityData 정의', (
     expect(gragas?.abilityData?.hexReduction).toBe(0.45);
   });
 
-  it('17.2b — 모데카이저 뜨거운 죽음: shield = [225, 250, 300]', () => {
+  it('17.3 — 모데카이저 뜨거운 죽음: shield = [175, 200, 400], mana 10/40', () => {
     const morde = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_MordekaiserCarry');
-    expect(morde?.abilityData?.shield).toEqual([225, 250, 300]);
+    expect(morde?.abilityData?.shield).toEqual([175, 200, 400]);
+    expect(morde?.abilityData?.mana).toBe('10/40');
   });
 
-  it('17.2b — 레오나 방패 여전사: damage = [90, 135, 225]', () => {
+  it('17.3 — 레오나 방패 여전사: HP ratio 24%, secondary [200,300,480] (17.3 nerf)', () => {
     const leona = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_LeonaCarry');
-    expect(leona?.abilityData?.damage).toEqual([90, 135, 225]);
+    expect(leona?.abilityData?.damage).toEqual([90, 135, 225]); // 17.2b 값 — 17.3 변경 없음
     expect(leona?.abilityData?.shield).toEqual([200, 240, 280]);
-    expect(leona?.abilityData?.baseDamageHpFrac).toBeCloseTo(0.28, 2);
+    expect(leona?.abilityData?.baseDamageHpFrac).toBeCloseTo(0.24, 2); // 17.3: 0.28 → 0.24
+    expect(leona?.abilityData?.secondaryDamage).toEqual([200, 300, 480]); // 17.3: [180,270,405] → [200,300,480]
   });
 
-  it('잭스 저 별을 향해: asGain starLevel 별 [0.15, 0.15, 0.20]', () => {
+  it('17.3 — 잭스 저 별을 향해: damage [170,250,450] (17.3 buff)', () => {
     const jax = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_JaxCarry');
     expect(jax?.abilityData?.asGain).toEqual([0.15, 0.15, 0.20]);
     expect(jax?.abilityData?.onAttackBonus).toEqual([45, 70, 105]);
-    expect(jax?.abilityData?.damage).toEqual([155, 230, 375]);
+    expect(jax?.abilityData?.damage).toEqual([170, 250, 450]); // 17.3: [155,230,375] → [170,250,450]
   });
 
   it('파이크 청부 살인마: tankBonus 0.60 + onKillRecast 0.70', () => {
@@ -79,11 +81,13 @@ describe('CARRY_AUGMENTS 카탈로그 — 8 영웅 증강 abilityData 정의', (
     expect(pyke?.abilityData?.secondaryDamage).toEqual([60, 90, 135]);
   });
 
-  it('아트록스 별빛 연계: 3-skill cycle + N.O.V.A. 변수', () => {
+  it('17.3 — 아트록스 별빛 연계: 3-skill cycle + secondary/slam buff + isolation nerf', () => {
     const aatrox = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_AatroxCarry');
     expect(aatrox?.abilityData?.skillCycleLabels).toEqual(['타격', '휩쓸기', '찍기']);
     expect(aatrox?.abilityData?.novaDamage).toEqual([120, 180, 270]);
-    expect(aatrox?.abilityData?.singleTargetMultiplier).toBe(2.5);
+    expect(aatrox?.abilityData?.secondaryDamage).toEqual([110, 165, 275]); // 17.3: [100,150,225] → [110,165,275]
+    expect(aatrox?.abilityData?.slamDamage).toEqual([200, 300, 475]); // 17.3: [160,240,360] → [200,300,475]
+    expect(aatrox?.abilityData?.singleTargetMultiplier).toBe(2.0); // 17.3: 2.5 → 2.0 (isolation nerf)
   });
 
   it('뽀삐 정령단 속도: armorScale 1.0 + spiritBounceOnKill', () => {
@@ -93,9 +97,9 @@ describe('CARRY_AUGMENTS 카탈로그 — 8 영웅 증강 abilityData 정의', (
     expect(poppy?.abilityData?.damage).toEqual([340, 510, 850]);
   });
 
-  it('꼬마정령 빅뱅: hexReduction + stunDuration', () => {
+  it('17.3 — 꼬마정령 빅뱅: hexReduction 0.35 (17.3 nerf) + stunDuration', () => {
     const ivern = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_IvernMinionCarry');
-    expect(ivern?.abilityData?.hexReduction).toBe(0.45);
+    expect(ivern?.abilityData?.hexReduction).toBe(0.35); // 17.3: 0.45 → 0.35 (Big Bang falloff per hex)
     expect(ivern?.abilityData?.stunDuration).toEqual([1.25, 1.5, 1.75]);
     expect(ivern?.abilityData?.onAttackBonus).toEqual([40, 60, 90]);
   });
@@ -545,15 +549,15 @@ describe('PR7-A — 파이크 carry X-shape 멀티 타겟 + onKill cascade', () 
 //   - N.O.V.A. 타격: 기존 cycle 유지 + 별도 추가 효과 (모든 적 novaDamage 물리 + 1초 knockup)
 //   - "타격 선택기": simulateOptions.{player,enemy}NovaStrikeSelectorUnit 사용자 지정
 describe('PR7-C — 아트록스 carry 3-skill cycle + N.O.V.A. 추가 발동', () => {
-  it('AatroxCarry abilityData 핵심 변수 (PR7-C 시뮬 의존)', () => {
+  it('AatroxCarry abilityData 핵심 변수 (PR7-C 시뮬 의존, 17.3 수치)', () => {
     const aatrox = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_AatroxCarry');
-    expect(aatrox?.abilityData?.damage).toEqual([140, 210, 315]);          // 타격
-    expect(aatrox?.abilityData?.secondaryDamage).toEqual([100, 150, 225]); // 휩쓸기
-    expect(aatrox?.abilityData?.slamDamage).toEqual([160, 240, 360]);      // 찍기 (PR7-C 추가)
+    expect(aatrox?.abilityData?.damage).toEqual([140, 210, 315]);          // 타격 (cycle 0) — 17.3 변경 없음
+    expect(aatrox?.abilityData?.secondaryDamage).toEqual([110, 165, 275]); // 휩쓸기 (cycle 1) — 17.3: [100,150,225] → [110,165,275]
+    expect(aatrox?.abilityData?.slamDamage).toEqual([200, 300, 475]);      // 찍기 (cycle 2) — 17.3: [160,240,360] → [200,300,475]
     expect(aatrox?.abilityData?.slamStunDuration).toBe(1.0);                // 찍기 knockup
     expect(aatrox?.abilityData?.novaDamage).toEqual([120, 180, 270]);      // N.O.V.A.
     expect(aatrox?.abilityData?.armorReduction).toBe(10);                   // 휩쓸기 debuff
-    expect(aatrox?.abilityData?.singleTargetMultiplier).toBe(2.5);          // 찍기 단독
+    expect(aatrox?.abilityData?.singleTargetMultiplier).toBe(2.0);          // 찍기 단독 — 17.3: 2.5 → 2.0 (isolation nerf)
     expect(aatrox?.damageTypeOverride).toBe('physical');
   });
 
@@ -593,7 +597,7 @@ describe('PR7-C — 아트록스 carry 3-skill cycle + N.O.V.A. 추가 발동', 
     expect(file).toMatch(/cycleIdx === 0[\s\S]+?pattern:\s*'single'/);
     expect(file).toMatch(/cycleIdx === 1[\s\S]+?pattern:\s*'cone'/);
     expect(file).toMatch(/pattern:\s*'aoe_circle'[\s\S]+?slamStunDuration/);
-    // 단독 적중 ×2.5 — refactor (carry-damage-modifier): helper 안 패턴 검증
+    // 단독 적중 ×2.0 (17.3 nerf, 2.5→2.0) — refactor (carry-damage-modifier): helper 안 패턴 검증
     expect(file).toMatch(/context\.aatroxIsSingleTargetSlam[\s\S]+?context\.aliveTargetCount === 1[\s\S]+?ad\.singleTargetMultiplier/);
   });
 
@@ -1079,7 +1083,7 @@ describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
   // 사용자 결정:
   //   - to_largest_cluster: 각 적 위치 중심 radius 2 내 타 적 개수 max 적 → dash target
   //   - multi-stun: caster (unit) 위치 기준 가장 가까운 3명 (radius 3 AOE 안 alive)
-  //   - hexReduction 0.45: abilityTarget 중심 multiplicative falloff (PR4 자폭 일관)
+  //   - hexReduction 0.35 (17.3 nerf, 0.45→0.35): abilityTarget 중심 multiplicative falloff (PR4 자폭 일관)
   describe('PR7-B — 꼬마정령 carry multi-stun + dash to_largest_cluster + hexReduction', () => {
     it('IvernMinionCarry abilityOverride dash = to_largest_cluster (기존 to_farthest 변경)', () => {
       const ivern = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_IvernMinionCarry');
@@ -1089,9 +1093,9 @@ describe('PR7-E — 미프 시너지 + carry onAttack 패시브', () => {
       expect(ivern!.abilityOverride.dash).toBe('to_largest_cluster');
     });
 
-    it('IvernMinionCarry abilityData hexReduction 0.45 / stunDuration [1.25, 1.5, 1.75]', () => {
+    it('IvernMinionCarry abilityData hexReduction 0.35 (17.3) / stunDuration [1.25, 1.5, 1.75]', () => {
       const ivern = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_IvernMinionCarry');
-      expect(ivern?.abilityData?.hexReduction).toBe(0.45);
+      expect(ivern?.abilityData?.hexReduction).toBe(0.35); // 17.3: 0.45 → 0.35
       expect(ivern?.abilityData?.stunDuration).toEqual([1.25, 1.5, 1.75]);
       expect(ivern?.abilityData?.damage).toEqual([240, 360, 560]);
     });


### PR DESCRIPTION
## Summary

위키 lint finding 직접 해소 PR — [[patch-17-3]] / [[hero-augment-carry]] 에서 검출된 **`carryAugments.ts` 17.3 sim drift 5건** 을 코드에 반영.

PR #107 이 17.3 trait/champion json 갱신했으나 `carryAugments.ts` 가 누락되어 17.2b 값 잔존. 본 PR 로 정합.

기반: 공식 패치노트 <https://teamfighttactics.leagueoflegends.com/en-us/news/game-updates/teamfight-tactics-patch-17-3/>

## 변경 5건

### 1. Shieldmaiden (Leona)
- `baseDamageHpFrac: 0.28 → 0.24` (primary HP scale nerf)
- `secondaryDamage: [180,270,405] → [200,300,480]` (line secondary buff)

### 2. Heat Death (Mordekaiser)
- `mana: '40/100' → '10/40'` (큰 폭 buff — 빠른 발동)
- `shield: [225,250,300] → [175,200,400]` (3성 대폭 buff, 1/2성 nerf)

### 3. Reach for the Stars (Jax)
- `damage: [155,230,375] → [170,250,450]` (buff)

### 4. Stellar Combo (Aatrox)
- `secondaryDamage: [100,150,225] → [110,165,275]` (휩쓸기 buff)
- `slamDamage: [160,240,360] → [200,300,475]` (찍기 buff)
- `singleTargetMultiplier: 2.5 → 2.0` (isolation nerf)

### 5. The Big Bang (IvernMinion / Meepsie)
- `hexReduction: 0.45 → 0.35` (헥스당 감소 완화 — buff)

각 entry 의 `desc` string 도 17.3 변경 내역 반영.

## 미반영 (인게임 verify 필요 TODO 코멘트)

다음 2건은 적용 위치가 모호해서 TODO 코멘트로 보류 — 인게임 측정 후 적용:

- **Termeepnal Velocity (Poppy) AS: 0.7 → 0.75** — augment grant 인지 `statOverrides.attackSpeed` 인지 모호
- **Bonk! (Nasus) Resists: 40 → 45** — `statOverrides 채움 정책` (사용자 인게임 측정 후 적용) 따라 보류

## 테스트 갱신

`tests/unit/simulator/hero-augment-stat-system.test.ts`:
- 5 expected 값 변경 (line 58/65/72/86/98) + describe 설명 string "17.2b" → "17.3" 갱신
- PR7-C 아트록스 describe 블록 (line 555-560) 도 17.3 동일 갱신
- PR7-B 꼬마정령 describe 블록 (line 1096-1098) 도 17.3 동일 갱신

## 검증

- [x] `pnpm lint` — exit 0 (pre-existing warnings 외 error 없음)
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm build` — exit 0
- [x] `pnpm vitest run tests/unit/simulator/` — **449 passed / 8 skipped (cascade 영향 없음)**
- [x] Gragas `hexReduction: 0.45` 는 보존 (17.3 패치노트에 Gragas 변경 없음 — 검증 통해 확인)

## 위키 cross-ref (별도 PR 대상)

본 PR 머지 후 위키 페이지의 "drift" 표기 갱신 필요 (직렬 워크플로우 — 본 PR 처리 후 wiki 갱신 PR):
- `wiki/patches/patch-17-3.md` "carry augment drift" 섹션 — 5건 ✓ 처리됨 표기
- `wiki/mechanics/hero-augment-carry.md` "17.3 sim drift" Lint 섹션 — 동일

## Review checklist

- [ ] 5 값 변경 패치노트와 일치 (Leona/Mord/Jax/Aatrox/IvernMinion)
- [ ] Gragas hexReduction 0.45 보존 (17.3 변경 없음 — Aatrox/Ivern 변경과 혼동 주의)
- [ ] Poppy/Nasus TODO 코멘트 적정성 — 인게임 verify 후 후속 PR 진행 의도

## 관련

- 위키 PR #114 — 17.3 patch notes 종합 ingest (본 lint finding 검출 PR)
- 위키 lint 워크플로우: 코드 ground truth verify ([[feedback_wiki_ingest_verify]])
- PR 직렬 처리 워크플로우 ([[feedback_pr_serial_workflow]])

🤖 Generated with [Claude Code](https://claude.com/claude-code)