### PR TITLE
docs(wiki): Mordekaiser carry source drift resolved — PR #124 머지 후 cleanup

### DIFF
--- a/docs/meta/wiki/augments/mordekaiser-carry.md
+++ b/docs/meta/wiki/augments/mordekaiser-carry.md
@@ -28,18 +28,19 @@ related:
 
 [[patch-17-2]] LIVE 게임 도입 carry augment. Gold tier, Stage 2 only. 활성 시 Mordekaiser (`TFT17_Mordekaiser`) 가 가장 강한 1명 → `Fighter` 변환 + 매초 주변 aoe_circle magic damage 패시브 + 시전 시 보호막 + 강화된 오라 4초. **17.2 → 17.2b → 17.3 3회 연속 변경** ([[leona-carry]] 와 함께 가장 변경 잦은 carry augment).
 
-**⚠️ Multi-source drift** (PR #123 Codex P2 review 발견): LeonaCarry 와 달리 `mordekaiserCarryActive` 플래그/duplicate const 는 없으나, **`applyMordekaiserProcCast` (combatLoop.ts:939) + `tickMordekaiserProc` (line 969) 가 raw `unit.champion.ability.variables` 를 직접 read** → `carryAugments.ts:238` 의 일부 변수 (shield/mana/empoweredDuration 등) 가 실제 sim 에 사용 안 됨. 자세한 분석은 아래 "Lint finding #7" 섹션.
+**✅ Source-of-truth drift 해소 (PR #124, `3678add`, 2026-05-18)**: PR #123 Codex P2 review 가 검출한 `applyMordekaiserProcCast` raw vars 우선 read 이슈를 PR #124 가 Option A 로 해결. 이제 carry augment 활성 시 `carryAugments.ts:238` 의 `shield`/`mana` 값이 sim 에 정확히 반영. 자세한 history 는 아래 "Lint finding #7 (resolved)" 섹션.
 
 ## 변환 후 메커니즘
 
-- **role**: `Fighter` (default, statOverrides 미설정)
+- **role**: `Fighter` (default)
 - **ability pattern**: `aoe_circle, radius: 1`
+- **statOverrides (PR #124 신규)**: `initialMana: 10, mana: 40` (17.3 patch note 정합) — `applyHeroCarryTransforms` 가 item delta 보존하며 적용 (Tear/Blue Buff 등 mana-altering item bonus 위에 누적)
 - **cast 흐름**:
-  1. 시전자 보호막 부여 (shield `[175, 200, 400]` starLevel별, 17.3)
+  1. 시전자 보호막 부여 (shield `[175, 200, 400]` starLevel별, 17.3) — `applyMordekaiserProcCast` 가 `unit.mordekaiserCarryShield` 우선 read (PR #124 신규 필드)
   2. 4초 동안 오라 강화 (`empoweredAuraDamage` × 4초)
 - **패시브 (별도 hook 미구현)**:
   - 매초 반경 N칸 magic damage (시작 N=1, 6초마다 +1)
-  - sim 미반영 — Mordekaiser passive hook 부재
+  - sim 미반영 — Mordekaiser passive hook 부재 (LIVE 패시브 동작 일부만 `tickMordekaiserProc` 가 구현 — N=1 고정, 6초마다 +1 확장 안 됨)
 
 ## 변수 (carryAugments.ts:238 abilityData, 17.3 LIVE 기준)
 
@@ -59,47 +60,57 @@ related:
 |------|------|
 | [[patch-17-2]] LIVE | **게임 도입** — Self-Destruct/Shieldmaiden 과 함께 carry augment 3종 신규. 초기 shield `[175, 200, 250]` (17.2b plan doc "before" 표기) |
 | [[patch-17-2b]] (2026-04-29) | shield `[175,200,250]` → **`[225,250,300]`** (전반 buff). mana 변동 없음 추정. carry augment sim 정식화 (CarryAugmentConfig 도입) |
-| [[patch-17-3]] (2026-05-13) | shield `[225,250,300]` → **`[175,200,400]`** (1/2성 17.2 원복 + 3성 대폭 buff) / mana `40/100` → **`10/40`** (큰 폭 buff, 매우 빠른 발동). PR #115 (`39cbce2`) sim 정합 |
+| [[patch-17-3]] (2026-05-13) | shield `[225,250,300]` → **`[175,200,400]`** (1/2성 17.2 원복 + 3성 대폭 buff) / mana `40/100` → **`10/40`** (큰 폭 buff, 매우 빠른 발동). PR #115 (`39cbce2`) carryAugments.ts entry 갱신 |
+| 2026-05-18 (PR #124, `3678add`) | **sim 정합 완결** — PR #115 가 carryAugments entry 만 갱신했지만 `applyMordekaiserProcCast` 가 raw vars read 해서 sim 미반영이던 갭 해소. `CombatUnit.mordekaiserCarryShield` 필드 신설 + `applyHeroCarryTransforms` 가 carry abilityData.shield override 저장 + applyMordekaiserProcCast 가 우선 read. mana 도 statOverrides 적용 (item delta 보존). 회귀 가드 2건 추가 (451 → 452 tests). 위키 lint #7 closed |
 
 → **3성 shield 폭증 + mana 단축** 으로 17.3 에서 3성 Mordekaiser 의 Heat Death 가 강력한 carry 옵션으로 부상 (사용자 패치 의도 추정).
 
-## sim 적용 상태 — `partial`
+## sim 적용 상태 — `active` (17.3 정합 완결)
 
 ✅ **활성**:
 - role 변환 `Fighter` (default)
-- aoe_circle radius 1 cast (`carryAugments.ts:238` abilityOverride 사용 — `getAbilityConfigForUnit:627` findCarryAugment 경로)
-- cast `damage` (carryAugments entry 사용, line 659 `damageArr = carryCfg.abilityData.damage`)
+- aoe_circle radius 1 cast (`carryAugments.ts:238` abilityOverride — `getAbilityConfigForUnit:627` findCarryAugment 경로)
+- cast `damage` (carryAugments entry 사용)
+- **shield `[175, 200, 400]` 17.3 sim 정합 (PR #124)** — `CombatUnit.mordekaiserCarryShield` 필드 + `applyHeroCarryTransforms` 가 carry abilityData.shield override 저장 → `applyMordekaiserProcCast` 가 raw `InitialShield` 대신 우선 read
+- **mana `10/40` 17.3 sim 정합 (PR #124)** — `statOverrides: { initialMana: 10, mana: 40 }` + `applyHeroCarryTransforms` 가 base champion mana 와 delta 보존 (item bonus 보존, PR #124 Codex P2 catch 반영)
 
-❌ **미반영 — Lint finding #7 (위키 검출 7번째 사례, PR #123 Codex P2 review 발견)**:
+🔍 **미반영 / 검증 필요**:
+- Mordekaiser passive 매초 오라 (시작 N=1, 6초마다 +1) — `tickMordekaiserProc` 는 raw `DamagePerProc`/`ShieldPerProc` 사용. **반경 N 확장 (6초마다 +1)** 분기 미구현. 별도 sim 작업 필요
+- `empoweredAuraDamage` 4초 강화 — raw `Duration` vars 와 통합 검증 필요
+- statOverrides 인게임 측정 — Mordekaiser augment 활성 시 다른 stat (HP/armor/range 등) 변화 (사용자 측정 대기)
 
-`applyMordekaiserProcCast` (combatLoop.ts:939) + `tickMordekaiserProc` (line 969) 가 **raw `unit.champion.ability.variables` 직접 read**:
+## ✅ Lint finding #7 — RESOLVED (PR #124, `3678add`, 2026-05-18)
 
+### 검출 (PR #123 Codex P2 review)
+`applyMordekaiserProcCast` (combatLoop.ts:939) + `tickMordekaiserProc` (line 969) 가 raw `unit.champion.ability.variables` 직접 read:
 ```ts
 const vars = unit.champion.ability.variables;
 const initialShield = readVarByStar(vars.find(v => v.name === 'InitialShield')?.value, ...);
-const duration = readVarByStar(vars.find(v => v.name === 'Duration')?.value, ...);
 ```
 
-→ `carryAugments.ts:238` 의 다음 변수가 **sim 에 사용 안 됨**:
-- `shield` `[175, 200, 400]` (17.3) — raw `InitialShield` vars 가 실제 적용
-- `mana` `'10/40'` (17.3) — combatLoop 에서 `carryCfg.abilityData.mana` read 0건 (전체 코드 grep)
-- `empoweredDuration: 4` — raw `Duration` vars 가 실제 적용
-- `empoweredAuraDamage`, `passiveDamage` — `tickMordekaiserProc` 의 raw `DamagePerProc` / `ShieldPerProc` 사용
+→ `carryAugments.ts:238` 의 shield `[175,200,400]` (17.3) / mana `'10/40'` / empoweredDuration 모두 sim 에 사용 안 됨. **PR #115 의 17.3 정합 코드 변경이 sim 미반영**.
 
-**중대 결과**: **PR #115 의 Mordekaiser shield/mana 17.3 정합 코드 변경이 실제 sim 에 반영 안 됨**. PR #116 의 "resolved" 표기 부정확. raw champion variables (`public/data/tft_set17_champions.json` 의 InitialShield/Duration/DamagePerProc/ShieldPerProc) 가 17.3 값을 반영하고 있는지 별도 verify 필요.
+### Fix (PR #124, Option A 선택)
+1. `CombatUnit.mordekaiserCarryShield: readonly number[] | null` 필드 신규
+2. `applyHeroCarryTransforms` (combatLoop.ts:2252): MordekaiserCarry case → `target.mordekaiserCarryShield = cfg.abilityData?.shield ?? null`
+3. `applyMordekaiserProcCast` (line 943): `unit.mordekaiserCarryShield !== null ? carryShield : rawInitialShield`
+4. `MordekaiserCarry.statOverrides` 추가 (`initialMana: 10, mana: 40`)
+5. `applyHeroCarryTransforms` mana 적용에 **item delta 보존** 추가 (PR #124 Codex P2 catch — `target.maxMana = so.mana + itemDelta`)
 
-**조치 후보 (별도 sim 정확도 PR)**:
-- 옵션 A: `applyMordekaiserProcCast` 가 carry augment 활성 시 `carryCfg.abilityData` 우선 read (다른 carry 와 일관성)
-- 옵션 B: raw champion variables (InitialShield/Duration 등) 가 17.3 값 반영하도록 `tft_set17_champions.json` 검증/갱신. carryAugments.ts entry 의 shield/mana 필드는 제거 (raw vars 단일 source)
+→ 17.3 patch note Heat Death shield/mana 가 sim 에 정확히 반영. mana-altering item (Tear/Blue Buff 등) 보존.
+
+### 회귀 가드 (PR #124)
+- `MordekaiserCarry statOverrides: 17.3 mana 10/40` (mana 정합 검증)
+- `MordekaiserCarry abilityData.shield + override 분기` (code fingerprint)
+- `applyHeroCarryTransforms mana override 는 item delta 보존` (Codex P2 회귀 가드)
 
 ## Lint 체크리스트
 
-- [ ] **Mordekaiser carry shield/mana raw vars 적용 verify** — `tft_set17_champions.json` 의 InitialShield/Duration 이 17.3 값 반영하는지 (별도 sim 클린업 PR — Lint #7)
-- [ ] **`carryAugments.ts:238` 의 shield/mana/empoweredDuration 필드 정리** — raw vars 단일 source 이면 entry 에서 제거 권장
-- [ ] **PR #115/#116 의 "resolved" 표기 정확화** — patch-17-3.md / hero-augment-carry.md 의 Mordekaiser 표 row 정정 필요
-- [ ] Mordekaiser passive 매초 오라 — `tickMordekaiserProc` 가 raw `DamagePerProc` 로 구현되어 있는지 (line 969 컨텍스트 read 시 적용 site 확인 가능)
-- [ ] statOverrides 인게임 측정
-- [ ] 17.2 LIVE 초기 shield 값 — 17.2 패치노트 명시 없음
+- [x] **Mordekaiser carry shield/mana sim 정합** — PR #124 (`3678add`) 머지 완료. carry abilityData 우선 read + statOverrides item delta 보존
+- [ ] Mordekaiser passive 매초 오라 — `tickMordekaiserProc` 의 반경 N 확장 (6초마다 +1) 미구현
+- [ ] `empoweredAuraDamage` × `empoweredDuration` (4초) sim 적용 site verify
+- [ ] statOverrides (HP/armor/range 등) 인게임 측정 — 사용자 측정 대기
+- [ ] 17.2 LIVE 초기 shield 값 — 17.2 패치노트 명시 없음 (역사적 기록만)
 
 ## 17.2 ↔ 17.3 비교 (역사적 흥미)
 

--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,6 +8,23 @@ format: newest first
 
 ## 2026-05-18
 
+### Lint resolved: Mordekaiser carry source-of-truth drift (Lint finding 7 closed)
+- **Trigger**: PR #124 (`3678add`) 머지 완료 — 직렬 워크플로우
+- **위키 lint 사이클 완결 사례** (도입 후 3번째 full-cycle):
+  - PR #123 augments/mordekaiser-carry.md ingest 중 Codex P2 catch — `applyMordekaiserProcCast` 가 raw vars 직접 read → PR #115 미반영 검출 (multi-source drift)
+  - PR #124 — Option A 구현: `CombatUnit.mordekaiserCarryShield` 필드 + `applyHeroCarryTransforms` 가 carry abilityData.shield override 저장 + statOverrides mana 적용
+  - PR #124 추가 Codex P2 catch — 절대값 mana override 가 item bonus 손실. amend 로 item delta 보존 로직 추가 (`feedback_wiki_ingest_verify` 의 "호출 순서/영향 trace" 룰 도입 배경)
+  - 본 cleanup PR — 위키 표기 drift → resolved
+- **위키 갱신 내역** (커밋 `c6d9e75`):
+  - `augments/mordekaiser-carry.md` — "Multi-source drift" → "✅ resolved (PR #124)" + 패치 히스토리 PR #124 row + sim 적용 상태 partial → active + Lint #7 fix 5단계 명시 + 회귀 가드 3건 명시 + Lint 체크리스트 shield/mana 정합 [x]
+  - `mechanics/hero-augment-carry.md` Mordekaiser row: statOverrides ❌ → ✅ + shield/mana sim 정합 명시. statOverrides 채움 정책 노트 보강
+- **위키 lint 가치 검증 누적 (7건, 3건 full-cycle 완결)**:
+  1~3: documented/resolved
+  4. AbilityTargetingType triad dead code → resolved (PR #117/118/119/120)
+  5. carryAugments 17.3 drift → resolved (PR #115/116) — **단 Mordekaiser 항목은 실제 미반영이었음 (#123 검출, #124 fix)**
+  6. LeonaCarry duplicate config — PR #123 open (sim 클린업 후보)
+  7. **Mordekaiser carry source drift — PR #124 + 본 cleanup PR 로 full-cycle 완결 ✅**
+
 ### Ingest: augments/leona-carry.md + augments/mordekaiser-carry.md — augments 폴더 정립
 - **Source** (`feedback_wiki_ingest_verify` + 함수 컨텍스트 룰 적용):
   - `src/data/carryAugments.ts:171` (LeonaCarry entry) / `:238` (MordekaiserCarry entry)

--- a/docs/meta/wiki/mechanics/hero-augment-carry.md
+++ b/docs/meta/wiki/mechanics/hero-augment-carry.md
@@ -80,11 +80,11 @@ augment 전용: `shield, shieldDuration, onAttackBonus, passiveDamage, empowered
 | `IvernMinionCarry` (빅뱅) | TFT17_IvernMinion | aoe_circle r=3, dash to_largest_cluster | ✅ | ❌ | `hexReduction 0.45` + `stunDuration` |
 | `JaxCarry` (저 별을 향해) | TFT17_Jax | self_buff AS+0.15 | ✅ | ❌ | `asGain` 영구 누적 + `onAttackBonus` |
 | `PykeCarry` (청부 살인마) | TFT17_Pyke | x_shape, dash to_lowest_hp | ✅ | ❌ | `tankBonusMultiplier 0.60` + `onKillRecastMultiplier 0.70` |
-| [[mordekaiser-carry]] (뜨거운 죽음) | TFT17_Mordekaiser | aoe_circle r=1 | ✅ | ❌ | `passiveDamage` (sim 미반영) + `empoweredAuraDamage` + `shield [175,200,400]` (17.3, 3성 대폭 buff) + mana `10/40` (17.3 단축) |
+| [[mordekaiser-carry]] (뜨거운 죽음) | TFT17_Mordekaiser | aoe_circle r=1 | ✅ | ✅ (PR #124: `initialMana: 10, mana: 40`) | `shield [175,200,400]` 17.3 sim 정합 (PR #124 `mordekaiserCarryShield` 필드) + mana item delta 보존 + `passiveDamage`/`empoweredAuraDamage` (passive hook 일부 미구현) |
 | `GragasCarry` (자폭) | TFT17_Gragas | aoe_circle r=3, selfDamage | ✅ | ❌ | `healthCost 0.20` + `hexReduction 0.45` + `tankBonusMultiplier 0.60` |
 | `InvaderZed` (침략자 제드) | TFT17_Zed | self_buff (5단계) | ✅ | ❌ | stage 4-2 획득 전용 |
 
-> **모든 augment 의 `statOverrides` 가 비어있음** — 사용자가 게임에서 augment 활성 후 stat 측정 작업 필요. 채워지면 sim 정확도 큰 폭 상승.
+> **statOverrides 채움 정책**: 사용자가 게임에서 augment 활성 후 stat 측정한 데이터로만 채움. 단 17.3 patch note 명시 값 (e.g., MordekaiserCarry mana 10/40) 은 PR #124 부터 적용 (item delta 보존 로직 추가). 대부분 augment 의 HP/armor/range/AS 등 stat 측정은 여전히 미완.
 
 ## role 변환 시 자동 따라오는 것
 


### PR DESCRIPTION
## Summary

**위키 lint 사이클 완결 사례 (도입 후 3번째 full-cycle).**

```
PR #123 ingest → Codex P2 catch (Mordekaiser raw vars drift)
   ↓
PR #124 — Option A 구현 (carry abilityData 우선 read + statOverrides)
   ↓ (추가 Codex P2: 절대값 mana override 가 item bonus 손실)
PR #124 amend — item delta 보존 로직 추가
   ↓
본 PR — 위키 표기 drift → resolved
```

## 갱신 내역

### `augments/mordekaiser-carry.md`
- 요약: "Multi-source drift" → **"✅ Source-of-truth drift 해소 (PR #124 `3678add`)"**
- 변환 후 메커니즘 + 변수 섹션: statOverrides + `mordekaiserCarryShield` 적용 사실 명시
- 패치 히스토리 표: PR #124 row 추가 (`sim 정합 완결`) + PR #115 entry 정확화 ("carryAugments entry 갱신" 으로 한정)
- sim 적용 상태: **`partial` → `active`** ✅ 활성에 shield/mana 17.3 정합 추가, 🔍 검증 필요 항목 축소 (passive 매초 오라 N 확장 + statOverrides 측정만 남음)
- **Lint #7 → resolved 표기** + fix 5단계 (CombatUnit 필드 / applyHeroCarryTransforms / applyMordekaiserProcCast / statOverrides / item delta 보존) + 회귀 가드 3건 명시
- Lint 체크리스트: shield/mana 정합 [x] 처리

### `mechanics/hero-augment-carry.md`
- Mordekaiser row: statOverrides ❌ → ✅ + shield/mana sim 정합 명시
- statOverrides 채움 정책 노트 보강 — "17.3 patch note 명시 값 적용 사실" (item delta 보존 로직 도입)

### `log.md`
- 신규 entry: "Lint resolved: Mordekaiser carry source-of-truth drift (Lint finding 7 closed)"
- 위키 lint 누적 7건 정리 — **3건 full-cycle 완결** (#4, #5, #7)

## 위키 lint 누적 상태 (7건)

| # | Finding | 상태 |
|---|---------|------|
| 1~3 | documented/resolved | — |
| 4 | AbilityTargetingType triad dead code | resolved (PR #117/118/119/120) |
| 5 | carryAugments 17.3 drift | resolved (PR #115/116) — 단 Mordekaiser 실제 미반영 (#7 에서 발견) |
| 6 | LeonaCarry duplicate config | PR #123 open (sim 클린업 후보) |
| 7 | **Mordekaiser carry source drift** | **PR #124 + 본 cleanup PR 로 full-cycle 완결 ✅** |

## 메모리 보강 흐름

PR #124 의 두 P2 catch 가 메모리 워크플로우의 두 신규 룰 도입 배경:
- **entity-wide grep** (`grep "Mordekaiser"` not just `"MordekaiserCarry"`)
- **호출 순서/영향 범위 trace** (`calculateStats` 이후 호출되는 `applyHeroCarryTransforms` 의 절대값 override 가 item bonus 손실)

→ 다음 ingest 부터 4단계 verify 룰 적용 예정.

## Review checklist

- [ ] Mordekaiser-carry.md drift → resolved 표기 정확성 (PR #124 코드 변경 vs 위키 갱신 일치)
- [ ] 패치 히스토리 PR #115 entry 정확화 ("entry 갱신" 으로 한정 — sim 적용은 #124)
- [ ] hero-augment-carry.md statOverrides 채움 정책 노트 — 17.3 patch note 값 적용 예외 명시

## 다음 후보 (직렬 워크플로우)

본 PR 머지 후:
1. **GragasCarry duplicate config + source drift verify** — LeonaCarry (lint #6) + Mordekaiser (lint #7) 와 동일 패턴 검증 후보. `grep "Gragas" combatLoop.ts` 로 entity-wide search
2. **LeonaCarry duplicate config sim 클린업** (Lint #6 sim 정확도 PR)
3. augments 나머지 페이지 ingest (Aatrox/Ivern/Jax/Pyke/Nasus/Poppy/Zed Carry)
4. 챔피언별 페이지 (Annie/Galio/Shen/Yasuo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)