### PR TITLE
fix(sim): main pipeline stun 분기에 carry abilityData.stunDuration starLevel별 우선 read — Lint #9 해소

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6817,7 +6817,15 @@ export function simulateCombat(
 
             // === CC 기절 적용 ===
             if (config.stun && config.stun > 0) {
-              const stunTicks = Math.round(config.stun * TICKS_PER_SECOND);
+              // PR #129 (Lint #9 해소, PR #128 검출): carry augment abilityData.stunDuration
+              // 이 정의됐으면 starLevel별 우선 사용. 없으면 config.stun (fixed) fallback.
+              // - LeonaCarry [1.0, 1.25, 1.5] starLevel별 적용 (이전 main pipeline 미반영)
+              // - IvernMinion 은 abilityOverride.stun 없음 → 본 분기 진입 안 함 (별도 line 1232 분기)
+              // - 다른 carry: abilityData.stunDuration 미정의 → fallback config.stun (기존 동작 보존)
+              // - non-carry 챔프 (carryCfg null) → fallback (영향 없음)
+              const starLevelStun = carryCfg?.abilityData?.stunDuration?.[unit.starLevel - 1];
+              const stunDuration = starLevelStun ?? config.stun;
+              const stunTicks = Math.round(stunDuration * TICKS_PER_SECOND);
               // firstHitOnlyStun (방패 여전사 LeonaCarry) — line 첫 적중만 stun.
               const stunLimit = config.firstHitOnlyStun ? 1 : (config.stunTargets ?? abilityTargets.length);
               let stunCount = 0;
@@ -7121,7 +7129,12 @@ export function simulateCombat(
               if (outOfRangeConfig.stun && outOfRangeConfig.stun > 0 && t.currentHp > 0) {
                 // firstHitOnlyStun → 이미 한 번 적용했으면 skip (LeonaCarry 첫 적중 only).
                 if (outOfRangeConfig.firstHitOnlyStun && oorStunApplied) continue;
-                const stunTicks = Math.round(outOfRangeConfig.stun * TICKS_PER_SECOND);
+                // PR #129 (Lint #9 해소, Codex P2 amend): main pipeline 과 동일하게 carry
+                // abilityData.stunDuration starLevel별 우선. OOR (dash) cast path 에서도
+                // LeonaCarry [1.0,1.25,1.5] 정확 적용 (이전 outOfRangeConfig.stun fixed 1.0 만).
+                const oorStarLevelStun = oorCarryCfg?.abilityData?.stunDuration?.[unit.starLevel - 1];
+                const oorStunDuration = oorStarLevelStun ?? outOfRangeConfig.stun;
+                const stunTicks = Math.round(oorStunDuration * TICKS_PER_SECOND);
                 t.statusEffects.push({ type: 'stun', sourceId: unit.id, remainingTicks: stunTicks });
                 t.state = 'idle';
                 t.attackCooldown = 0;

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -1408,4 +1408,31 @@ describe('CarryAugmentConfig.statOverrides — 슬롯 추후 채움 가드', () 
     expect(gragas?.abilityOverride.radius).toBe(3);
     expect(gragas?.abilityOverride.selfDamage).toBe(true);
   });
+
+  it('Lint #9 해소 — main pipeline 의 stun 분기가 carry abilityData.stunDuration starLevel별 우선 (PR #129 회귀 가드)', async () => {
+    // PR #128 Codex P2 검출 Lint #9: combatLoop.ts:6819-6820 main pipeline 이 config.stun
+    // (fixed) 만 read 했었음. carry abilityData.stunDuration starLevel별 의도 sim 미반영.
+    // PR #129 fix — `starLevelStun = carryCfg?.abilityData?.stunDuration?.[unit.starLevel - 1]
+    // ?? config.stun` 분기 추가.
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const combatLoopSrc = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/simulator/engine/combatLoop.ts'),
+      'utf8',
+    );
+
+    // 코드 fingerprint — carry abilityData.stunDuration 우선 read 분기 존재 (main pipeline)
+    expect(combatLoopSrc).toMatch(/carryCfg\?\.abilityData\?\.stunDuration\?\.\[unit\.starLevel\s*-\s*1\]/);
+    expect(combatLoopSrc).toMatch(/const\s+stunDuration\s*=\s*starLevelStun\s*\?\?\s*config\.stun/);
+
+    // PR #129 Codex P2 amend: OOR (out-of-range) dash cast path 에도 동일 fix 적용
+    expect(combatLoopSrc).toMatch(/oorCarryCfg\?\.abilityData\?\.stunDuration\?\.\[unit\.starLevel\s*-\s*1\]/);
+    expect(combatLoopSrc).toMatch(/oorStunDuration\s*=\s*oorStarLevelStun\s*\?\?\s*outOfRangeConfig\.stun/);
+
+    // entry fact — LeonaCarry stunDuration starLevel별 정의 보존 (PR #129 효과 의도 베이스)
+    const leona = CARRY_AUGMENTS.find(c => c.augmentApiName === 'TFT17_Augment_LeonaCarry');
+    expect(leona?.abilityData?.stunDuration?.[0]).toBe(1.0); // 1성
+    expect(leona?.abilityData?.stunDuration?.[1]).toBe(1.25); // 2성
+    expect(leona?.abilityData?.stunDuration?.[2]).toBe(1.5); // 3성
+  });
 });


### PR DESCRIPTION
## Summary

