### PR TITLE
fix(sim): Ability interface + AbilityEffect + EffectType 제거 — PR #117 후속 클린업

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -413,24 +413,6 @@ export interface StatusEffect {
   value?: number;
 }
 
-// === Ability Types (Structured) ===
-export type EffectType = 'damage' | 'heal' | 'shield' | 'stun' | 'slow' | 'burn' | 'knockup';
-
-export interface AbilityEffect {
-  type: EffectType;
-  value: number;
-  durationTicks?: number;
-  damageType?: 'physical' | 'magic' | 'true';
-}
-
-export interface Ability {
-  name: string;
-  type: 'active' | 'passive';
-  damageType: 'physical' | 'magic' | 'true';
-  effects: AbilityEffect[];
-  castTimeTicks: number;
-}
-
 // === Augment Types (Structured) ===
 export type AugmentEffectType = 'stat_modifier' | 'trait_bonus' | 'on_event' | 'unique';
 


### PR DESCRIPTION
## Summary

PR #117 의 dead code triad 제거에서 scope strict 로 보존했던 `Ability` interface 와 그 인접 type 들 (`AbilityEffect`, `EffectType`) 을 함께 제거. 위키 [[ability-targeting]] 의 "Ability interface 자체 dead 검증 — 후속 정리 PR 후보" 항목 직접 해소.

## 제거 대상 (모두 호출처 0 — grep 재verify)

| 식별자 | 위치 (제거 전) | 비고 |
|--------|---------------|------|
| `EffectType` | `src/types/index.ts:417` (7 string union) | `AbilityEffect` 내부에서만 참조 |
| `AbilityEffect` | `src/types/index.ts:419` interface | `Ability.effects` 필드에서만 참조 |
| `Ability` | `src/types/index.ts:426` interface | 호출처 0 (PR #117 시점 + 본 PR 재confirm) |

**총 -18 lines, 0 insertions.**

## 배경

sim 어빌리티 시스템은 `AbilityConfig` (`ability.ts`) + `findAbilityTargets` (plural) 로 통일됨. legacy `Ability` interface 와 그 effects/type 시스템은 architecture transition 잔재로 어떤 데이터/코드도 참조하지 않음.

- `attack.ts:25` 의 `// Ability damage` 는 단순 주석 (코드 reference 아님)
- `MfModeAbility` 는 별개 type (mf 모드 전용) — 본 PR 무관, 보존

## 검증

- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm build` — exit 0
- [x] `pnpm vitest run tests/unit/simulator/` — **449 passed / 8 skipped** (변화 없음 — sim 정확도 영향 없음 입증)
- [x] grep 재verify — 잔여 사용처 0

## 위키 cross-ref (별도 PR — 직렬 워크플로우)

본 PR 머지 후 cleanup PR:
- `wiki/mechanics/ability-targeting.md` Lint 체크리스트의 "Ability interface 자체 dead 검증 — 후속 정리 PR 후보" 항목 → `[x]` 처리 + 본 PR 커밋 hash 명시
- `wiki/log.md` "Lint resolved" entry (Ability interface family 제거 사실 기록)

## Review checklist

- [ ] 3 식별자 호출처 0 재확인
- [ ] `MfModeAbility` 와 혼동 없는지 (별개 type, 보존)
- [ ] PR #117 + 본 PR 합산 = -94 lines (76 + 18) — legacy ability 잔재 완전 제거 확인

## 후속 PR 후보 (직렬 워크플로우)

본 PR 머지 후:
1. **wiki cleanup** — Lint 체크리스트 [x] 처리 (위 cross-ref 섹션)
2. `patches/patch-17-2.md` predecessor 페이지
3. `mechanics/spell-crit.md` PDCA 진행 중 feature
4. Poppy/Nasus 인게임 verify 후 statOverrides 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)