### PR TITLE
docs(wiki): ingest augments/gragas-carry.md — Lint #8 (duplicate config + radius shadow bug)

### DIFF
--- a/docs/meta/wiki/augments/gragas-carry.md
+++ b/docs/meta/wiki/augments/gragas-carry.md
@@ -1,0 +1,151 @@
+---
+id: gragas-carry
+type: augment
+display_name_kr: 자폭 (Self-Destruct)
+api_name: TFT17_Augment_GragasCarry
+target_champion: TFT17_Gragas
+tier: Gold
+stage: 2 only
+current_patch_status: active
+sim_active: partial   # duplicate config + radius shadow bug (아래 Lint #8)
+last_verified: 2026-05-18
+sources:
+  - src/data/carryAugments.ts:254 (GragasCarry entry — radius 3)
+  - src/lib/simulator/engine/combatLoop.ts:604 (GRAGAS_CARRY_ABILITY const — radius 0)
+  - src/lib/simulator/engine/combatLoop.ts:626 (getAbilityConfigForUnit flag 우선 분기)
+  - src/lib/simulator/engine/combatLoop.ts:2264 (applyHeroCarryTransforms gragasCarryActive set)
+  - src/lib/simulator/engine/combatLoop.ts:6259-6299 (자폭 self damage + 적군 AOE inline 분기)
+  - public/data/tft_set17_augments.json:584
+  - 공식 17.2 / 17.2b 패치노트
+related:
+  - "[[hero-augment-carry]]"
+  - "[[patch-17-2]]"
+  - "[[patch-17-2b]]"
+  - "[[leona-carry]]"
+  - "[[mordekaiser-carry]]"
+---
+
+# 자폭 (GragasCarry, Self-Destruct)
+
+## 요약
+
+[[patch-17-2]] LIVE 게임 도입 carry augment. Gold tier, Stage 2 only. 활성 시 Gragas (`TFT17_Gragas`) 가 가장 강한 1명 → `Fighter` 변환 + selfDamage cast (자기 자신 데미지, HP floor=1) + 반경 3칸 적군 magic AOE (PR4 17.2b 후속 도입). **17.2b 1회 변경 후 17.3 변경 없음**.
+
+⚠️ **2 lint findings 동시 검출** (PR #126 — 본 페이지 ingest 중):
+1. **Duplicate config pattern** ([[leona-carry]] Lint #6 와 동일): `GRAGAS_CARRY_ABILITY` const + `carryAugments.ts:254` entry 가 다른 값 (`radius: 0` vs `radius: 3`)
+2. **Radius shadow bug** — flag 우선 분기로 const radius 0 사용 → 적군 AOE 가 사실상 작동 안 함 (sim 정확도 큰 갭)
+
+## 변환 후 메커니즘
+
+- **role**: `Fighter` (default, statOverrides 미설정)
+- **ability pattern**: `aoe_circle` (config 따라 radius 다름 — Lint #8 참조)
+- **cast 흐름**:
+  1. 자기 자신에게 selfDamage 적용 (`abilityData.healthCost = 0.20` × maxHp, HP floor 1)
+  2. 반경 N 칸 적군 magic AOE (의도: `baseAOE = maxHp × baseDamageHpFrac + AP × (damage[star] / 100)`, distance multiplier `(1 - hexReduction)^dist`, tank 상대 ×1.60)
+
+## 변수 (carryAugments.ts:254 abilityData, 17.2b LIVE 기준)
+
+| 변수 | 값 | 설명 |
+|------|-----|------|
+| `mana` | `30/80` | 시작/최대 마나 |
+| `damage` | `[280, 420, 630]` | starLevel별 AP base damage |
+| `healthCost` | **`0.20`** | 자기 자신 maxHp 비율 self-damage (17.2b: 0.30 → 0.20) |
+| `hexReduction` | **`0.45`** | 헥스당 감소 배율 (17.2b: 0.55 → 0.45) |
+| `baseDamageHpFrac` | `0.10` | base AOE 에 maxHp × 10% 가산 |
+| `tankBonusMultiplier` | `0.60` | 탱커 상대 +60% damage |
+| `selfDamageHpFloor` | `1` | self-damage 로 0 이하 안 됨 |
+| `damageType` | `magic` | |
+
+## ⚠️ Lint finding #8 — Gragas duplicate config + radius shadow (위키 검출 8번째 사례)
+
+`getAbilityConfigForUnit` (combatLoop.ts:626) 가 `gragasCarryActive` flag 우선 → `GRAGAS_CARRY_ABILITY` const 사용. carryAugments entry 의 `abilityOverride.radius: 3` 가 shadow 됨.
+
+### Sub-finding A: Duplicate config inconsistency
+
+| 출처 | pattern | radius |
+|------|---------|:--:|
+| `combatLoop.ts:604` `GRAGAS_CARRY_ABILITY` const | `aoe_circle` | **`0`** |
+| `carryAugments.ts:254` `GragasCarry.abilityOverride` | `aoe_circle` | **`3`** |
+
+LeonaCarry Lint #6 와 동일 패턴.
+
+### Sub-finding B: 적군 AOE radius shadow bug (sim 정확도 큰 갭)
+
+`combatLoop.ts:6288` main cast pipeline 의 적군 AOE 분기:
+```ts
+const aoeRadius = config.radius ?? 3;  // ← 0 은 nullish 아님 → fallback 안 됨
+for (const t of opposingTeam) {
+  const dist = hexDistance(unit.position, t.position);
+  if (dist > aoeRadius) continue;  // dist > 0 인 모든 적 skip
+  // ... AOE damage 적용
+}
+```
+
+`config = GRAGAS_CARRY_ABILITY` (radius 0) 라면 `0 ?? 3 = 0`. `dist > 0` 인 모든 적 skip → **caster 와 같은 hex 에 있는 적군만 hit** (사실상 0명).
+
+→ patch note 와 desc 명시 "반경 3칸 magic damage" 가 sim 에 작동 안 함. PR4 (17.2b 후속) 가 적군 AOE 코드 추가했지만 radius 0 때문에 무력화. carryAugments entry 의 `radius: 3` 의도가 sim 미반영.
+
+**조치 후보 (별도 sim 정확도 PR)**:
+- 옵션 A: `GRAGAS_CARRY_ABILITY.radius` 0 → 3 (단순. const 의 "적군 데미지 없음" 주석은 17.2 도입 시점 — outdated. PR4 가 적군 AOE 도입 후 갱신 안 됨)
+- 옵션 B: `LEONA_CARRY_ABILITY` / `GRAGAS_CARRY_ABILITY` const 둘 다 제거 + flag 경로 우회 → carryAugments entry 단일 source (LeonaCarry Lint #6 와 통합 해소)
+- 옵션 C: `aoeRadius = (config.radius != null && config.radius > 0) ? config.radius : 3` 같은 fallback (0 도 fallback)
+
+> 옵션 B 가 가장 깨끗 — Lint #6 (LeonaCarry duplicate) 와 동시 해소.
+
+### 추가 — Mordekaiser pattern 과 비교
+
+| Carry | duplicate const | source drift 패턴 | sim 정합 |
+|-------|:---------------:|:----------------:|:--------:|
+| LeonaCarry (#6) | ✅ ([[leona-carry]]) | ❌ (carryAugments entry 사용) | partial — stun duration mismatch |
+| MordekaiserCarry (#7) | ❌ | ✅ (raw vars vs carryAugments entry) | **resolved (PR #124)** |
+| **GragasCarry (#8)** | ✅ (radius mismatch) | ❌ | **partial — 적군 AOE 거의 무력화** |
+
+→ Gragas 는 LeonaCarry 의 duplicate const 패턴 + 더 심각한 결과 (적군 AOE 무력화). 같은 sim 클린업 PR (옵션 B) 로 동시 해소 가능.
+
+## 패치 히스토리
+
+| 패치 | 변경 |
+|------|------|
+| [[patch-17-2]] LIVE | **게임 도입** — Heat Death/Shieldmaiden 과 함께 carry augment 3종 신규. PR4 (17.2b 후속) 가 적군 AOE 코드 도입 — 단 radius 0 때문에 작동 안 함 (Lint #8 sub-B) |
+| [[patch-17-2b]] (2026-04-29) | healthCost `0.30 → 0.20` (자기 손실 완화) / hexReduction `0.55 → 0.45` (헥스당 감소 완화 — buff). carry augment sim 정식화 (CarryAugmentConfig 도입) |
+| [[patch-17-3]] (2026-05-13) | **변경 없음** (17.3 patch note 에 Self-Destruct 항목 없음). 17.2b 값 그대로 유지 |
+
+## sim 적용 상태 — `partial`
+
+✅ **활성**:
+- role 변환 `Fighter`
+- `aoe_circle` pattern + `selfDamage: true` + HP floor 1
+- self-damage 공식 (`maxHp × healthCost`)
+- carry abilityData 직접 read — `healthCost`/`damage`/`baseDamageHpFrac`/`hexReduction`/`tankBonusMultiplier`/`damageType` 모두 main cast pipeline (line 6263-6299) 에서 사용 (Mordekaiser 와 달리 별도 specific helper 없음)
+
+❌ **미반영 (Lint #8 sub-B)**:
+- **적군 AOE radius shadow bug** — `GRAGAS_CARRY_ABILITY.radius = 0` 이 carryAugments entry `radius: 3` 을 shadow → 적군 AOE 사실상 작동 안 함. patch note "반경 3칸 magic damage" 의도 무력화
+
+❌ **미반영 (statOverrides 측정 대기)**:
+- HP/armor/MR/AS/range/damage 등 augment 활성 시 변환된 stat — 사용자 인게임 측정 필요
+
+## Lint 체크리스트
+
+- [ ] **Lint #8 sub-A**: `GRAGAS_CARRY_ABILITY` const vs `carryAugments.ts:254` entry duplicate 정리 (옵션 B 권장 — LeonaCarry Lint #6 와 동시 해소)
+- [ ] **Lint #8 sub-B**: 적군 AOE radius shadow bug fix — 사용자 결정 후 sim 클린업 PR (옵션 A 가 가장 단순)
+- [ ] `tickGragasProc` 같은 specific helper 없는지 (entity-wide grep `Gragas` 결과 0건 확인됨 — Mordekaiser 와 달리 multi-source drift 없음)
+- [ ] statOverrides 인게임 측정 — Gragas augment 활성 vs 비활성 stat 차이
+- [ ] 17.2 LIVE 초기 healthCost/hexReduction 값 — 17.2b plan doc "before" 표기로 역추정 (`0.30` / `0.55`)
+
+## 17.2 vs 17.2b 비교 (역사적 기록)
+
+| 변수 | 17.2 (도입) | 17.2b | 의도 |
+|------|:-----------:|:----:|------|
+| `healthCost` | `0.30` (추정) | **`0.20`** | 자기 손실 완화 |
+| `hexReduction` | `0.55` (추정) | **`0.45`** | 헥스당 감소 완화 (먼 적도 더 맞음) |
+| `damage` | `[280, 420, 630]` (변동 없음) | `[280, 420, 630]` | — |
+
+→ 17.2b 는 전반적 buff. Gragas 사용률 활성화 의도.
+
+## 관련
+
+- [[hero-augment-carry]] — carry augment 시스템 전체
+- [[leona-carry]] — 동일 duplicate const 패턴 (Lint #6) + 같은 17.2 도입 시점
+- [[mordekaiser-carry]] — 다른 multi-source 패턴 (Lint #7, resolved PR #124)
+- [[patch-17-2]] / [[patch-17-2b]] — 도입 + 조정 시점
+- 코드: `src/data/carryAugments.ts:254`, `src/lib/simulator/engine/combatLoop.ts:604/626/6259`

--- a/docs/meta/wiki/index.md
+++ b/docs/meta/wiki/index.md
@@ -36,8 +36,9 @@ _미작성_
 
 ## Augments
 
-- [[leona-carry]] (방패 여전사) — 17.2 도입, 3회 연속 변경 carry augment. ⚠️ duplicate config lint (combatLoop `LEONA_CARRY_ABILITY` const vs carryAugments entry)
-- [[mordekaiser-carry]] (뜨거운 죽음) — 17.2 도입, 3회 연속 변경. 17.3 3성 shield `[175,200,400]` 대폭 buff. Mordekaiser passive 매초 오라 sim 미반영
+- [[leona-carry]] (방패 여전사) — 17.2 도입, 3회 연속 변경 carry augment. ⚠️ Lint #6: duplicate config (`LEONA_CARRY_ABILITY` const vs carryAugments entry)
+- [[mordekaiser-carry]] (뜨거운 죽음) — 17.2 도입, 3회 연속 변경. ✅ Lint #7 resolved (PR #124 source drift fix). Mordekaiser passive 매초 오라 N 확장 sim 미반영
+- [[gragas-carry]] (자폭) — 17.2 도입. ⚠️ **Lint #8**: duplicate config + **radius shadow bug** (`GRAGAS_CARRY_ABILITY.radius=0` 이 entry `radius=3` shadow → 적군 AOE 무력화)
 
 ## Raw Sources (Layer 1)
 
@@ -50,8 +51,8 @@ _미작성_
 ## 작성 우선순위 (다음 후보)
 
 위키화 가치 높은 순:
-1. **augments 나머지 8개** — Gragas/Aatrox/Ivern/Jax/Pyke/Nasus/Poppy/Zed Carry. 특히 Gragas 는 LeonaCarry 와 동일 duplicate config 패턴 (`GRAGAS_CARRY_ABILITY` const + `gragasCarryActive` flag) verify 후 lint finding 보강
-2. **챔피언별** — Annie, Galio, Shen, Yasuo (이미 plan 문서 존재)
-3. **Poppy/Nasus 인게임 verify 후 statOverrides 적용** (Lint #5 잔존 TODO — 사용자 측정 필요)
-4. **`mechanics/ability-pattern-internals`** — `findAbilityTargets` 9 패턴 알고리즘 깊이 (line/bounce 알고리즘 디테일, getHexesInLine/Cone 헬퍼)
-5. **`patches/patch-17-1`** — Set 17 출시 시점 (더 thin, 도메인 가치 낮음)
+1. **Lint #6 + #8 통합 sim 클린업 PR** — LeonaCarry/GragasCarry duplicate const 둘 다 제거 + flag 경로 우회 → carryAugments entry 단일 source. **Gragas radius shadow bug (적군 AOE 무력화) 동시 해소** — sim 정확도 큰 갭
+2. **augments 나머지 7개** — Aatrox/Ivern/Jax/Pyke/Nasus/Poppy/Zed Carry
+3. **챔피언별** — Annie, Galio, Shen, Yasuo (이미 plan 문서 존재)
+4. **Poppy/Nasus 인게임 verify 후 statOverrides 적용** (Lint #5 잔존 TODO — 사용자 측정 필요)
+5. **`mechanics/ability-pattern-internals`** — `findAbilityTargets` 9 패턴 알고리즘 깊이 (line/bounce 알고리즘 디테일, getHexesInLine/Cone 헬퍼)

--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,6 +8,34 @@ format: newest first
 
 ## 2026-05-18
 
+### Ingest: augments/gragas-carry.md — 2 lint findings 동시 검출 (Lint #8 sub-A + sub-B)
+- **Source** (`feedback_wiki_ingest_verify` 4단계 워크플로우 적용 — entity-wide grep 핵심):
+  - `src/data/carryAugments.ts:254` (GragasCarry entry — abilityOverride radius 3)
+  - `src/lib/simulator/engine/combatLoop.ts:604` (GRAGAS_CARRY_ABILITY const — radius 0) — entity-wide grep `"Gragas"` 로 발견
+  - `combatLoop.ts:626` getAbilityConfigForUnit flag 우선 분기
+  - `combatLoop.ts:6259-6299` 자폭 self damage + 적군 AOE inline 분기 (함수 컨텍스트 read)
+  - `combatLoop.ts:2264` applyHeroCarryTransforms gragasCarryActive set
+- **⚠️ Lint finding #8 (2 sub-findings 동시)**:
+  - **Sub-A (LeonaCarry #6 와 동일 패턴)**: `GRAGAS_CARRY_ABILITY` const `radius: 0` vs `carryAugments.ts:GragasCarry.abilityOverride.radius: 3` — 두 source 다른 값
+  - **Sub-B (sim 정확도 큰 갭)**: main cast pipeline line 6288 `const aoeRadius = config.radius ?? 3` 에서 `0 ?? 3 = 0` (0 은 nullish 아님). `dist > 0` 인 모든 적 skip → **caster 같은 hex 적군만 hit (사실상 0명)** → patch note "반경 3칸 magic damage" 의도 무력화. PR4 (17.2b 후속) 가 적군 AOE 코드 추가했지만 radius 0 때문에 비활성. carryAugments entry `radius: 3` 의도 sim 미반영
+- **Mordekaiser pattern (#7) 과 비교**:
+  - GragasCarry: LeonaCarry duplicate const 패턴 (#6) + radius shadow 결과 더 심각 (적군 AOE 무력화)
+  - 다행히 source drift (raw vars vs carryAugments) 패턴은 없음 — `applyGragasCast` / `tickGragas` 같은 specific helper 없음. main cast pipeline inline 분기 (line 6259-6299) 가 carryAugments abilityData 직접 read
+- **권장 조치** (별도 sim 정확도 PR — index.md 우선순위 1번 등록):
+  - **옵션 B 권장**: `LEONA_CARRY_ABILITY` + `GRAGAS_CARRY_ABILITY` const 둘 다 제거 + flag 경로 우회 → carryAugments entry 단일 source. **Lint #6 + #8 동시 해소**
+- **Cross-ref 갱신**:
+  - `mechanics/hero-augment-carry.md` Gragas row — Lint #8 명시 + [[gragas-carry]] 링크
+  - `index.md` Augments 섹션 [[gragas-carry]] 추가 + 우선순위 1번 갱신 (#6+#8 통합 PR 강조)
+- **위키 lint 누적 (8건, 3건 full-cycle 완결)**:
+  1~5: documented/resolved (4 full-cycle)
+  6. LeonaCarry duplicate config — open
+  7. Mordekaiser carry source drift — full-cycle ✅
+  8. **GragasCarry duplicate config + radius shadow bug — 본 PR 검출, sim 정확도 PR 후보 (Lint #6 와 동시 해소 권장)**
+- **entity-wide grep 룰 가치 누적 검증 (3번째)**:
+  1. PR #123 Mordekaiser drift 검출 (룰 도입 배경)
+  2. PR #124 메모리 적용 후 fix
+  3. **본 PR Gragas duplicate + radius shadow 검출** (메모리 룰 enforcement 효과 — 같은 lint cycle 빠른 검출)
+
 ### Lint resolved: Mordekaiser carry source-of-truth drift (Lint finding 7 closed)
 - **Trigger**: PR #124 (`3678add`) 머지 완료 — 직렬 워크플로우
 - **위키 lint 사이클 완결 사례** (도입 후 3번째 full-cycle):

--- a/docs/meta/wiki/mechanics/hero-augment-carry.md
+++ b/docs/meta/wiki/mechanics/hero-augment-carry.md
@@ -81,7 +81,7 @@ augment 전용: `shield, shieldDuration, onAttackBonus, passiveDamage, empowered
 | `JaxCarry` (저 별을 향해) | TFT17_Jax | self_buff AS+0.15 | ✅ | ❌ | `asGain` 영구 누적 + `onAttackBonus` |
 | `PykeCarry` (청부 살인마) | TFT17_Pyke | x_shape, dash to_lowest_hp | ✅ | ❌ | `tankBonusMultiplier 0.60` + `onKillRecastMultiplier 0.70` |
 | [[mordekaiser-carry]] (뜨거운 죽음) | TFT17_Mordekaiser | aoe_circle r=1 | ✅ | ✅ (PR #124: `initialMana: 10, mana: 40`) | `shield [175,200,400]` 17.3 sim 정합 (PR #124 `mordekaiserCarryShield` 필드) + mana item delta 보존 + `passiveDamage`/`empoweredAuraDamage` (passive hook 일부 미구현) |
-| `GragasCarry` (자폭) | TFT17_Gragas | aoe_circle r=3, selfDamage | ✅ | ❌ | `healthCost 0.20` + `hexReduction 0.45` + `tankBonusMultiplier 0.60` |
+| [[gragas-carry]] (자폭) | TFT17_Gragas | aoe_circle r=3, selfDamage | ✅ | ❌ | `healthCost 0.20` + `hexReduction 0.45` + `tankBonusMultiplier 0.60`. ⚠️ **Lint #8 duplicate config + radius shadow bug**: `GRAGAS_CARRY_ABILITY` const `radius=0` 이 entry `radius=3` 을 shadow → **적군 AOE 거의 무력화** |
 | `InvaderZed` (침략자 제드) | TFT17_Zed | self_buff (5단계) | ✅ | ❌ | stage 4-2 획득 전용 |
 
 > **statOverrides 채움 정책**: 사용자가 게임에서 augment 활성 후 stat 측정한 데이터로만 채움. 단 17.3 patch note 명시 값 (e.g., MordekaiserCarry mana 10/40) 은 PR #124 부터 적용 (item delta 보존 로직 추가). 대부분 augment 의 HP/armor/range/AS 등 stat 측정은 여전히 미완.


### PR DESCRIPTION
## Summary

augments/ 폴더 3번째 entry. **entity-wide grep 룰 (메모리 워크플로우)** 적용 중 2 lint sub-findings 동시 검출. 그 중 sub-B 는 **sim 정확도 큰 갭** (적군 AOE 사실상 무력화).

## ⚠️ Lint finding #8 (위키 검출 8번째, 2 sub-findings)

### Sub-A: Duplicate config inconsistency (LeonaCarry #6 와 동일 패턴)

| 출처 | pattern | radius |
|------|---------|:--:|
| `combatLoop.ts:604` `GRAGAS_CARRY_ABILITY` const | `aoe_circle` | **`0`** |
| `carryAugments.ts:254` `GragasCarry.abilityOverride` | `aoe_circle` | **`3`** |

`getAbilityConfigForUnit:626` 가 `gragasCarryActive` flag 우선 분기 → const 사용 → entry shadow.

### Sub-B: Radius shadow bug — 적군 AOE 무력화 (sim 정확도 큰 갭)

`combatLoop.ts:6288` main cast pipeline 적군 AOE 분기:
```ts
const aoeRadius = config.radius ?? 3;  // ← 0 은 nullish 아님 → fallback 안 됨
for (const t of opposingTeam) {
  const dist = hexDistance(unit.position, t.position);
  if (dist > aoeRadius) continue;  // dist > 0 인 모든 적 skip
}
```

`config = GRAGAS_CARRY_ABILITY` (radius 0) → `0 ?? 3 = 0`. → **caster 같은 hex 적군만 hit (사실상 0명)**.

→ patch note 와 desc 명시 "반경 3칸 magic damage" 가 sim 에 작동 안 함. PR4 (17.2b 후속) 가 적군 AOE 코드 추가했지만 radius 0 때문에 무력화. carryAugments entry `radius: 3` 의도 sim 미반영.

## 다른 carry pattern 비교

| Carry | Lint | duplicate const | source drift | sim 정합 |
|-------|------|:---------------:|:------------:|:--------:|
| [[leona-carry]] | #6 | ✅ | ❌ | partial — stun duration mismatch |
| [[mordekaiser-carry]] | #7 | ❌ | ✅ | **resolved (PR #124)** |
| **[[gragas-carry]]** | **#8** | ✅ (radius) | ❌ | **partial — 적군 AOE 무력화** |

## 권장 조치 — Lint #6 + #8 통합 sim 클린업 PR

옵션 B 권장:
- `LEONA_CARRY_ABILITY` + `GRAGAS_CARRY_ABILITY` const **둘 다 제거**
- `getAbilityConfigForUnit` 의 flag 우선 분기 우회 → `findCarryAugment` 경로 사용
- → carryAugments entry 단일 source. **Lint #6 + #8 동시 해소**

대안 옵션:
- 옵션 A: `GRAGAS_CARRY_ABILITY.radius` 0 → 3 (단순 fix, duplicate 잔존)
- 옵션 C: fallback 변경 `config.radius != null && > 0 ? : 3` (0 도 fallback)

## entity-wide grep 룰 가치 검증 (3번째 누적 사례)

`feedback_wiki_ingest_verify` 메모리의 **entity-wide grep 룰** 효과 누적:
1. PR #123 — Mordekaiser drift 검출 (룰 도입 배경)
2. PR #124 — 룰 적용한 sim fix
3. **본 PR — Gragas duplicate + radius shadow 검출** (메모리 enforcement 효과 — 빠른 검출)

→ 룰 누적 적용으로 lint 검출 패턴 안정화.

## 페이지 구조 (`augments/gragas-carry.md`, ~200 lines)

- 요약 (2 lint findings 동시 검출 명시)
- 변환 후 메커니즘 + 변수 표 (17.2b 기준)
- ⚠️ Lint #8 분석 (sub-A duplicate config, sub-B radius shadow)
- 다른 carry pattern (#6/#7) 비교 표
- 패치 히스토리 (17.2 도입 → 17.2b 조정, 17.3 변경 없음)
- sim 적용 상태 (`partial` — sub-B 때문에 적군 AOE 미반영)
- Lint 체크리스트 (#8 sub-A/sub-B 두 항목)

## 위키 lint 누적 상태 (8건)

| # | 상태 |
|---|------|
| 1~5 | documented/resolved (4 full-cycle) |
| 6 LeonaCarry duplicate config | open |
| 7 Mordekaiser carry source drift | full-cycle ✅ (PR #124+#125) |
| **8 GragasCarry duplicate + radius shadow** | **검출 (sim 정확도 PR 후보)** |

## Cross-ref 갱신

- `mechanics/hero-augment-carry.md` Gragas row — Lint #8 명시 + `[[gragas-carry]]` 링크
- `index.md` Augments 섹션 `[[gragas-carry]]` 추가 + 우선순위 1번 갱신 (`#6+#8 통합 PR` 강조)
- `log.md` ingest entry + lint 누적 8건 정리 + entity-wide grep 룰 가치 검증 누적

## Review checklist

- [ ] Lint #8 sub-A duplicate config 정확성 (`GRAGAS_CARRY_ABILITY.radius=0` vs carryAugments `radius=3`)
- [ ] Lint #8 sub-B radius shadow 결과 (`0 ?? 3 = 0` 동작 + AOE 가드 영향) 정확성
- [ ] Mordekaiser (#7) 와의 패턴 차이 명확화 (Gragas 는 source drift 없음 — main pipeline inline 분기가 carryAugments 직접 read)
- [ ] 권장 조치 옵션 B 적절성 (LeonaCarry + GragasCarry 동시 해소)

## 다음 후보 (직렬 워크플로우)

본 PR 머지 후:
1. **Lint #6 + #8 통합 sim 클린업 PR** (옵션 B — const 제거 + flag 경로 우회)
2. augments 나머지 7개 (Aatrox/Ivern/Jax/Pyke/Nasus/Poppy/Zed Carry)
3. 챔피언별 페이지

🤖 Generated with [Claude Code](https://claude.com/claude-code)