### PR TITLE
docs(wiki): augments 폴더 정립 + Leona/Mordekaiser Carry + 신규 Lint #6 (duplicate config)

### DIFF
--- a/docs/meta/wiki/augments/leona-carry.md
+++ b/docs/meta/wiki/augments/leona-carry.md
@@ -1,0 +1,109 @@
+---
+id: leona-carry
+type: augment
+display_name_kr: 방패 여전사 (Shieldmaiden)
+api_name: TFT17_Augment_LeonaCarry
+target_champion: TFT17_Leona
+tier: Gold
+stage: 2 only
+current_patch_status: active
+sim_active: partial   # carryAugments.ts entry vs combatLoop legacy const duplicate (아래 Lint finding)
+last_verified: 2026-05-18
+sources:
+  - src/data/carryAugments.ts:171 (LeonaCarry entry — abilityOverride/abilityData)
+  - src/lib/simulator/engine/combatLoop.ts:614 (LEONA_CARRY_ABILITY const)
+  - src/lib/simulator/engine/combatLoop.ts:626 (getAbilityConfigForUnit flag 분기)
+  - src/lib/simulator/engine/combatLoop.ts:2249 (applyHeroCarryTransforms leonaCarryActive set)
+  - public/data/tft_set17_augments.json:66
+  - 공식 17.2 / 17.3 패치노트
+related:
+  - "[[hero-augment-carry]]"
+  - "[[patch-17-2]]"
+  - "[[patch-17-2b]]"
+  - "[[patch-17-3]]"
+  - "[[ability-targeting]]"
+---
+
+# 방패 여전사 (LeonaCarry, Shieldmaiden)
+
+## 요약
+
+[[patch-17-2]] LIVE 게임 도입 carry augment. Gold tier, Stage 2 only. 활성 시 Leona (`TFT17_Leona`) 가 가장 강한 1명 → `Fighter` 변환 + line-pattern dash 어빌리티 + 첫 적중 stun. **17.2 → 17.2b → 17.3 3회 연속 변경** (가장 변경 잦은 carry augment 중 하나).
+
+## 변환 후 메커니즘
+
+- **role**: `Fighter` (default, statOverrides 미설정)
+- **ability pattern**: `line, maxTargets: 4, dash: to_target, firstHitOnlyStun: true`
+- **cast 흐름**:
+  1. 2초 동안 시전자 보호막 (shield `[200, 240, 280]` starLevel별, duration 2s)
+  2. 최대 3칸 돌진해 적이 가장 많은 일직선 타격 (탱커 우선)
+  3. 첫 적중 대상: **AD 데미지 + maxHP 24% 추가 + 기절** (17.3 nerf, 이전 28%)
+  4. 추가 line 대상 (최대 3명 추가): AD secondaryDamage
+
+## 변수 (carryAugments.ts:171 abilityData, 17.3 LIVE 기준)
+
+| 변수 | 값 | 설명 |
+|------|-----|------|
+| `damage` | `[90, 135, 225]` | starLevel별 primary AD damage (17.2b nerf 이후 17.3 변경 없음) |
+| `shield` | `[200, 240, 280]` | starLevel별 시전자 보호막 |
+| `shieldDuration` | `2` (초) | 보호막 지속 |
+| `baseDamageHpFrac` | **`0.24`** | primary 데미지에 maxHP × 24% 가산 (17.3: 0.28 → 0.24) |
+| `stunDuration` | `[1.0, 1.25, 1.5]` (초) | starLevel별 stun 지속 |
+| `secondaryDamage` | **`[200, 300, 480]`** | line 추가 대상 AD damage (17.3: [180,270,405] → [200,300,480]) |
+| `damageType` | `physical` | |
+
+## ⚠️ Lint finding (위키 검출 6번째 사례) — Duplicate config inconsistency
+
+LeonaCarry 가 **2개 config 로 정의**되어 있음. `getAbilityConfigForUnit` (`combatLoop.ts:622-630`) 에서 flag 우선 체크 → legacy const 가 carryAugments entry 를 shadow:
+
+| 출처 | stun (config) | stunDuration (abilityData) |
+|------|:--:|:--:|
+| `combatLoop.ts:614` `LEONA_CARRY_ABILITY` const | **`1.5`** (fixed) | — |
+| `carryAugments.ts:171` `LeonaCarry.abilityOverride` | `1.0` (fixed) | `[1.0, 1.25, 1.5]` (starLevel별) |
+
+**실제 sim 동작**: `LEONA_CARRY_ABILITY.stun = 1.5` 사용 (`applyHeroCarryTransforms:2250` 가 `leonaCarryActive = true` 설정 후 `getAbilityConfigForUnit:626` 가 우선 분기).
+
+**결과**:
+- 1성/2성 stun 도 1.5초 적용 (abilityData.stunDuration `[1.0, 1.25]` 무시됨)
+- carryAugments entry 의 stun 1.0 도 무시됨
+- starLevel 별 다른 stun duration 의도가 sim 에 반영 안 됨
+
+→ **별도 sim 클린업 PR 후보**:
+- 옵션 A: `LEONA_CARRY_ABILITY` 제거 + flag 경로 우회 → carryAugments entry 사용. starLevel별 stun 정확화. CC duration 변경 (Codex review 필요)
+- 옵션 B: `LEONA_CARRY_ABILITY` 가 `abilityData.stunDuration[starLevel]` 참조하도록 동적화
+
+GragasCarry 도 동일 패턴 추정 (`GRAGAS_CARRY_ABILITY` const + `gragasCarryActive` flag). 별도 페이지 작성 시 verify.
+
+## 패치 히스토리 (3회 연속 변경)
+
+| 패치 | 변경 |
+|------|------|
+| [[patch-17-2]] LIVE | **게임 도입** — Heat Death/Self-Destruct 와 함께 carry augment 3종 신규. 초기 값: damage `[110,165,250]`, baseDamageHpFrac 0.28 (추정 — 17.2 패치노트 명시 없음, 17.2b plan doc 가 17.2b 시점 값 기록) |
+| [[patch-17-2b]] (2026-04-29) | damage `[110,165,250]` → **`[90,135,225]`** (큰 nerf). carry augment sim 정식화 (CarryAugmentConfig + abilityData + statOverrides) |
+| [[patch-17-3]] (2026-05-13) | baseDamageHpFrac 0.28 → **0.24** (HP scale nerf) + secondaryDamage `[180,270,405]` → **`[200,300,480]`** (line buff). PR #115 (`39cbce2`) sim 정합 |
+
+## sim 적용 상태 — `partial`
+
+✅ **활성**:
+- role 변환 `Fighter` (default)
+- line dash + maxTargets 4 + firstHitOnlyStun
+- primary damage (carryAugments entry) + secondaryDamage (line 추가 대상)
+- baseDamageHpFrac maxHP 24% 가산
+- shield + duration
+
+❌ **미반영 / Lint finding**:
+- **stun duration starLevel별 분기** — abilityData.stunDuration `[1.0, 1.25, 1.5]` 가 LEONA_CARRY_ABILITY const 의 `stun: 1.5` 에 shadow 됨. 1성/2성 stun 도 1.5초 적용 (위 Lint finding 참조)
+- statOverrides (HP/AS/range/etc 변환 후 stat) 미설정 — [[hero-augment-carry]] 의 모든 entry 공통 미완 항목
+
+## Lint 체크리스트
+
+- [ ] **LEONA_CARRY_ABILITY const vs carryAugments entry duplicate 정리** — 본 페이지 Lint finding (별도 sim 클린업 PR)
+- [ ] statOverrides 인게임 측정 — Leona augment 활성 vs 비활성 stat 차이
+- [ ] 17.2 LIVE 초기 값 정확성 — 17.2 패치노트 명시 없음, 17.2b plan doc 의 "before" 표기로 역추정. 외부 archive 로 검증 가능
+
+## 관련
+
+- [[hero-augment-carry]] — carry augment 시스템 전체
+- [[patch-17-2]] / [[patch-17-2b]] / [[patch-17-3]] — 변경 시점
+- [[ability-targeting]] — line pattern 알고리즘 (`maxTargets` 거리순 cap)
+- 코드: `src/data/carryAugments.ts:171`, `src/lib/simulator/engine/combatLoop.ts:614/626/2249`