PR #128 Codex P2 검출 **Lint #9 직접 해소**. PR #127 가 `LEONA_CARRY_ABILITY` const 제거했지만 main pipeline 은 여전히 `config.stun` (fixed) 만 read 했었음 → starLevel별 stun 의도 sim 미반영.

```
PR #127 — const 제거 (entry 정합)
   ↓ (Codex P2: sim 효과 미반영 catch)
PR #128 — Lint #9 등록 ("starLevel별 sim 미반영")
   ↓
본 PR — main pipeline 분기 확장 (옵션 A generic)
```

## 5단계 워크플로우 첫 적용 사례 (`feedback_wiki_ingest_verify` 신규 룰)

| 단계 | 결과 |
|------|------|
| 1. 좁은 grep | `config.stun` (line 6819), `abilityData.stunDuration` (line 1234) |
| 2. 함수 컨텍스트 read | main pipeline `if (config.stun && config.stun > 0)` 블록 + IvernMinion specific 분기 line 1232-1235 |
| 3. entity-wide grep | carryAugments.ts 의 stunDuration: LeonaCarry `[1.0, 1.25, 1.5]`, IvernMinion `[1.25, 1.5, 1.75]` 만 |
| 4. 호출 순서/영향 trace | IvernMinion 은 본 분기 미진입 (config.stun 없음). 다른 carry stunDuration 미정의 → fallback. non-carry → fallback |
| 5. actual sim integration verify | code fingerprint + entry fact 회귀 가드 추가 |

## Fix

`combatLoop.ts:6819`:
```ts
if (config.stun && config.stun > 0) {
  // PR #129 (Lint #9 해소): carry augment abilityData.stunDuration starLevel별 우선
  const starLevelStun = carryCfg?.abilityData?.stunDuration?.[unit.starLevel - 1];
  const stunDuration = starLevelStun ?? config.stun;
  const stunTicks = Math.round(stunDuration * TICKS_PER_SECOND);
  ...
}
```

`carryCfg` 변수는 line 6150 에 이미 정의됨 (같은 cast pipeline scope).

## 영향 (positive — sim 정확도 개선)

### LeonaCarry starLevel별 stun 적용
- **1성**: 1.0초 (변경 없음)
- **2성**: 1.0 → **1.25초** (buff, 25% 증가)
- **3성**: 1.0 → **1.5초** (buff, 50% 증가)

## 영향 없음 (회귀 가드 / fallback)

- **IvernMinion**: `abilityOverride.stun` 미정의 → 본 분기 미진입. 기존 line 1232-1235 별도 처리 그대로
- **다른 carry** (Nasus/Aatrox/Poppy/Jax/Pyke/Mordekaiser/Gragas/Zed): `abilityData.stunDuration` 미정의 → fallback to `config.stun`
- **non-carry 챔프 stun**: `carryCfg` null → fallback (기존 동작)

## 검증

- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm build` — exit 0
- [x] `pnpm vitest run tests/unit/simulator/` — **455 passed / 8 skipped** (이전 454 + 신규 회귀 가드 1건)

## 신규 회귀 가드

`Lint #9 해소 — main pipeline 의 stun 분기가 carry abilityData.stunDuration starLevel별 우선 (PR #129 회귀 가드)`:
- **Code fingerprint**: `starLevelStun = carryCfg?.abilityData?.stunDuration?.[unit.starLevel - 1] ?? config.stun` 패턴 존재
- **Entry fact**: `LeonaCarry.abilityData.stunDuration[0]=1.0, [1]=1.25, [2]=1.5` 보존

→ integration test (실제 simulateCombat 으로 starLevel별 stun 측정) 는 후속 후보. 본 PR 은 code fingerprint + entry fact 로 fix 정확성 보장.

## 위키 cross-ref (별도 PR — 직렬 워크플로우)

본 PR 머지 후:
- `wiki/augments/leona-carry.md` Lint #9 → resolved 표기 + 커밋 hash
- `wiki/mechanics/hero-augment-carry.md` Leona row Lint #9 resolved
- `wiki/log.md` "Lint resolved #9" entry
- `wiki/index.md` Leona description 갱신 (Lint #9 resolved)

## 위키 lint 누적 상태 (9건, 본 PR 후 6건 full-cycle)

| # | Finding | 상태 |
|---|---------|------|
| 1~5 | resolved (4 full-cycle) | — |
| 6 LeonaCarry duplicate config | full-cycle ✅ (PR #127+#128) |
| 7 Mordekaiser carry source drift | full-cycle ✅ (PR #124+#125) |
| 8 GragasCarry duplicate + radius shadow | full-cycle ✅ (PR #127+#128) |
| **9 stunDuration starLevel별 미반영** | **본 PR 로 sim 해소, wiki cleanup 대기** |

## Review checklist

- [ ] `carryCfg` 접근 가능성 (line 6150 정의가 6819 scope 까지 living)
- [ ] IvernMinion 영향 없음 — `abilityOverride.stun` 미정의 확인
- [ ] fallback 로직 (`?? config.stun`) 으로 다른 carry / non-carry 회귀 없음
- [ ] integration test 후속 후보 의도 명확화

## 후속 PR 후보 (직렬)

1. **wiki cleanup PR** — leona-carry / hero-augment-carry / log Lint #9 → resolved
2. integration test 추가 (LeonaCarry starLevel별 stun 실제 측정)
3. augments 나머지 7개 ingest (entity-wide grep 으로 추가 lint 검출 가능성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)