### PR TITLE
docs(wiki): Ability interface family 제거 후 cleanup — PR #119 머지 반영

### DIFF
--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,6 +8,20 @@ format: newest first
 
 ## 2026-05-18
 
+### Sim cleanup: Ability interface family 제거 (PR #117 후속, lint #4 보강)
+- **Trigger**: PR #119 (`dc7137e`) 머지 완료 — 직렬 워크플로우
+- **배경**: PR #117 는 위키 검출 triad 만 제거 (scope strict). PR #119 가 남은 `Ability` interface + 인접 type 까지 정리.
+- **제거 (cascaded dead — 모두 호출처 0)**:
+  - `EffectType` (7 string union)
+  - `AbilityEffect` interface
+  - `Ability` interface
+  - **총 -18 lines** (PR #117 + #119 합산 -94 lines)
+- **위키 갱신 내역**:
+  - `mechanics/ability-targeting.md` 패치 히스토리 표에 PR #119 row 추가 (legacy ability 잔재 완전 제거)
+  - Lint 체크리스트 — "Ability interface 자체 dead 검증 — 후속 정리 PR 후보" 항목 [x] 처리 + 커밋 `dc7137e` 명시
+- **검증 (PR #119)**: pnpm lint/typecheck/build 통과 + `pnpm vitest run tests/unit/simulator/` 449 passed (변화 없음)
+- **legacy ability 시스템 → AbilityConfig 통일 완결**: sim 어빌리티 경로가 architecture transition 완료된 상태로 정리됨 (`AbilityConfig` + `findAbilityTargets` 단일 경로)
+
 ### Lint resolved: AbilityTargetingType triad dead code (Lint finding 4 closed)
 - **Trigger**: PR #117 (`bab401b`) 머지 완료 — 직렬 워크플로우 적용
 - **위키 lint 사이클 완결 사례** (도입 후 2번째 full-cycle):

--- a/docs/meta/wiki/mechanics/ability-targeting.md
+++ b/docs/meta/wiki/mechanics/ability-targeting.md
@@ -119,6 +119,7 @@ fallback = `[primaryTarget]` (single 과 동일). 안전 default.
 | [[patch-17-2b]] (PR7-A) | `x_shape` 패턴 추가 — Pyke carry "X 모양 베기". 9 패턴 완성 |
 | (legacy 잔재) | `AbilityTargetingType` + `findAbilityTarget` (singular) + `Ability.targeting` 필드 — architecture transition 잔재 |
 | 2026-05-18 (PR #117, `bab401b`) | **legacy triad 제거** — `AbilityTargetingType` type, `findAbilityTarget` 함수, `Ability.targeting` 필드 모두 sim 코드에서 삭제 (-76 lines). 위키 lint #4 closed |
+| 2026-05-18 (PR #119, `dc7137e`) | **legacy ability 잔재 완전 제거** — 남아있던 `Ability` interface + `AbilityEffect` interface + `EffectType` type 제거 (-18 lines). PR #117 합산 -94 lines |
 
 ## sim 적용 상태 — `active`
 
@@ -139,7 +140,7 @@ fallback = `[primaryTarget]` (single 과 동일). 안전 default.
 - [x] `damageDecay` 실제 사용 챔프 검증 (2026-05-18 — PR #113 Codex P2 자기-fix). 6 챔프 + combatLoop:6479 active.
 - [x] `dot.duration` 실제 사용 챔프 검증 (2026-05-18 동일 fix). 8 챔프 + combatLoop:6390/7050 active.
 - [ ] 신규 패턴 추가 시 `AbilityPattern` type + `findAbilityTargets` switch 양쪽 갱신 필요
-- [ ] `Ability` interface 자체 dead 검증 — 사용처 0 확인됨 (PR #117 grep). 후속 정리 PR 후보
+- [x] `Ability` interface 자체 dead 검증 — **제거 완료 (PR #119, `dc7137e`, 2026-05-18)**. 인접 `AbilityEffect` + `EffectType` 도 함께 제거 (cascaded dead)
 
 ## 관련
 


### PR DESCRIPTION
## Summary

PR #117 (legacy triad 제거) 후속 PR #119 (`Ability` interface + `AbilityEffect` + `EffectType` 제거) 의 위키 표기 갱신.

```
PR #117 triad 제거 → PR #118 wiki cleanup ✓
                          ↓ (scope strict 후속)
PR #119 interface family 제거 → 본 PR wiki cleanup
```

## 갱신 내역

### `mechanics/ability-targeting.md`
- 패치 히스토리 표에 **PR #119 row 추가** (legacy ability 잔재 완전 제거, -18 lines, PR #117 합산 -94 lines)
- Lint 체크리스트 "Ability interface 자체 dead 검증 — 후속 정리 PR 후보" 항목 → **`[x]` 처리** + 커밋 `dc7137e` 명시

### `log.md`
- 신규 entry: "Sim cleanup: Ability interface family 제거"
- legacy ability → `AbilityConfig` 통일 완결 사실 기록

## legacy ability 시스템 정리 완결

sim 어빌리티 경로가 architecture transition 완료 상태:
- ❌ legacy `Ability` interface + effects 시스템 (-94 lines, PR #117 + #119)
- ✅ live: `AbilityConfig` (`ability.ts`) + `findAbilityTargets` (plural) 단일 경로

## Review checklist

- [ ] 위키 표기 정확성 (PR #119 코드 변경 vs 위키 갱신 일치)
- [ ] Lint 체크리스트 [x] 처리 적절성

## 다음 후보 (직렬 워크플로우)

본 PR 머지 후 ingest 작업으로 이동 (lint cleanup 사이클 완결):
1. `patches/patch-17-2.md` — Fountain inactive 시기 predecessor 페이지 (thin)
2. **`mechanics/spell-crit.md`** — PDCA 진행 중 feature (fresh sim knowledge file back, 권장)
3. Poppy/Nasus 인게임 verify 후 statOverrides 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)