### PR TITLE
docs(wiki): 17.3 carry augment drift resolved — PR #115 머지 후 cleanup

### DIFF
--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,6 +8,28 @@ format: newest first
 
 ## 2026-05-18
 
+### Lint resolved: carryAugments.ts 17.3 sim drift (Lint finding 5 closed)
+- **Trigger**: PR #115 (`39cbce2`) 머지 완료 — 사용자 직렬 워크플로우 적용
+- **위키 lint 사이클 완결 사례** (도입 후 첫 full-cycle):
+  - PR #114 ingest 중 [[patch-17-3]] / [[hero-augment-carry]] 가 `carryAugments.ts` 17.3 drift 5+ entries 검출
+  - PR #115 로 sim 정합 (Leona/Mord/Jax/Aatrox/IvernMinion 5건)
+  - 본 cleanup PR — 위키 표기 drift → resolved 갱신
+- **위키 갱신 내역**:
+  - `patches/patch-17-3.md` "조정 Augments — Champion augments" 표: ⚠️ drift → ✅ PR #115 머지 완료. sim 정합 칼럼 추가 (✅/🔍 TODO)
+  - `patches/patch-17-3.md` "Lint findings" 섹션: drift → resolved 표기 + 커밋 hash 명시
+  - `mechanics/hero-augment-carry.md` "17.3 sim drift" 섹션 → "17.3 sim 정합" + PR #115 링크
+  - `mechanics/hero-augment-carry.md` 패치 히스토리 17.3 row: "별도 PR 필요" → "PR #115 머지 완료"
+  - `mechanics/hero-augment-carry.md` "시뮬 적용 상태" ✅ 활성 항목에 17.3 변경분 5건 정확 반영 추가
+- **TODO 잔존 항목** (인게임 verify 후 후속 PR):
+  - PoppyCarry Termeepnal AS 0.7 → 0.75 (augment grant vs statOverride 모호)
+  - NasusCarry Bonk! resists 40 → 45 (statOverrides 채움 정책)
+- **위키 lint 가치 검증 누적**:
+  1. Fountain stale memory (PR #109 이전)
+  2. plan doc "8 영웅 증강" vs 코드 10건
+  3. CLAUDE.md targeting weight/mana 표 stale 3건 (PR #112 로 해소)
+  4. AbilityTargetingType triad dead code (별도 클린업 PR 대기)
+  5. **carryAugments.ts 17.3 drift (PR #115 로 해소 ✅, 본 cleanup PR)**
+
 ### Major rewrite: patches/patch-17-3.md — 공식 패치노트 정상화 후 종합 ingest
 - **Trigger**: 사용자 — "17.3 패치노트 정상화 됐을 것 같은데 찾아봐주라"
 - **Source** (`feedback_wiki_ingest_verify` 워크플로우):

--- a/docs/meta/wiki/mechanics/hero-augment-carry.md
+++ b/docs/meta/wiki/mechanics/hero-augment-carry.md
@@ -103,23 +103,24 @@ augment 전용: `shield, shieldDuration, onAttackBonus, passiveDamage, empowered
 | **[[patch-17-2b]]** (2026-04-29) | **CarryAugmentConfig 정식화 + 8 영웅 증강 abilityData 채움 + statOverrides 슬롯 도입** (PR #68 + PR3). 같은 패치에서 `GragasCarry.healthCost` 30→20%, `hexReduction` 55→45%; `MordekaiserCarry.shield` 175/200/250 → 225/250/300; `LeonaCarry.damage` 110/165/250 → 90/135/225 |
 | 17.2b 후속 | PR7-A: `PykeCarry` x_shape pattern + dash to_lowest_hp + onKillRecast / PR7-B: `IvernMinionCarry` dash to_largest_cluster + hexReduction / PR7-C: `AatroxCarry` slam (cycle counter % 3 == 2) + slamStun |
 | 17.2b N.O.V.A. 후속 | `AatroxCarry.novaDamage` 추가 — 5-NOVA 시너지 + 타격 선택기 활성 시 |
-| 17.3 LIVE (2026-05-13) | **다수 carry augment 수치 조정** — 공식 패치노트 확정 (아래 "17.3 sim drift" 섹션 참조). 코드 `carryAugments.ts` 는 17.2b 값 유지 중 — 별도 sim 정확도 PR 필요 |
+| 17.3 LIVE (2026-05-13) | **다수 carry augment 수치 조정** — 공식 패치노트 확정. 5건 sim 정합 적용 (PR #115, `39cbce2`, 2026-05-18): Leona/Mord/Jax/Aatrox/IvernMinion. Poppy/Nasus 2건은 적용 위치 모호로 TODO 코멘트 |
 
-## ⚠️ 17.3 sim drift (Lint finding 5번째, 2026-05-18 update)
+## ✅ 17.3 sim 정합 — PR #115 머지 완료 (Lint finding 5 resolved, 2026-05-18)
 
-17.3 LIVE 공식 패치노트가 정상화되며 다수 carry augment 수치 조정 확인. 단 `carryAugments.ts` 는 17.2b 값 그대로 — sim 정확도 갭. **별도 PR 후보**.
+위키 lint 사이클 완결 사례: ingest (PR #114, 17.3 패치노트 종합) → drift 검출 → 코드 정합 PR (#115, `39cbce2`) → resolved.
 
-| Carry augment | 코드 (17.2b) | 17.3 LIVE 공식 |
-|--------------|-------------|----------------|
-| Shieldmaiden (Leona) | `baseDamageHpFrac: 0.28`, `secondaryDamage: [180,270,405]` | **24%**, **`[200,300,480]`** |
-| Heat Death (Mordekaiser) | `shield: [225,250,300]`, mana `40/100` | **`[175,200,400]`**, **`10/40`** |
-| Reach for the Stars (Jax) | `damage: [155,230,375]` | **`[170,250,450]`** |
-| Stellar Combo (Aatrox) | 2nd `[100,150,225]`, 3rd `[160,240,360]`, `singleTargetMultiplier: 2.5` | **`[110,165,275]`**, **`[200,300,475]`**, **`2.0`** |
-| The Big Bang (Meepsie/IvernMinion) | `hexReduction: 0.45` | **0.35** |
-| Termeepnal Velocity (Poppy) | AS 0.7 (현재 변수 위치 별도 verify) | **0.75** |
-| Bonk! (Nasus) | resists 미설정 (`statOverrides` 비어있음) | **40 → 45** |
+| Carry augment | 17.2b → 17.3 변경 | sim 정합 |
+|--------------|-------------------|:--------:|
+| Shieldmaiden (Leona) | `baseDamageHpFrac` 0.28 → 0.24, `secondaryDamage` `[180,270,405]` → `[200,300,480]` | ✅ |
+| Heat Death (Mordekaiser) | `shield` `[225,250,300]` → `[175,200,400]`, mana `40/100` → `10/40` | ✅ |
+| Reach for the Stars (Jax) | `damage` `[155,230,375]` → `[170,250,450]` | ✅ |
+| Stellar Combo (Aatrox) | 2nd `[100,150,225]` → `[110,165,275]`, 3rd `[160,240,360]` → `[200,300,475]`, isolation `2.5 → 2.0` | ✅ |
+| The Big Bang (Meepsie/IvernMinion) | `hexReduction: 0.45 → 0.35` | ✅ |
+| Termeepnal Velocity (Poppy) | AS `0.7 → 0.75` (augment grant vs statOverride 모호) | 🔍 TODO (`carryAugments.ts:PoppyCarry` 위 코멘트 — 인게임 verify) |
+| Bonk! (Nasus) | resists `40 → 45` (statOverrides 채움 정책 — 인게임 측정 후) | 🔍 TODO (`carryAugments.ts:NasusCarry` 위 코멘트) |
 
-→ 자세한 매핑은 [[patch-17-3]] "조정 Augments — Champion augments" 참조.
+검증: pnpm lint/typecheck/build 통과 + `pnpm vitest run tests/unit/simulator/` 449 passed.
+자세한 매핑은 [[patch-17-3]] "조정 Augments — Champion augments" 참조.
 
 ## 시뮬 적용 상태 — `partial`
 
@@ -127,6 +128,7 @@ augment 전용: `shield, shieldDuration, onAttackBonus, passiveDamage, empowered
 - 10개 augment 모두 abilityData 채워짐 → cast damage 시뮬 정확
 - role 변환 + ability pattern + dash + selfDamage 적용
 - 17.2b 변경분 (Gragas/Mordekaiser/Leona) 정확 반영
+- **17.3 변경분 (Leona/Mord/Jax/Aatrox/IvernMinion 5건) 정확 반영** (PR #115, `39cbce2`)
 
 ❌ **미완 (사용자 인게임 측정 대기)**:
 - 모든 augment 의 `statOverrides` (HP/armor/MR/AS/range 등 변환 후 stat)

--- a/docs/meta/wiki/patches/patch-17-3.md
+++ b/docs/meta/wiki/patches/patch-17-3.md
@@ -130,17 +130,17 @@ related:
 
 ### Champion augments (carry augment 그룹)
 
-⚠️ 다수 carry augment 가 17.3 에서 조정됐으나 **`carryAugments.ts` 코드는 17.2b 값 유지** — sim drift 발생 (아래 Lint 섹션):
+✅ **PR #115 머지 완료 (2026-05-18, commit `39cbce2`)** — 5건 sim 정합 적용. Poppy/Nasus 2건은 적용 위치 모호로 TODO 코멘트 (인게임 verify 후 후속 PR).
 
-| Augment | 17.2b (sim 코드) | 17.3 LIVE 공식 |
-|---------|-----------------|----------------|
-| Shieldmaiden (Leona) | `baseDamageHpFrac: 0.28`, secondary `[180,270,405]` | **24%**, **`[200,300,480]`** |
-| Heat Death (Mordekaiser) | shield `[225,250,300]`, mana `40/100` | **`[175,200,400]`**, **`10/40`** |
-| Reach for the Stars (Jax) | damage `[155,230,375]` | **`[170,250,450]`** |
-| Stellar Combo (Aatrox) | 2nd `[100,150,225]`, 3rd `[160,240,360]`, isolation `2.5` | **`[110,165,275]`**, **`[200,300,475]`**, **`2.0`** |
-| Termeepnal Velocity (Poppy) | AS `0.7` (별도 코드) | **`0.75`** |
-| The Big Bang (Meepsie/IvernMinion) | `hexReduction: 0.45` | **0.35** |
-| Bonk! (Nasus) | resists 미설정 | resists **40 → 45** |
+| Augment | 17.2b | 17.3 LIVE | sim 정합 |
+|---------|-------|----------|:--------:|
+| Shieldmaiden (Leona) | `baseDamageHpFrac: 0.28`, secondary `[180,270,405]` | `0.24`, `[200,300,480]` | ✅ |
+| Heat Death (Mordekaiser) | shield `[225,250,300]`, mana `40/100` | `[175,200,400]`, `10/40` | ✅ |
+| Reach for the Stars (Jax) | damage `[155,230,375]` | `[170,250,450]` | ✅ |
+| Stellar Combo (Aatrox) | 2nd `[100,150,225]`, 3rd `[160,240,360]`, isolation `2.5` | `[110,165,275]`, `[200,300,475]`, `2.0` | ✅ |
+| The Big Bang (Meepsie/IvernMinion) | `hexReduction: 0.45` | `0.35` | ✅ |
+| Termeepnal Velocity (Poppy) | AS `0.7` (별도 코드) | `0.75` | 🔍 TODO (`carryAugments.ts:PoppyCarry` 위 TODO 주석 — augment grant vs statOverride 모호, 인게임 verify) |
+| Bonk! (Nasus) | resists 미설정 | resists `40 → 45` | 🔍 TODO (`carryAugments.ts:NasusCarry` 위 TODO 주석 — statOverrides 채움 정책, 인게임 측정 후) |
 
 ### Economy augments
 - Buried Treasures Rounds: 5 → **4**
@@ -190,19 +190,23 @@ related:
 - PR #107 — 17.3 trait/champion 데이터 갱신 (champions.json, traits.json)
 - PR #108 — Shen passive fix (BonusDamageOnAttack 45/75 → 20/30) ✓
 - PR #109 — Stargazer Fountain active (PR-3, dev 머지) ✓
-- 후속 PR 후보 — carryAugments.ts 17.3 정합 (아래 Lint 섹션)
+- PR #115 (`39cbce2`) — carryAugments.ts 17.3 정합 ✅ 머지 완료
 
-## ⚠️ Lint findings — sim 정확도 갭
+## ✅ Lint findings — sim 정확도 갭 (resolved)
 
-### 1. `carryAugments.ts` 17.3 drift (위키 lint 5번째 사례)
-위 "조정 Augments — Champion augments" 표 참조. 5+ entry 가 17.2b 값 유지. **별도 sim 정확도 PR 필요**:
+### 1. `carryAugments.ts` 17.3 drift (위키 lint 5번째 사례) — **PR #115 (`39cbce2`) 머지 완료, 2026-05-18**
 
-- LeonaCarry: `baseDamageHpFrac` 0.28 → 0.24, `secondaryDamage` `[180,270,405]` → `[200,300,480]`
-- MordekaiserCarry: `shield` `[225,250,300]` → `[175,200,400]`, mana `40/100` → `10/40`
-- JaxCarry: `damage` `[155,230,375]` → `[170,250,450]`
-- AatroxCarry: `secondaryDamage` `[100,150,225]` → `[110,165,275]`, `slamDamage` `[160,240,360]` → `[200,300,475]`, `singleTargetMultiplier` 2.5 → 2.0
-- IvernMinionCarry: `hexReduction` 0.45 → 0.35
-- PoppyCarry (Termeepnal): AS 0.7 → 0.75 (해당 변수 위치 별도 verify)
+위 "조정 Augments — Champion augments" 표 참조. 5건 코드 정합 적용 + 2건 TODO 코멘트 (인게임 verify 대기):
+
+- LeonaCarry: `baseDamageHpFrac` 0.28 → 0.24, `secondaryDamage` `[180,270,405]` → `[200,300,480]` ✅
+- MordekaiserCarry: `shield` `[225,250,300]` → `[175,200,400]`, mana `40/100` → `10/40` ✅
+- JaxCarry: `damage` `[155,230,375]` → `[170,250,450]` ✅
+- AatroxCarry: `secondaryDamage` `[100,150,225]` → `[110,165,275]`, `slamDamage` `[160,240,360]` → `[200,300,475]`, `singleTargetMultiplier` 2.5 → 2.0 ✅
+- IvernMinionCarry: `hexReduction` 0.45 → 0.35 ✅
+- PoppyCarry (Termeepnal): AS 0.7 → 0.75 — 🔍 TODO (`carryAugments.ts:PoppyCarry` 코멘트, 인게임 verify 후 후속 PR)
+- NasusCarry (Bonk!): resists 40 → 45 — 🔍 TODO (`carryAugments.ts:NasusCarry` 코멘트, statOverrides 채움 정책)
+
+검증: pnpm lint/typecheck/build 통과 + `pnpm vitest run tests/unit/simulator/` 449 passed.
 
 ### 2. champion stat 검증 미완 항목
 17.3 변경됐다고 명시되었으나 코드 verify 안 된 항목 — 추가 grep 필요:


### PR DESCRIPTION
## Summary

**위키 lint 사이클 완결 사례 (도입 후 첫 full-cycle).**

PR #114 의 17.3 patch notes ingest 가 검출한 `carryAugments.ts` 17.3 drift 5+ entries 가 PR #115 (`39cbce2`) 로 sim 정합 적용됨. 본 PR 은 위키 페이지의 "drift" 표기를 "resolved" 로 갱신해 ingest → 검출 → 코드 정합 → 위키 cleanup 사이클을 닫는다.

```
PR #114 ingest → drift 검출 → PR #115 sim 정합 → 본 PR cleanup ✓
```

## 갱신 내역

### `patches/patch-17-3.md`
- "조정 Augments — Champion augments" 표: ⚠️ drift → **✅ resolved**
  - sim 정합 칼럼 추가 (✅ 5건 / 🔍 TODO 2건)
  - 커밋 `39cbce2` 명시
- "Lint findings" 섹션: drift → resolved 표기 + 검증 결과 (pnpm lint/typecheck/build + vitest 449 passed)

### `mechanics/hero-augment-carry.md`
- "⚠️ 17.3 sim drift" Lint 섹션 → **✅ 17.3 sim 정합** (PR #115 링크)
- 패치 히스토리 17.3 row: "별도 PR 필요" → "PR #115 머지 완료 — Leona/Mord/Jax/Aatrox/IvernMinion 5건"
- "시뮬 적용 상태" ✅ 활성 항목에 17.3 변경분 5건 정확 반영 추가

### `log.md`
- 신규 entry: "Lint resolved: carryAugments.ts 17.3 sim drift (Lint finding 5 closed)"
- 위키 도입 후 lint 가치 검증 누적 5건 정리 — 본 PR 이 lint #5 의 첫 full-cycle 완결

## 잔존 TODO (인게임 verify 후 후속 PR)

- **PoppyCarry Termeepnal AS** 0.7 → 0.75 — augment grant vs statOverride 모호
- **NasusCarry Bonk! resists** 40 → 45 — statOverrides 채움 정책 (사용자 인게임 측정 후)

## Review checklist

- [ ] drift → resolved 표기 정확성 (PR #115 코드 변경 vs 위키 표기 일치)
- [ ] Poppy/Nasus TODO 표기 — 인게임 verify 의도 명확한지
- [ ] 위키 lint 사이클 누적 (5건) 정리 정확성

## 다음 후보 (직렬 워크플로우)

본 PR 머지 후:
1. **AbilityTargetingType triad dead code 클린업** (Lint #4 — sim 코드 변경 PR)
2. `patches/patch-17-2.md` — Fountain inactive 시기 predecessor 페이지
3. `mechanics/spell-crit.md` — PDCA 진행 중 feature
4. Poppy/Nasus 인게임 verify 후 statOverrides 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)