### PR TITLE
fix(sim): LEONA_CARRY_ABILITY / GRAGAS_CARRY_ABILITY const 제거 — Lint #6 + #8 동시 해소

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -596,35 +596,26 @@ function applyHexBuffs(units: CombatUnit[], hexBuffs: HexBuff[]): void {
   }
 }
 
-/**
- * 자폭 (TFT17_Augment_GragasCarry) ability 변환 config.
- * 거대한 폭발: 적군 데미지 없음, 자기 자신만 데미지 + HP floor=1 (자기 스킬로 죽지 않음).
- * damage 값은 그라가스 ability "Damage" 변수 그대로 (heal 제거).
+/** 캐리 증강 포함 AbilityConfig 결정.
+ *
+ * PR #127 (Lint #6 + #8 통합 해소): 이전 LEONA_CARRY_ABILITY / GRAGAS_CARRY_ABILITY
+ * const + gragasCarryActive / leonaCarryActive flag 우선 분기 제거. carryAugments.ts
+ * entry 의 abilityOverride 가 단일 source.
+ *
+ * 해소된 lint findings:
+ *   - #6 LeonaCarry duplicate config: 이전 const stun 1.5 (fixed) 가 entry stun 1.0 +
+ *     abilityData stunDuration [1.0, 1.25, 1.5] (starLevel별) 을 shadow. 이제 entry
+ *     사용되며 starLevel별 stun 의도 정합 (단 main cast pipeline 의 starLevel별
+ *     stun 적용 site 는 별도 — abilityData.stunDuration read 위치 verify 필요)
+ *   - #8 GragasCarry radius shadow bug: 이전 const radius 0 이 entry radius 3 을
+ *     shadow + main pipeline `config.radius ?? 3` 의 0 nullish-not-fallback 문제로
+ *     적군 AOE 무력화. 이제 entry radius 3 사용 → patch note 의도 정합 (반경 3칸)
+ *
+ * gragasCarryActive / leonaCarryActive flag 자체는 sim 코드 사용처 없으나
+ * 테스트 assertion 8건 사용 중이므로 scope strict (CLAUDE.md "Don't refactor
+ * beyond what task requires") 보존. flag 자체 dead 정리는 별도 PR 후보.
  */
-const GRAGAS_CARRY_ABILITY: AbilityConfig = {
-  pattern: 'aoe_circle',
-  radius: 0,
-  selfDamage: true,
-  selfDamageHpFloor: 1,
-};
-
-/**
- * 방패 여전사 (TFT17_Augment_LeonaCarry) ability 변환 config.
- * 적 가로질러 dash + line 관통 물리 피해 + 첫 적중 대상에만 기절 (CC).
- */
-const LEONA_CARRY_ABILITY: AbilityConfig = {
-  pattern: 'line',
-  maxTargets: 4,
-  dash: 'to_target',
-  stun: 1.5,
-  firstHitOnlyStun: true,
-};
-
-/** 캐리 증강 포함 AbilityConfig 결정 */
 function getAbilityConfigForUnit(unit: CombatUnit, augmentApiNames: string[]): AbilityConfig {
-  // hero augment carry 변환 — applyHeroCarryTransforms 가 활성 unit 에 flag 설정.
-  if (unit.gragasCarryActive) return GRAGAS_CARRY_ABILITY;
-  if (unit.leonaCarryActive) return LEONA_CARRY_ABILITY;
   const carry = findCarryAugment(unit.champion.apiName, augmentApiNames);
   if (carry) return carry.abilityOverride;
   return CHAMPION_ABILITY_PATTERNS[unit.champion.apiName] ?? { pattern: 'single' };

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -1373,4 +1373,39 @@ describe('CarryAugmentConfig.statOverrides — 슬롯 추후 채움 가드', () 
     expect(combatLoopSrc).toMatch(/target\.champion\.stats\.initialMana[\s\S]+?itemDelta\s*=\s*target\.currentMana/);
     expect(combatLoopSrc).toMatch(/target\.currentMana\s*=\s*so\.initialMana\s*\+\s*itemDelta/);
   });
