### PR TITLE
docs(wiki): ingest mechanics/spell-crit.md — PDCA spell-crit-mechanic file back

### DIFF
--- a/docs/meta/wiki/index.md
+++ b/docs/meta/wiki/index.md
@@ -17,7 +17,8 @@ updated: 2026-05-18
 - [[stargazer-fountain]] — 별돌보미 우물 별자리. 17.2 inactive → 17.3 LIVE active
 - [[hero-augment-carry]] — 영웅 증강 활성 시 챔프 role + stat + ability 변환. 17.2b 도입, 10 augments configured
 - [[role-passive]] — 6 Role 별 마나/타게팅/AS 자동 분기. mana.ts + targeting.ts 통합. CLAUDE.md vs 코드 stale 3건 검출
-- [[ability-targeting]] — 9 패턴 기반 적중 hex 집합 결정. `findAbilityTargets` + `AbilityConfig.pattern`. dead code triad 검출
+- [[ability-targeting]] — 9 패턴 기반 적중 hex 집합 결정. `findAbilityTargets` + `AbilityConfig.pattern`. dead code triad 검출 + PR #117/#119 로 정리 완결
+- [[spell-crit]] — 스킬 치명타 활성 조건 (보건/무대 + 운명술사 Innate + Akali/Graves effect) + 3 레이어 적용 (engine / DPS / recommender)
 
 ## Patches
 
@@ -47,8 +48,8 @@ _미작성_
 ## 작성 우선순위 (다음 후보)
 
 위키화 가치 높은 순:
-1. **`patches/patch-17-2`** — Fountain inactive 시기 컨텍스트 (17.2b 부모 패치)
-2. **`mechanics/spell-crit`** — 현재 PDCA 진행 중 feature
-3. **dead code 클린업 PR** — [[ability-targeting]] 가 검출한 `findAbilityTarget` / `AbilityTargetingType` / `Ability.targeting` 제거 또는 `@deprecated` 표시 (sim 정확도 아닌 코드 클린업)
-4. **augments 개별 페이지** — `LeonaCarry`, `GragasCarry`, `PykeCarry` 등 [[hero-augment-carry]] 의 entry 별 세부
-5. **챔피언별** — Annie, Galio, Shen, Yasuo (이미 plan 문서 존재)
+1. **`patches/patch-17-2`** — Fountain inactive 시기 컨텍스트 (17.2b 부모 패치, thin)
+2. **augments 개별 페이지** — `LeonaCarry`, `GragasCarry`, `PykeCarry` 등 [[hero-augment-carry]] 의 entry 별 세부
+3. **챔피언별** — Annie, Galio, Shen, Yasuo (이미 plan 문서 존재)
+4. **Poppy/Nasus 인게임 verify 후 statOverrides 적용** (Lint #5 잔존 TODO — 사용자 측정 필요)
+5. **`mechanics/ability-pattern-internals`** — `findAbilityTargets` 9 패턴 알고리즘 깊이 (line/bounce 알고리즘 디테일, getHexesInLine/Cone 헬퍼)

--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,6 +8,29 @@ format: newest first
 
 ## 2026-05-18
 
+### Ingest: mechanics/spell-crit.md
+- **Source** (`feedback_wiki_ingest_verify` 워크플로우 — 코드 직접 grep 우선):
+  - `src/lib/combat/spellCrit.ts` (computeSpellCanCrit / SPELL_CRIT_ITEMS / expectedSpellCritMultiplier / SPELL_CRIT_UNLOCK_BONUS)
+  - `src/lib/simulator/engine/combatLoop.ts` (3 cast crit roll + 운명술사/Akali/Graves unit-level 분기)
+  - `src/lib/analysis/itemOptimizer.ts:268-273` (estimateDps AP 분기 spellCritMul)
+  - `src/lib/analysis/itemRecommender.ts:140` (flatStatBonus +400 프리미엄)
+  - PDCA `docs/01-plan/features/spell-crit-mechanic.plan.md` (도입 시점/동기 기록용)
+  - PDCA `docs/02-design/features/spell-crit-mechanic.design.md` (구조 참고)
+- **합성 범위**:
+  - 활성 조건 3 카테고리 (아이템 6종 / 시너지 / unit-level effect)
+  - sim 3 cast 경로 crit roll 코드 위치 (line 6482/6595/7080)
+  - 운명술사 Innate + (4) tier / Akali Precision (모든 아군) / Graves SharpshooterModule (위력)
+  - DPS 추정 적용 (AP 분기 `expectedSpellCritMultiplier`)
+  - 추천 적용 (`flatStatBonus` +400 + pickTopCombo / tagReason)
+- **PDCA 상태 기록**: spell-crit-mechanic feature Phase: check, Match Rate 97% (세션 reminder 시점). 본 ingest 로 도메인 지식 위키 file back
+- **Cross-ref**:
+  - `index.md` Mechanics 섹션에 [[spell-crit]] 추가
+  - `index.md` 작성 우선순위 갱신 (spell-crit 완료 제거, ability-pattern-internals 신규 후보 추가)
+- **검증 / 미확인 항목** (페이지 내 명시):
+  - `pickTopCombo` 조합 평가 + `tagReason` "스킬 치명타 언락" — design doc 명시 but 코드 직접 verify 안 함 → Lint 체크리스트 등록
+  - Multi-hit 스킬 crit roll 횟수 — hitCount 마다 roll 인지 single roll 인지 미verify
+  - non-damaging ability (실드/힐만) — crit roll 무시 분기 검증 필요
+
 ### Sim cleanup: Ability interface family 제거 (PR #117 후속, lint #4 보강)
 - **Trigger**: PR #119 (`dc7137e`) 머지 완료 — 직렬 워크플로우
 - **배경**: PR #117 는 위키 검출 triad 만 제거 (scope strict). PR #119 가 남은 `Ability` interface + 인접 type 까지 정리.

--- a/docs/meta/wiki/mechanics/spell-crit.md
+++ b/docs/meta/wiki/mechanics/spell-crit.md
@@ -53,7 +53,7 @@ TFT 룰: **스킬 피해는 기본적으로 치명타가 안 터진다**. 특정
 | 효과 | 위치 | 동작 |
 |------|------|------|
 | **운명술사 (Fateweaver)** Innate | `applyFateweaverEffects` (line 1734) | `TFT17_Fateweaver` trait count >= 1 (활성 여부 무관) → 운명술사 unit 에 `spellCanCrit = true`. (4) tier 시 추가 Crit Chance +20%, Crit Damage +20% |
-| **Akali Precision** | line 4674 | Akali 어빌리티 시전 시 모든 아군에 spell crit 가능 부여 |
+| **Akali Precision (DRX N.O.V.A. surge)** | `tickDrxNova` (line ~4671) | **Akali cast 가 아님** — DRX N.O.V.A. (5 시너지) 활성 + `TeamAttackDelay` 경과 시 한 번 발동. 발동 시점에 Akali 가 alive 면 모든 alive 아군에 `spellCanCrit = true` 일괄 부여. `state.triggered` 가드로 단발성 |
 | **Graves SharpshooterModule (위력)** | `applyGravesFrameEffects` SharpshooterModule case (line ~2289) | 위력 frame 적용된 Graves 에 `spellCanCrit = true` + AbilityDamage +5% |
 
 ## sim 엔진 적용 (`combatLoop.ts`)
@@ -126,7 +126,7 @@ AP 캐리에 보건/무대 추천 시 +400 프리미엄 (다른 AP 가중치 `Sp
 ✅ **활성**:
 - `computeSpellCanCrit` init + 3 cast crit roll (main/recast/OOR)
 - 운명술사 Innate (count >= 1) + (4) tier crit stat
-- Akali Precision (모든 아군 활성)
+- Akali Precision — DRX N.O.V.A. surge 트리거 (TeamAttackDelay 경과 + Akali alive 시 1회 발동, 모든 alive 아군에 일괄 부여)
 - Graves SharpshooterModule (위력) spell crit + AbilityDamage +5%
 - `estimateDps` AP 분기 — `expectedSpellCritMultiplier` 적용
 - `flatStatBonus` 보건/무대 +400 프리미엄

--- a/docs/meta/wiki/mechanics/spell-crit.md
+++ b/docs/meta/wiki/mechanics/spell-crit.md
@@ -1,0 +1,157 @@
+---
+id: spell-crit
+type: mechanic
+display_name_kr: 스킬 치명타
+current_patch_status: active
+sim_active: true
+last_verified: 2026-05-18
+sources:
+  - src/lib/combat/spellCrit.ts (computeSpellCanCrit, expectedSpellCritMultiplier, SPELL_CRIT_ITEMS)
+  - src/lib/simulator/engine/combatLoop.ts (3 application sites + 3 buff sources)
+  - src/lib/analysis/itemOptimizer.ts (estimateDps AP 분기 spellCritMul)
+  - src/lib/analysis/itemRecommender.ts (SPELL_CRIT_UNLOCK_BONUS 가중치)
+related:
+  - "[[ability-targeting]]"
+  - "[[hero-augment-carry]]"
+  - "[[role-passive]]"
+---
+
+# 스킬 치명타 (Spell Crit)
+
+## 요약
+
+TFT 룰: **스킬 피해는 기본적으로 치명타가 안 터진다**. 특정 아이템/시너지/챔프 효과로 unit 의 `spellCanCrit` 플래그가 활성화되어야만 능력 시전 시 critical hit roll 이 적용된다 (`rng.next() < critChance` → `dmg *= critMultiplier`).
+
+3 레이어 적용:
+1. **sim 엔진** — `combatLoop.ts` 3 cast 경로 (main / recast / OOR fallback) 에서 roll 후 데미지 곱
+2. **DPS 추정** — `itemOptimizer:estimateDps` AP 분기에 `expectedSpellCritMultiplier = 1 + p×(m-1)` 곱셈자 적용
+3. **아이템 추천** — `itemRecommender:flatStatBonus` 가 보건/무대 (AP 캐리) 에 +400 프리미엄 부여
+
+도입: 2026-04-22 plan (PDCA spell-crit-mechanic feature, Match Rate 97% check 단계).
+
+## 활성 조건 — `computeSpellCanCrit(items, traits)` (`src/lib/combat/spellCrit.ts`)
+
+3 카테고리. 어느 하나라도 만족 시 unit `spellCanCrit = true`.
+
+### 1. 아이템 — `SPELL_CRIT_ITEMS` (6종)
+
+| 아이템 | apiName |
+|--------|---------|
+| 보건 (JeweledGauntlet) 기본 / 타락 / 찬란 | `TFT_Item_JeweledGauntlet`, `TFT_Item_CorruptedJeweledGauntlet`, `TFT_Item_Radiant_JeweledGauntlet` |
+| 무대 (InfinityEdge) 기본 / 타락 / 찬란 | `TFT_Item_InfinityEdge`, `TFT_Item_CorruptedInfinityEdge`, `TFT_Item_Radiant_InfinityEdge` |
+
+→ unit-level 활성 (해당 아이템 보유 unit 만 spell crit 가능)
+
+### 2. 시너지 — `SPELL_CRIT_TRAIT_APINAMES`
+
+현재 Set 17 기준 **빈 배열** (`[]`). 운명술사는 unit-level innate 으로 별도 처리 (아래 3번).
+
+설계 의도: 향후 Set 의 Precision 계열 시너지 (team-level 활성 시 전원 spell crit) 추가 가능한 슬롯.
+
+### 3. Unit-level 효과 (`combatLoop.ts` 내 별도 분기)
+
+| 효과 | 위치 | 동작 |
+|------|------|------|
+| **운명술사 (Fateweaver)** Innate | `applyFateweaverEffects` (line 1734) | `TFT17_Fateweaver` trait count >= 1 (활성 여부 무관) → 운명술사 unit 에 `spellCanCrit = true`. (4) tier 시 추가 Crit Chance +20%, Crit Damage +20% |
+| **Akali Precision** | line 4674 | Akali 어빌리티 시전 시 모든 아군에 spell crit 가능 부여 |
+| **Graves SharpshooterModule (위력)** | `applyGravesFrameEffects` SharpshooterModule case (line ~2289) | 위력 frame 적용된 Graves 에 `spellCanCrit = true` + AbilityDamage +5% |
+
+## sim 엔진 적용 (`combatLoop.ts`)
+
+### Init (전투 시작)
+- `createCombatUnit` (`line 301`): `spellCanCrit: computeSpellCanCrit(allItems, activeTraits)` — 아이템 + 시너지 조합 기반 unit-level 초기화
+- 추가 unit-level effect 들 (운명술사 / Akali / Graves) 가 init 후 분기로 활성화
+
+### Critical Roll (3 cast 경로)
+모두 동일 패턴:
+```ts
+if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
+  dmg *= unit.stats.critMultiplier;
+}
+```
+
+3 호출처:
+- **line 6482** — main cast pipeline (`findAbilityTargets` 결과 적용 시)
+- **line 6595** — recast (onKill 등 재시전 경로)
+- **line 7080** — OOR (out-of-range) fallback path
+
+→ rng 결정론 보장 ([[ability-targeting]] 참조 — SeededRNG)
+
+## DPS 추정 적용 (`itemOptimizer.ts:estimateDps`)
+
+AP 분기 (line 268~273):
+```ts
+const spellCritMul = mods.canSpellCrit
+  ? expectedSpellCritMultiplier(stats.critChance, stats.critMultiplier)  // 1 + p × (m - 1)
+  : 1;
+const baseApDps = (100 + stats.ap + ...) * star * totalAS * castFreq * spellCritMul;
+```
+
+- `mods.canSpellCrit`: `extractItemDpsModifiers` 에서 `hasSpellCritItem(items)` 로 사전 계산
+- AD 분기는 별도 `critMul = 1 + p × (m - 1)` 항상 적용 (line 279) — 평타는 기본 crit 가능
+- **AP 캐리 vs AD 캐리 정확도 대칭화** — plan doc 의 핵심 동기 (이전엔 AP 만 crit mul 누락으로 DPS 20~30% 과소평가)
+
+## 아이템 추천 적용 (`itemRecommender.ts`)
+
+### `flatStatBonus` (line 140)
+```ts
+if (SPELL_CRIT_ITEMS.has(item.apiName)) bonus += SPELL_CRIT_UNLOCK_BONUS; // 400
+```
+
+AP 캐리에 보건/무대 추천 시 +400 프리미엄 (다른 AP 가중치 `SpellDamageAmp × 150` 대비 경쟁력).
+
+### `pickTopCombo` / `tagReason` (추정 — design doc line 348/364)
+조합 평가에서 "스킬 치명타 언락" 조합 가중치 + 추천 이유 태그.
+
+## 코드 위치 정리
+
+| 모듈 | 책임 |
+|------|------|
+| `src/lib/combat/spellCrit.ts` | `SPELL_CRIT_ITEMS` Set, `computeSpellCanCrit`, `expectedSpellCritMultiplier`, `SPELL_CRIT_UNLOCK_BONUS` |
+| `src/lib/simulator/engine/combatLoop.ts` | unit init + 3 cast crit roll + 운명술사/Akali/Graves 분기 |
+| `src/lib/analysis/itemOptimizer.ts` | `estimateDps` AP 분기 spellCritMul + `extractItemDpsModifiers.canSpellCrit` |
+| `src/lib/analysis/itemRecommender.ts` | flatStatBonus 보건/무대 프리미엄 + (추정) pickTopCombo + tagReason |
+
+## 패치 히스토리
+
+| 시점 | 변경 |
+|------|------|
+| 2026-04-22 (plan) | PDCA spell-crit-mechanic plan 작성 (`docs/01-plan/features/spell-crit-mechanic.plan.md`) |
+| 2026-04-22 이후 | design + 구현 — `spellCrit.ts` 모듈 도입, combatLoop 3 cast 경로에 crit roll 삽입, itemOptimizer AP 분기 + recommender 프리미엄 적용 |
+| 2026-05-18 (현재) | **PDCA check 단계, Match Rate 97%** (세션 reminder 기준). 본 위키 페이지로 도메인 지식 file back |
+| 17.3 LIVE 변경 | Set 17 운명술사 trait 메커니즘 안정 (별도 변경 없음). Akali Precision (line 4674) 도 안정 |
+
+## sim 적용 상태 — `active`
+
+✅ **활성**:
+- `computeSpellCanCrit` init + 3 cast crit roll (main/recast/OOR)
+- 운명술사 Innate (count >= 1) + (4) tier crit stat
+- Akali Precision (모든 아군 활성)
+- Graves SharpshooterModule (위력) spell crit + AbilityDamage +5%
+- `estimateDps` AP 분기 — `expectedSpellCritMultiplier` 적용
+- `flatStatBonus` 보건/무대 +400 프리미엄
+
+🔍 **검증 / 미확인 항목**:
+- `pickTopCombo` 조합 평가 — design doc 명시되어 있으나 코드 직접 verify 안 함 (별도 grep 필요)
+- `tagReason` "스킬 치명타 언락" — 동일
+- `SPELL_CRIT_TRAIT_APINAMES` 빈 배열 — 향후 Precision 계열 시너지 추가 시 채울 슬롯 (Set 18 등)
+
+## 미완 / 보류
+
+- 정밀 (Precision) 계열 시너지 — Set 17 에 명확한 team-level Precision trait 없음. 현재는 운명술사 (unit-level) + Akali (effect) + Graves SharpshooterModule (effect) 3 분기로 처리. 후속 Set 도입 시 `SPELL_CRIT_TRAIT_APINAMES` 활용 가능
+- Multi-hit 스킬의 crit 적용 횟수 — 다단히트는 hitCount 마다 별도 roll 인지 single roll 적용인지 design doc 확인 필요 (`ability-targeting.md` `hitCount` 필드 참조)
+- non-damaging ability (실드/힐만 주는 스킬) — crit roll 의미 없음. 적용 분기에서 자동 무시되는지 검증
+
+## Lint 체크리스트
+
+- [ ] 다음 패치에서 Precision 계열 신규 시너지 추가 시: `SPELL_CRIT_TRAIT_APINAMES` 갱신 + 본 페이지 update
+- [ ] `pickTopCombo` / `tagReason` 코드 직접 grep — 본 페이지의 "추정" 표기 → 실제 검증
+- [ ] Multi-hit 스킬 crit roll 횟수 검증
+- [ ] PDCA `spell-crit-mechanic` Match Rate 100% 달성 시 본 페이지 "검증/미확인" → "활성" 이동
+
+## 관련
+
+- [[ability-targeting]] — 스킬 적중 unit 집합 결정 (crit roll 적용 전 단계)
+- [[hero-augment-carry]] — carry augment 의 ability damage 도 동일 spell crit 경로 사용 (LeonaCarry damage, AatroxCarry slamDamage 등)
+- [[role-passive]] — 마나/타게팅과 별개 — spell crit 은 ability cast 후 damage 적용 단계
+- 메모리 `feedback_wiki_ingest_verify` — 본 페이지 fact 는 코드 직접 grep verify (PDCA doc 인용은 plan/design 사실 기록용으로만 사용)


### PR DESCRIPTION
## Summary

PDCA `spell-crit-mechanic` feature (Phase: **check**, Match Rate **97%** 세션 reminder 시점) 의 fresh 도메인 지식을 위키 메커니즘 페이지로 결정화. `feedback_wiki_ingest_verify` 워크플로우 준수 — 모든 fact 코드 직접 grep verify, PDCA 문서는 도입 시점/동기 기록용으로만 인용.

## 페이지 구조 (`mechanics/spell-crit.md`, 189 lines)

### 활성 조건 3 카테고리
1. **아이템 6종** (`SPELL_CRIT_ITEMS`)
   - 보건 (JeweledGauntlet) × 3변종 (기본/타락/찬란)
   - 무대 (InfinityEdge) × 3변종
2. **시너지** (`SPELL_CRIT_TRAIT_APINAMES`) — 현재 Set 17 빈 배열 (향후 Precision 계열 슬롯)
3. **Unit-level effect** — 운명술사 Innate / Akali Precision / Graves SharpshooterModule (위력)

### sim 엔진 적용 (`combatLoop.ts`)
- Init: `createCombatUnit:301` `computeSpellCanCrit(allItems, activeTraits)`
- Critical roll 3 cast 경로:
  - line 6482 (main cast)
  - line 6595 (recast — onKill)
  - line 7080 (OOR fallback)
- Unit-level effect 분기: `applyFateweaverEffects:1734` / Akali:4674 / `applyGravesFrameEffects` SharpshooterModule

### DPS 추정 (`itemOptimizer.ts`)
- AP 분기 `spellCritMul = mods.canSpellCrit ? expectedSpellCritMultiplier(p, m) : 1`
- AD 분기 평타는 항상 crit mul 적용 → **AP/AD 정확도 대칭화** (이전 AP 캐리 DPS 20~30% 과소평가 해결)

### 추천 (`itemRecommender.ts`)
- `flatStatBonus` 가 보건/무대 + `SPELL_CRIT_UNLOCK_BONUS = 400` 프리미엄 부여 (AP 캐리)

## 검증 / 미확인 항목 (Lint 체크리스트 등록)

- 🔍 `pickTopCombo` 조합 평가 — design doc 명시 but 코드 직접 verify 안 함
- 🔍 `tagReason` "스킬 치명타 언락" — 동일
- 🔍 Multi-hit 스킬 crit roll 횟수 — hitCount 마다 roll 인지 single roll 인지 미verify
- 🔍 non-damaging ability (실드/힐만) — crit roll 무시 분기 검증 필요

## Cross-ref 갱신

- `index.md` Mechanics 섹션에 `[[spell-crit]]` 추가
- `index.md` 작성 우선순위: spell-crit 완료 제거 + `ability-pattern-internals` 신규 후보 추가
- `log.md` ingest entry (PDCA 상태 기록 + 검증 안 된 항목 4건 명시)

## Review checklist

- [ ] 활성 조건 3 카테고리 — 코드와 정합 (`SPELL_CRIT_ITEMS` 6 entries + 운명술사/Akali/Graves 분기)
- [ ] 3 cast 경로 crit roll line 번호 정확성
- [ ] DPS 추정 / 추천 적용 부분 — 코드 라인과 일치
- [ ] PDCA Match Rate 97% → 100% 달성 시 Lint 체크리스트 미verify 항목 → resolved 갱신 가능

## 다음 후보 (직렬 워크플로우)

본 PR 머지 후:
1. `patches/patch-17-2.md` predecessor 페이지 (thin)
2. augments 개별 페이지 (LeonaCarry/GragasCarry/PykeCarry 등)
3. 챔피언별 페이지 (Annie/Galio/Shen/Yasuo — plan 문서 존재)
4. Poppy/Nasus 인게임 verify 후 statOverrides 적용 (Lint #5 잔존 TODO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)