--- a/docs/meta/wiki/augments/mordekaiser-carry.md
+++ b/docs/meta/wiki/augments/mordekaiser-carry.md
@@ -1,0 +1,102 @@
+---
+id: mordekaiser-carry
+type: augment
+display_name_kr: 뜨거운 죽음 (Heat Death)
+api_name: TFT17_Augment_MordekaiserCarry
+target_champion: TFT17_Mordekaiser
+tier: Gold
+stage: 2 only
+current_patch_status: active
+sim_active: partial   # passive 매초 tick 미구현
+last_verified: 2026-05-18
+sources:
+  - src/data/carryAugments.ts:238 (MordekaiserCarry entry)
+  - src/lib/simulator/engine/combatLoop.ts (carry augment 일괄 처리 — duplicate const 없음, carryAugments entry 직접 사용)
+  - public/data/tft_set17_augments.json:168
+  - 공식 17.2 / 17.3 패치노트
+related:
+  - "[[hero-augment-carry]]"
+  - "[[patch-17-2]]"
+  - "[[patch-17-2b]]"
+  - "[[patch-17-3]]"
+  - "[[leona-carry]]"
+---
+
+# 뜨거운 죽음 (MordekaiserCarry, Heat Death)
+
+## 요약
+
+[[patch-17-2]] LIVE 게임 도입 carry augment. Gold tier, Stage 2 only. 활성 시 Mordekaiser (`TFT17_Mordekaiser`) 가 가장 강한 1명 → `Fighter` 변환 + 매초 주변 aoe_circle magic damage 패시브 + 시전 시 보호막 + 강화된 오라 4초. **17.2 → 17.2b → 17.3 3회 연속 변경** ([[leona-carry]] 와 함께 가장 변경 잦은 carry augment).
+
+LeonaCarry 와 달리 `mordekaiserCarryActive` 플래그 + duplicate const 없음 — `carryAugments.ts:238` entry 가 단일 source. Lint duplicate finding **해당 없음**.
+
+## 변환 후 메커니즘
+
+- **role**: `Fighter` (default, statOverrides 미설정)
+- **ability pattern**: `aoe_circle, radius: 1`
+- **cast 흐름**:
+  1. 시전자 보호막 부여 (shield `[175, 200, 400]` starLevel별, 17.3)
+  2. 4초 동안 오라 강화 (`empoweredAuraDamage` × 4초)
+- **패시브 (별도 hook 미구현)**:
+  - 매초 반경 N칸 magic damage (시작 N=1, 6초마다 +1)
+  - sim 미반영 — Mordekaiser passive hook 부재
+
+## 변수 (carryAugments.ts:238 abilityData, 17.3 LIVE 기준)
+
+| 변수 | 값 | 설명 |
+|------|-----|------|
+| `mana` | **`10/40`** | 시작/최대 마나 (17.3: `40/100` → `10/40` — 매우 빠른 발동) |
+| `damage` | `[50, 75, 115]` | starLevel별 cast 시 오라 damage |
+| `passiveDamage` | `[20, 30, 45]` | starLevel별 패시브 매초 오라 (sim 미반영) |
+| `empoweredAuraDamage` | `[50, 75, 115]` | cast 후 4초간 강화 오라 |
+| `empoweredDuration` | `4` (초) | 강화 오라 지속 |
+| `shield` | **`[175, 200, 400]`** | starLevel별 시전자 보호막 (17.3: `[225,250,300]` → `[175,200,400]` — 3성 대폭 buff, 1/2성 nerf) |
+| `damageType` | `magic` | |
+
+## 패치 히스토리 (3회 연속 변경)
+
+| 패치 | 변경 |
+|------|------|
+| [[patch-17-2]] LIVE | **게임 도입** — Self-Destruct/Shieldmaiden 과 함께 carry augment 3종 신규. 초기 shield `[175, 200, 250]` (17.2b plan doc "before" 표기) |
+| [[patch-17-2b]] (2026-04-29) | shield `[175,200,250]` → **`[225,250,300]`** (전반 buff). mana 변동 없음 추정. carry augment sim 정식화 (CarryAugmentConfig 도입) |
+| [[patch-17-3]] (2026-05-13) | shield `[225,250,300]` → **`[175,200,400]`** (1/2성 17.2 원복 + 3성 대폭 buff) / mana `40/100` → **`10/40`** (큰 폭 buff, 매우 빠른 발동). PR #115 (`39cbce2`) sim 정합 |
+
+→ **3성 shield 폭증 + mana 단축** 으로 17.3 에서 3성 Mordekaiser 의 Heat Death 가 강력한 carry 옵션으로 부상 (사용자 패치 의도 추정).
+
+## sim 적용 상태 — `partial`
+
+✅ **활성**:
+- role 변환 `Fighter` (default)
+- aoe_circle radius 1 cast
+- cast damage + shield + duration
+- 17.3 변경분 (shield/mana) 정합 ([[patch-17-3]] cleanup PR #116 + sim PR #115)
+
+❌ **미반영**:
+- **passive 매초 오라 (시작 N=1, 6초마다 +1)** — Mordekaiser 패시브 hook 부재. damage tick 분기 + 반경 확장 로직 미구현
+- `empoweredAuraDamage` 4초 강화 — 현재 cast 후 별도 4초 dot 분기 없음 (`empoweredDuration` 변수 정의되어 있으나 적용 site 미확인). 별도 verify 필요
+- statOverrides 미설정
+
+## Lint 체크리스트
+
+- [ ] **Mordekaiser passive 매초 오라 sim 구현** — Mordekaiser 패시브 hook 추가 (별도 sim 정확도 PR)
+- [ ] `empoweredAuraDamage` × `empoweredDuration` (4초) sim 적용 site verify — combatLoop 에서 어떻게 처리되는지 (`dot.duration` 메커니즘과 통합 가능?)
+- [ ] statOverrides 인게임 측정 — Mordekaiser augment 활성 vs 비활성 stat 차이
+- [ ] 17.2 LIVE 초기 shield `[175,200,250]` 값 — 17.2 패치노트 명시 없음, 17.2b plan doc "before" 표기로 역추정
+
+## 17.2 ↔ 17.3 비교 (역사적 흥미)
+
+shield 변경 궤적:
+- 17.2: `[175, 200, 250]` (게임 도입)
+- 17.2b: `[225, 250, 300]` (전반 buff)
+- **17.3: `[175, 200, 400]`** (1/2성 17.2 원복, 3성만 대폭 buff)
+
+→ Riot 의 balance 의도 추정:
+- 17.2b 까지: 모든 starLevel 강화 (carry augment 도입 후 사용률 낮음 → 활성화 의도)
+- 17.3: 1/2성 nerf (사용률 과대 → 진입 장벽 강화) + 3성 buff (고난도 보상)
+
+## 관련
+
+- [[hero-augment-carry]] — carry augment 시스템 전체
+- [[leona-carry]] — 같은 17.2 도입 carry augment 3종 중 하나
+- [[patch-17-2]] / [[patch-17-2b]] / [[patch-17-3]] — 변경 시점
+- 코드: `src/data/carryAugments.ts:238`, `tft_set17_augments.json:168`

--- a/docs/meta/wiki/augments/mordekaiser-carry.md
+++ b/docs/meta/wiki/augments/mordekaiser-carry.md
@@ -28,7 +28,7 @@ related:
 
 [[patch-17-2]] LIVE 게임 도입 carry augment. Gold tier, Stage 2 only. 활성 시 Mordekaiser (`TFT17_Mordekaiser`) 가 가장 강한 1명 → `Fighter` 변환 + 매초 주변 aoe_circle magic damage 패시브 + 시전 시 보호막 + 강화된 오라 4초. **17.2 → 17.2b → 17.3 3회 연속 변경** ([[leona-carry]] 와 함께 가장 변경 잦은 carry augment).
 
-LeonaCarry 와 달리 `mordekaiserCarryActive` 플래그 + duplicate const 없음 — `carryAugments.ts:238` entry 가 단일 source. Lint duplicate finding **해당 없음**.
+**⚠️ Multi-source drift** (PR #123 Codex P2 review 발견): LeonaCarry 와 달리 `mordekaiserCarryActive` 플래그/duplicate const 는 없으나, **`applyMordekaiserProcCast` (combatLoop.ts:939) + `tickMordekaiserProc` (line 969) 가 raw `unit.champion.ability.variables` 를 직접 read** → `carryAugments.ts:238` 의 일부 변수 (shield/mana/empoweredDuration 등) 가 실제 sim 에 사용 안 됨. 자세한 분석은 아래 "Lint finding #7" 섹션.
 
 ## 변환 후 메커니즘
 
@@ -67,21 +67,39 @@ LeonaCarry 와 달리 `mordekaiserCarryActive` 플래그 + duplicate const 없�
 
 ✅ **활성**:
 - role 변환 `Fighter` (default)
-- aoe_circle radius 1 cast
-- cast damage + shield + duration
-- 17.3 변경분 (shield/mana) 정합 ([[patch-17-3]] cleanup PR #116 + sim PR #115)
+- aoe_circle radius 1 cast (`carryAugments.ts:238` abilityOverride 사용 — `getAbilityConfigForUnit:627` findCarryAugment 경로)
+- cast `damage` (carryAugments entry 사용, line 659 `damageArr = carryCfg.abilityData.damage`)
 
-❌ **미반영**:
-- **passive 매초 오라 (시작 N=1, 6초마다 +1)** — Mordekaiser 패시브 hook 부재. damage tick 분기 + 반경 확장 로직 미구현
-- `empoweredAuraDamage` 4초 강화 — 현재 cast 후 별도 4초 dot 분기 없음 (`empoweredDuration` 변수 정의되어 있으나 적용 site 미확인). 별도 verify 필요
-- statOverrides 미설정
+❌ **미반영 — Lint finding #7 (위키 검출 7번째 사례, PR #123 Codex P2 review 발견)**:
+
+`applyMordekaiserProcCast` (combatLoop.ts:939) + `tickMordekaiserProc` (line 969) 가 **raw `unit.champion.ability.variables` 직접 read**:
+
+```ts
+const vars = unit.champion.ability.variables;
+const initialShield = readVarByStar(vars.find(v => v.name === 'InitialShield')?.value, ...);
+const duration = readVarByStar(vars.find(v => v.name === 'Duration')?.value, ...);
+```
+
+→ `carryAugments.ts:238` 의 다음 변수가 **sim 에 사용 안 됨**:
+- `shield` `[175, 200, 400]` (17.3) — raw `InitialShield` vars 가 실제 적용
+- `mana` `'10/40'` (17.3) — combatLoop 에서 `carryCfg.abilityData.mana` read 0건 (전체 코드 grep)
+- `empoweredDuration: 4` — raw `Duration` vars 가 실제 적용
+- `empoweredAuraDamage`, `passiveDamage` — `tickMordekaiserProc` 의 raw `DamagePerProc` / `ShieldPerProc` 사용
+
+**중대 결과**: **PR #115 의 Mordekaiser shield/mana 17.3 정합 코드 변경이 실제 sim 에 반영 안 됨**. PR #116 의 "resolved" 표기 부정확. raw champion variables (`public/data/tft_set17_champions.json` 의 InitialShield/Duration/DamagePerProc/ShieldPerProc) 가 17.3 값을 반영하고 있는지 별도 verify 필요.
+
+**조치 후보 (별도 sim 정확도 PR)**:
+- 옵션 A: `applyMordekaiserProcCast` 가 carry augment 활성 시 `carryCfg.abilityData` 우선 read (다른 carry 와 일관성)
+- 옵션 B: raw champion variables (InitialShield/Duration 등) 가 17.3 값 반영하도록 `tft_set17_champions.json` 검증/갱신. carryAugments.ts entry 의 shield/mana 필드는 제거 (raw vars 단일 source)
 
 ## Lint 체크리스트
 
-- [ ] **Mordekaiser passive 매초 오라 sim 구현** — Mordekaiser 패시브 hook 추가 (별도 sim 정확도 PR)
-- [ ] `empoweredAuraDamage` × `empoweredDuration` (4초) sim 적용 site verify — combatLoop 에서 어떻게 처리되는지 (`dot.duration` 메커니즘과 통합 가능?)
-- [ ] statOverrides 인게임 측정 — Mordekaiser augment 활성 vs 비활성 stat 차이
-- [ ] 17.2 LIVE 초기 shield `[175,200,250]` 값 — 17.2 패치노트 명시 없음, 17.2b plan doc "before" 표기로 역추정
+- [ ] **Mordekaiser carry shield/mana raw vars 적용 verify** — `tft_set17_champions.json` 의 InitialShield/Duration 이 17.3 값 반영하는지 (별도 sim 클린업 PR — Lint #7)
+- [ ] **`carryAugments.ts:238` 의 shield/mana/empoweredDuration 필드 정리** — raw vars 단일 source 이면 entry 에서 제거 권장
+- [ ] **PR #115/#116 의 "resolved" 표기 정확화** — patch-17-3.md / hero-augment-carry.md 의 Mordekaiser 표 row 정정 필요
+- [ ] Mordekaiser passive 매초 오라 — `tickMordekaiserProc` 가 raw `DamagePerProc` 로 구현되어 있는지 (line 969 컨텍스트 read 시 적용 site 확인 가능)
+- [ ] statOverrides 인게임 측정
+- [ ] 17.2 LIVE 초기 shield 값 — 17.2 패치노트 명시 없음
 
 ## 17.2 ↔ 17.3 비교 (역사적 흥미)
 

--- a/docs/meta/wiki/index.md
+++ b/docs/meta/wiki/index.md
@@ -36,7 +36,8 @@ _미작성_
 
 ## Augments
 
-_미작성_
+- [[leona-carry]] (방패 여전사) — 17.2 도입, 3회 연속 변경 carry augment. ⚠️ duplicate config lint (combatLoop `LEONA_CARRY_ABILITY` const vs carryAugments entry)
+- [[mordekaiser-carry]] (뜨거운 죽음) — 17.2 도입, 3회 연속 변경. 17.3 3성 shield `[175,200,400]` 대폭 buff. Mordekaiser passive 매초 오라 sim 미반영
 
 ## Raw Sources (Layer 1)
 
@@ -49,7 +50,7 @@ _미작성_
 ## 작성 우선순위 (다음 후보)
 
 위키화 가치 높은 순:
-1. **augments 개별 페이지** — `LeonaCarry`, `GragasCarry`, `PykeCarry` 등 [[hero-augment-carry]] 의 entry 별 세부
+1. **augments 나머지 8개** — Gragas/Aatrox/Ivern/Jax/Pyke/Nasus/Poppy/Zed Carry. 특히 Gragas 는 LeonaCarry 와 동일 duplicate config 패턴 (`GRAGAS_CARRY_ABILITY` const + `gragasCarryActive` flag) verify 후 lint finding 보강
 2. **챔피언별** — Annie, Galio, Shen, Yasuo (이미 plan 문서 존재)
 3. **Poppy/Nasus 인게임 verify 후 statOverrides 적용** (Lint #5 잔존 TODO — 사용자 측정 필요)
 4. **`mechanics/ability-pattern-internals`** — `findAbilityTargets` 9 패턴 알고리즘 깊이 (line/bounce 알고리즘 디테일, getHexesInLine/Cone 헬퍼)

--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,6 +8,33 @@ format: newest first
 
 ## 2026-05-18
 
+### Ingest: augments/leona-carry.md + augments/mordekaiser-carry.md — augments 폴더 정립
+- **Source** (`feedback_wiki_ingest_verify` + 함수 컨텍스트 룰 적용):
+  - `src/data/carryAugments.ts:171` (LeonaCarry entry) / `:238` (MordekaiserCarry entry)
+  - `src/lib/simulator/engine/combatLoop.ts:614` (LEONA_CARRY_ABILITY const) — 함수 컨텍스트 read 로 발견
+  - `src/lib/simulator/engine/combatLoop.ts:622-630` (getAbilityConfigForUnit flag 우선 분기 — duplicate config inconsistency 원인)
+  - `src/lib/simulator/engine/combatLoop.ts:2249-2250` (applyHeroCarryTransforms leonaCarryActive set)
+  - 공식 17.2 / 17.3 패치노트
+- **선정 이유**: 10 carry augment 중 가장 패치 변경 많은 2개 (17.2 도입 → 17.2b → 17.3 3회 변경)
+- **augments/ 폴더 컨벤션 정립** (schema.md 의 `augments/<id>.md` 첫 entry)
+- **⚠️ 신규 Lint finding (위키 검출 6번째 사례) — LeonaCarry duplicate config inconsistency**:
+  - `combatLoop.ts:614` `LEONA_CARRY_ABILITY` const `stun: 1.5`
+  - `carryAugments.ts:171` `LeonaCarry.abilityOverride` `stun: 1.0`, abilityData `stunDuration: [1.0, 1.25, 1.5]` starLevel별
+  - `getAbilityConfigForUnit:626` 가 `leonaCarryActive` flag 우선 분기 → legacy const 우선
+  - 결과: starLevel별 stun duration 의도 (`[1.0, 1.25, 1.5]`) 가 sim 에 반영 안 됨. 1성/2성도 1.5초 적용
+  - → 별도 sim 클린업 PR 후보 (옵션 A: const 제거 + flag 경로 우회 / 옵션 B: const 가 abilityData 참조 동적화)
+  - **GragasCarry 도 동일 패턴 추정** (`GRAGAS_CARRY_ABILITY` const + `gragasCarryActive` flag) — 다음 PR (GragasCarry 페이지) 에서 verify
+- **함수 컨텍스트 룰 가치 검증**: `grep LEONA_CARRY_ABILITY` 만 보고 const 정의 발견 → `getAbilityConfigForUnit` 함수 전체 read 로 flag 우선 분기 인식 → duplicate inconsistency 검출. 메모리 `feedback_wiki_ingest_verify` 의 "함수 컨텍스트 read" 룰이 정확히 작동
+- **부수 갱신 — hero-augment-carry.md 표**:
+  - LeonaCarry row: `baseDamageHpFrac 0.28` (drift) → `0.24` (17.3) + duplicate config lint 명시 + [[leona-carry]] 링크
+  - MordekaiserCarry row: shield/mana 17.3 값 명시 + passive 미반영 명시 + [[mordekaiser-carry]] 링크
+- **Cross-ref**:
+  - `index.md` Augments 섹션 활성화 (_미작성_ → 2 entries)
+  - `index.md` 작성 우선순위 갱신 (augments 나머지 8개로 1순위 — Gragas duplicate verify 가치 강조)
+- **위키 lint 누적 (6건)**:
+  1~5: 기존 (Fountain memory / "8 영웅 증강" / CLAUDE.md weight / dead code triad / carryAugments drift)
+  6. **본 ingest — LeonaCarry duplicate config inconsistency**
+
 ### Ingest: patches/patch-17-2.md — Set 17 메이저 패치 계보 완결
 - **Source** (`feedback_wiki_ingest_verify` 워크플로우):
   - 공식 17.2 패치노트 (URL 동일, 17.2 LIVE 본문 + 17.2b mid-patch 섹션 분리 추출)

--- a/docs/meta/wiki/mechanics/hero-augment-carry.md
+++ b/docs/meta/wiki/mechanics/hero-augment-carry.md
@@ -76,11 +76,11 @@ augment 전용: `shield, shieldDuration, onAttackBonus, passiveDamage, empowered
 | `NasusCarry` (꽁!) | TFT17_Nasus | single | ✅ | ❌ | `bonusPerKill` |
 | `AatroxCarry` (별빛 연계) | TFT17_Aatrox | cone r=1 | ✅ | ❌ | 3-skill cycle (`skillCycleLabels`) + `novaDamage` + `slamDamage` |
 | `PoppyCarry` (정령단 속도) | TFT17_Poppy | single r=4 | ✅ | ❌ | `armorScale 1.0` + `spiritBounceOnKill` |
-| `LeonaCarry` (방패 여전사) | TFT17_Leona | line maxT=4, dash | ✅ | ❌ | `shield` + `baseDamageHpFrac 0.28` + `secondaryDamage` |
+| [[leona-carry]] (방패 여전사) | TFT17_Leona | line maxT=4, dash | ✅ | ❌ | `shield` + `baseDamageHpFrac 0.24` (17.3) + `secondaryDamage`. ⚠️ **duplicate config**: combatLoop `LEONA_CARRY_ABILITY` (stun 1.5) 가 carryAugments entry (stun 1.0 + stunDuration starLevel별) 를 shadow — 위키 lint #6 |
 | `IvernMinionCarry` (빅뱅) | TFT17_IvernMinion | aoe_circle r=3, dash to_largest_cluster | ✅ | ❌ | `hexReduction 0.45` + `stunDuration` |
 | `JaxCarry` (저 별을 향해) | TFT17_Jax | self_buff AS+0.15 | ✅ | ❌ | `asGain` 영구 누적 + `onAttackBonus` |
 | `PykeCarry` (청부 살인마) | TFT17_Pyke | x_shape, dash to_lowest_hp | ✅ | ❌ | `tankBonusMultiplier 0.60` + `onKillRecastMultiplier 0.70` |
-| `MordekaiserCarry` (뜨거운 죽음) | TFT17_Mordekaiser | aoe_circle r=1 | ✅ | ❌ | `passiveDamage` + `empoweredAuraDamage` + `shield` |
+| [[mordekaiser-carry]] (뜨거운 죽음) | TFT17_Mordekaiser | aoe_circle r=1 | ✅ | ❌ | `passiveDamage` (sim 미반영) + `empoweredAuraDamage` + `shield [175,200,400]` (17.3, 3성 대폭 buff) + mana `10/40` (17.3 단축) |
 | `GragasCarry` (자폭) | TFT17_Gragas | aoe_circle r=3, selfDamage | ✅ | ❌ | `healthCost 0.20` + `hexReduction 0.45` + `tankBonusMultiplier 0.60` |
 | `InvaderZed` (침략자 제드) | TFT17_Zed | self_buff (5단계) | ✅ | ❌ | stage 4-2 획득 전용 |
 


### PR DESCRIPTION
## Summary

`augments/` 폴더 컨벤션 정립 PR. 10 carry augment 중 가장 패치 변경 많은 2개 (17.2 → 17.2b → 17.3 3회 연속 변경) 부터 시작. **함수 컨텍스트 read 룰 적용 중 신규 lint finding 검출**.

## 페이지 2개 신규

### `augments/leona-carry.md` (방패 여전사)
- line dash + 첫 적중 stun + maxHP scale
- 17.2 도입 → 17.2b damage `[110,165,250]→[90,135,225]` → 17.3 baseDamageHpFrac `0.28→0.24` + secondaryDamage `[180,270,405]→[200,300,480]`

### `augments/mordekaiser-carry.md` (뜨거운 죽음)
- aoe_circle r=1 cast + 4s 강화 오라 + passive 매초 (sim 미반영)
- 17.2 shield `[175,200,250]` → 17.2b `[225,250,300]` → 17.3 `[175,200,400]` (3성 대폭 buff) + mana `40/100→10/40`

## ⚠️ 신규 Lint finding (위키 검출 6번째 사례)

**LeonaCarry duplicate config inconsistency**:

| 출처 | stun (config) | stunDuration (abilityData) |
|------|:--:|:--:|
| `combatLoop.ts:614` `LEONA_CARRY_ABILITY` const | **`1.5`** (fixed) | — |
| `carryAugments.ts:171` `LeonaCarry.abilityOverride` | `1.0` (fixed) | `[1.0, 1.25, 1.5]` (starLevel별) |

`getAbilityConfigForUnit:626` 가 `leonaCarryActive` flag 우선 분기 → **legacy const 우선**:
```ts
if (unit.leonaCarryActive) return LEONA_CARRY_ABILITY;  // ← stun 1.5
const carry = findCarryAugment(...);
if (carry) return carry.abilityOverride;  // ← stun 1.0 (shadow)
```

**결과**: 1성/2성 stun 도 1.5초 적용. `abilityData.stunDuration` 의 starLevel별 의도가 sim 에 반영 안 됨.

**조치 (별도 sim 클린업 PR 후보)**:
- 옵션 A: `LEONA_CARRY_ABILITY` 제거 + flag 경로 우회 → carryAugments entry 사용 (단 CC duration 1.5→1.0 등으로 변경 — Codex review 필요)
- 옵션 B: `LEONA_CARRY_ABILITY` 가 `abilityData.stunDuration[starLevel]` 참조하도록 동적화

**GragasCarry 도 동일 패턴 추정** (`GRAGAS_CARRY_ABILITY` const + `gragasCarryActive` flag) — 다음 PR (GragasCarry 페이지) 에서 verify.

## 함수 컨텍스트 룰 가치 검증

`feedback_wiki_ingest_verify` 강화 룰 적용 사례:
- `grep "LEONA_CARRY_ABILITY"` 결과 line 614 만 보면 단순 const 정의 인식 (lint 검출 못함)
- **`getAbilityConfigForUnit` 함수 전체 read** → flag 우선 분기 인식 → carryAugments entry 가 shadow 됨 검출
- → 메모리 워크플로우의 "함수 컨텍스트 read" 룰이 정확히 작동

## 부수 갱신

`mechanics/hero-augment-carry.md` 표:
- LeonaCarry row `baseDamageHpFrac 0.28` (drift) → `0.24` (17.3) + duplicate config lint 명시 + `[[leona-carry]]` 링크
- MordekaiserCarry row shield/mana 17.3 값 + passive 미반영 명시 + `[[mordekaiser-carry]]` 링크

`index.md`:
- Augments 섹션 활성화 (`_미작성_` → 2 entries)
- 우선순위 갱신 (augments 나머지 8개 1순위 — Gragas duplicate verify 가치 강조)

`log.md`: ingest entry + lint 누적 6건

## 위키 lint 누적 (6건, 3건 full-cycle resolved)

| # | Finding | 상태 |
|---|---------|------|
| 1 | Fountain stale memory | resolved (PR #109 이전) |
| 2 | "8 영웅 증강" vs 코드 10건 | documented |
| 3 | CLAUDE.md weight/mana 3건 | resolved (PR #112) |
| 4 | AbilityTargetingType triad dead code | resolved (PR #117+#118 / extension #119+#120) |
| 5 | carryAugments.ts 17.3 drift | resolved (PR #115+#116) |
| 6 | **LeonaCarry duplicate config inconsistency** | **새로 검출 — 별도 sim 클린업 PR 후보** |

## Review checklist

- [ ] LeonaCarry duplicate config 검출 정확성 (`LEONA_CARRY_ABILITY` 가 진짜 carryAugments entry 를 shadow 하는지)
- [ ] MordekaiserCarry passive 매초 오라 sim 미반영 사실
- [ ] augments 폴더 컨벤션 (frontmatter / sources / 패치 히스토리 / Lint 체크리스트) 적절성

## 다음 후보 (직렬 워크플로우)

본 PR 머지 후:
1. **augments 나머지 8개** — 특히 GragasCarry duplicate verify (LeonaCarry 와 동일 패턴 추정)
2. LeonaCarry duplicate config sim 클린업 (옵션 A/B 결정 후)
3. 챔피언별 페이지 (Annie/Galio/Shen/Yasuo)
4. Poppy/Nasus 인게임 verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)