+
+  it('Lint #6 + #8 해소 — LEONA_CARRY_ABILITY / GRAGAS_CARRY_ABILITY const 제거 + flag 우선 분기 우회 (PR #127 회귀 가드)', async () => {
+    // PR #126 검출 Lint #6 (LeonaCarry duplicate config) + Lint #8 (GragasCarry duplicate
+    // config + radius shadow bug) 동시 해소. carryAugments.ts entry 단일 source.
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const combatLoopSrc = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+
+    // legacy const 정의 완전 제거
+    expect(combatLoopSrc).not.toMatch(/const\s+LEONA_CARRY_ABILITY\s*[:=]/);
+    expect(combatLoopSrc).not.toMatch(/const\s+GRAGAS_CARRY_ABILITY\s*[:=]/);
+
+    // getAbilityConfigForUnit 의 flag 우선 return 분기 제거 (entry 단일 경로)
+    expect(combatLoopSrc).not.toMatch(/if\s*\(\s*unit\.gragasCarryActive\s*\)\s*return\s+GRAGAS_CARRY_ABILITY/);
+    expect(combatLoopSrc).not.toMatch(/if\s*\(\s*unit\.leonaCarryActive\s*\)\s*return\s+LEONA_CARRY_ABILITY/);
+
+    // entry sanity — carryAugments 의 abilityOverride 가 사용되는 path 만 유지
+    expect(combatLoopSrc).toMatch(/function\s+getAbilityConfigForUnit[\s\S]+?findCarryAugment\(unit\.champion\.apiName[\s\S]+?carry\.abilityOverride/);
+  });
+
+  it('Lint #6 + #8 fact — carryAugments entry 가 단일 source 의 정확값 보유 (PR #127 의존)', () => {
+    // LeonaCarry: stun 1.0 (config) + stunDuration [1.0, 1.25, 1.5] (starLevel별, abilityData)
+    const leona = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_LeonaCarry');
+    expect(leona?.abilityOverride.stun).toBe(1.0);  // 이전 LEONA_CARRY_ABILITY const 의 1.5 shadow 해소
+    expect(leona?.abilityData?.stunDuration).toEqual([1.0, 1.25, 1.5]);
+
+    // GragasCarry: radius 3 (이전 GRAGAS_CARRY_ABILITY const 의 radius 0 shadow 해소 → 적군 AOE 정상 작동)
+    const gragas = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_GragasCarry');
+    expect(gragas?.abilityOverride.pattern).toBe('aoe_circle');
+    expect(gragas?.abilityOverride.radius).toBe(3);
+    expect(gragas?.abilityOverride.selfDamage).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

위키 검출 **2 lint findings 동시 해소** PR. Option B 채택 — legacy const 제거 + flag 우선 분기 우회 → `carryAugments.ts` entry 단일 source.

```
PR #123 → Lint #6 LeonaCarry duplicate config (open)
PR #126 → Lint #8 GragasCarry duplicate + radius shadow (open)
   ↓
본 PR — 옵션 B 단일 사이클 동시 해소
```

## 해소된 lint findings

### Lint #6 — LeonaCarry duplicate config (PR #123 검출)
- `combatLoop.ts:615` `LEONA_CARRY_ABILITY` const `stun: 1.5` (fixed)
- `carryAugments.ts:171` entry `stun: 1.0` + `abilityData.stunDuration: [1.0, 1.25, 1.5]` (starLevel별)
- **결과**: 1성/2성 stun 도 1.5초 적용. starLevel별 의도 sim 미반영

### Lint #8 — GragasCarry duplicate + radius shadow (PR #126 검출)
- `combatLoop.ts:604` `GRAGAS_CARRY_ABILITY` const `radius: 0`
- `carryAugments.ts:254` entry `abilityOverride.radius: 3`
- **결과**: main pipeline `config.radius ?? 3` 의 `0 ?? 3 = 0` (nullish 아님) → `dist > 0` 인 모든 적 skip → **적군 AOE 사실상 무력화**. patch note "반경 3칸 magic damage" 의도 미반영

## Fix (Option B — scope strict)

### 코드 변경
- `combatLoop.ts:599-621` `LEONA_CARRY_ABILITY` + `GRAGAS_CARRY_ABILITY` const 제거
- `combatLoop.ts:625-627` `getAbilityConfigForUnit` 의 flag 우선 분기 우회
- `findCarryAugment(...) → carry.abilityOverride` 단일 경로

```ts
// Before:
function getAbilityConfigForUnit(unit, augmentApiNames) {
  if (unit.gragasCarryActive) return GRAGAS_CARRY_ABILITY;  // ← radius 0
  if (unit.leonaCarryActive) return LEONA_CARRY_ABILITY;    // ← stun 1.5
  const carry = findCarryAugment(...);
  if (carry) return carry.abilityOverride;
  return CHAMPION_ABILITY_PATTERNS[...] ?? { pattern: 'single' };
}

// After:
function getAbilityConfigForUnit(unit, augmentApiNames) {
  const carry = findCarryAugment(...);
  if (carry) return carry.abilityOverride;  // ← Leona stun 1.0 / Gragas radius 3
  return CHAMPION_ABILITY_PATTERNS[...] ?? { pattern: 'single' };
}
```

### scope strict 보존 (CLAUDE.md "Don't refactor beyond what task requires")
- `gragasCarryActive` / `leonaCarryActive` **flag 자체는 보존** — sim 코드 사용처 없으나 테스트 assertion 8건 (`hero-carry-augments.test.ts` + `hero-augment-stat-system.test.ts`) 가 flag check 중
- flag 자체 dead 정리는 별도 PR 후보

## 영향 (positive — sim 정확도 개선)

| Carry | Before (const shadow) | After (entry 단일 source) |
|-------|----------------------|---------------------------|
| Leona stun | `1.5` fixed (starLevel 무관) | `[1.0, 1.25, 1.5]` starLevel별 — **1성/2성 너프 적용** |
| Gragas 적군 AOE | radius 0 → 무력화 | radius 3 → **정상 작동** (반경 3칸 + hexReduction 0.45 + tankBonus 0.60) |

## 검증

- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm build` — exit 0
- [x] `pnpm vitest run tests/unit/simulator/` — **454 passed / 8 skipped** (이전 452 + 신규 회귀 가드 2건). 기존 LeonaCarry/GragasCarry 테스트 전부 통과 — const 값에 의존하던 곳 없었음 (예: stun 1.5 expect 직접 assertion 없음)

## 신규 회귀 가드 (2건)

1. **Code fingerprint 가드**: `LEONA_CARRY_ABILITY` / `GRAGAS_CARRY_ABILITY` const 미존재 + flag 우선 return 분기 미존재 + `findCarryAugment → abilityOverride` 경로 존재
2. **Entry fact 가드**: `LeonaCarry.abilityOverride.stun = 1.0`, `LeonaCarry.abilityData.stunDuration = [1.0, 1.25, 1.5]`, `GragasCarry.abilityOverride.radius = 3` 등 단일 source 정확값

## 위키 cross-ref (별도 PR — 직렬 워크플로우)

본 PR 머지 후 cleanup PR:
- `wiki/augments/leona-carry.md` Lint #6 → resolved 표기 + 커밋 hash 명시
- `wiki/augments/gragas-carry.md` Lint #8 (sub-A + sub-B) → resolved 표기
- `wiki/log.md` "Lint resolved #6 + #8" entry

## 위키 lint 누적 상태 (8건, 본 PR 후 5건 full-cycle)

| # | Finding | 상태 |
|---|---------|------|
| 1~3 | documented/resolved | — |
| 4 | AbilityTargetingType triad | full-cycle ✅ |
| 5 | carryAugments 17.3 drift | full-cycle ✅ (단 #7 발견) |
| 6 | **LeonaCarry duplicate config** | **본 PR 로 sim 해소, wiki cleanup 대기** |
| 7 | Mordekaiser drift | full-cycle ✅ |
| 8 | **GragasCarry duplicate + radius shadow** | **본 PR 로 sim 해소 (sub-A + sub-B), wiki cleanup 대기** |

## Review checklist

- [ ] Const 제거 후 다른 reference 잔존 없는지 (typecheck 통과로 확인됨)
- [ ] LeonaCarry stun starLevel별 적용 — abilityData.stunDuration 의 read 위치도 별도 verify (간접: 회귀 가드의 entry fact)
- [ ] GragasCarry 적군 AOE radius 3 실제 작동 — sim integration 테스트 추가 후보 (코드 fingerprint 만으로는 동작 verify 불충분)
- [ ] flag 자체 (`gragasCarryActive` / `leonaCarryActive`) 보존 적절성 (scope strict, 별도 dead 정리 PR)

## 다음 후보 (직렬 워크플로우)

본 PR 머지 후:
1. **wiki cleanup PR** — `leona-carry.md` Lint #6 + `gragas-carry.md` Lint #8 → resolved
2. **flag 자체 dead 정리** — `gragasCarryActive` / `leonaCarryActive` sim 미사용 + 테스트 의존 정리 (별도 PR)
3. augments 나머지 7개 (Aatrox/Ivern/Jax/Pyke/Nasus/Poppy/Zed Carry) — entity-wide grep 으로 동일 패턴 검출 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)