### PR TITLE
docs(wiki): Lint #9 (stunDuration starLevel별) resolved — PR #129 머지 후 cleanup

### DIFF
--- a/docs/meta/wiki/augments/leona-carry.md
+++ b/docs/meta/wiki/augments/leona-carry.md
@@ -7,7 +7,7 @@ target_champion: TFT17_Leona
 tier: Gold
 stage: 2 only
 current_patch_status: active
-sim_active: active   # Lint #6 resolved (PR #127, 9e6ddb3) — entry 단일 source. statOverrides 인게임 측정만 남음
+sim_active: active   # Lint #6 resolved (PR #127) + Lint #9 resolved (PR #129, main + OOR fix). statOverrides 인게임 측정만 남음
 last_verified: 2026-05-18
 sources:
   - src/data/carryAugments.ts:171 (LeonaCarry entry — abilityOverride/abilityData)
@@ -83,9 +83,10 @@ LeonaCarry 가 2개 config 로 정의되어 있었음. `getAbilityConfigForUnit`
 | [[patch-17-2]] LIVE | **게임 도입** — Heat Death/Self-Destruct 와 함께 carry augment 3종 신규. 초기 값: damage `[110,165,250]`, baseDamageHpFrac 0.28 (추정 — 17.2 패치노트 명시 없음, 17.2b plan doc 가 17.2b 시점 값 기록) |
 | [[patch-17-2b]] (2026-04-29) | damage `[110,165,250]` → **`[90,135,225]`** (큰 nerf). carry augment sim 정식화 (CarryAugmentConfig + abilityData + statOverrides) |
 | [[patch-17-3]] (2026-05-13) | baseDamageHpFrac 0.28 → **0.24** (HP scale nerf) + secondaryDamage `[180,270,405]` → **`[200,300,480]`** (line buff). PR #115 (`39cbce2`) sim 정합 |
-| 2026-05-18 (PR #127, `9e6ddb3`) | **Lint #6 sim 해소** — `LEONA_CARRY_ABILITY` const 제거 (`GRAGAS_CARRY_ABILITY` 동시) + flag 우선 분기 우회 → carryAugments entry 단일 source. **stun 1.0 fixed 적용** (이전 1.5 → 1.0 fixed). starLevel별 stunDuration `[1.0, 1.25, 1.5]` 활용은 별도 — Lint #9 (아래) 참조. [[gragas-carry]] Lint #8 과 같은 사이클 |
+| 2026-05-18 (PR #127, `9e6ddb3`) | **Lint #6 sim 해소** — `LEONA_CARRY_ABILITY` const 제거 (`GRAGAS_CARRY_ABILITY` 동시) + flag 우선 분기 우회 → carryAugments entry 단일 source. **stun 1.0 fixed 적용** (이전 1.5 → 1.0 fixed). [[gragas-carry]] Lint #8 과 같은 사이클 |
+| 2026-05-18 (PR #129, `8abbba0`) | **Lint #9 sim 해소** — main pipeline (line 6819-6831) + OOR fallback (line 7129-7140) 양쪽 분기 확장: `carryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? config.stun`. **starLevel별 stun [1.0, 1.25, 1.5] sim 적용** (1성 변경 없음, 2★ 1.0→1.25, 3★ 1.0→1.5). Codex P2 amend 로 OOR 누락 catch — 위키 [[ability-targeting]] cast path 3종 정보가 워크플로우 룰 도입 배경 |
 
-## sim 적용 상태 — `partial` (Lint #6 resolved, Lint #9 신규 검출)
+## sim 적용 상태 — `active` (Lint #6 + #9 모두 resolved)
 
 ✅ **활성**:
 - role 변환 `Fighter` (default)
@@ -93,37 +94,39 @@ LeonaCarry 가 2개 config 로 정의되어 있었음. `getAbilityConfigForUnit`
 - primary damage (carryAugments entry) + secondaryDamage (line 추가 대상)
 - baseDamageHpFrac maxHP 24% 가산 (17.3 sim 정합)
 - shield + duration
-- **`stun: 1.0` fixed (entry abilityOverride.stun, PR #127)** — 이전 const 1.5 → 1.0. 모든 starLevel 1초 적용
+- **starLevel별 stun `[1.0, 1.25, 1.5]` sim 적용 (PR #129)** — main pipeline + OOR fallback 양쪽 분기. 1★ 1.0초 / 2★ 1.25초 / 3★ 1.5초
 
-❌ **미반영 — Lint #9 (PR #128 Codex P2 review 검출)**:
-- **starLevel별 stunDuration `[1.0, 1.25, 1.5]` 활용 안 됨** — `combatLoop.ts:6819-6820` main pipeline 이 `config.stun` (fixed 1.0) 만 read. `abilityData.stunDuration` 의 main pipeline read 0건. **IvernMinion-specific 분기 (line 1232-1234) 만 `carryCfg.abilityData.stunDuration` 사용**. → 2성/3성 stun 도 1.0초 (의도 1.25/1.5 미적용)
+🔍 **검증 필요 / 미완**:
 - statOverrides (HP/AS/range/etc) — 사용자 인게임 측정 대기
+- integration test (실제 simulateCombat 으로 starLevel별 stun 측정) — 후속 후보 (PR #129 는 code fingerprint + entry fact 가드)
 
-## ⚠️ Lint finding #9 — stunDuration starLevel별 main pipeline 미반영 (PR #128 Codex P2 검출)
+## ✅ Lint finding #9 — RESOLVED (PR #129, `8abbba0`, 2026-05-18)
 
-### 검출
-PR #128 Codex P2 review 가 PR #127 의 "starLevel별 stun sim 정합" 표기 부정확 catch:
-- `combatLoop.ts:6819-6820` main cast pipeline: `if (config.stun && config.stun > 0) { const stunTicks = Math.round(config.stun * TICKS_PER_SECOND); }` — **config.stun fixed 만 read**
-- `combatLoop.ts:1234`: `const stunArr = carryCfg.abilityData.stunDuration;` — IvernMinion-specific 분기에만 존재 (line 1232-1234 컨텍스트)
-- LeonaCarry abilityOverride.stun = 1.0 (fixed) → 모든 starLevel 1.0초
+PR #128 검출 → PR #129 (옵션 A 채택 — 옵션 C와 사실상 동일) 해소. Codex P2 amend 로 OOR cast path 누락 catch 후 main + OOR 양쪽 fix 완결.
 
-### 결과
-PR #127 가 한 일 = stun 1.5 (const) → 1.0 (entry config). **starLevel별 stunDuration 적용은 여전히 미반영**. abilityData.stunDuration `[1.0, 1.25, 1.5]` 의 의도 (3성 1.5초 stun) sim 미반영.
+### 검출 시점 (PR #128) — 기록 보존
+- `combatLoop.ts:6819-6820` main pipeline: `if (config.stun && config.stun > 0) { stunTicks = config.stun * TICKS_PER_SECOND; }` — **config.stun fixed 만 read**
+- `combatLoop.ts:1234`: `carryCfg.abilityData.stunDuration` read 는 IvernMinion-specific 분기 전용
+- LeonaCarry abilityData.stunDuration `[1.0, 1.25, 1.5]` 정의되어 있으나 main pipeline 미read → 모든 starLevel 1.0초
 
-### 조치 후보 (별도 sim 정확도 PR)
-- 옵션 A: main pipeline `config.stun` 분기를 `abilityData.stunDuration[unit.starLevel - 1] ?? config.stun` 로 확장
-- 옵션 B: LeonaCarry abilityOverride.stun 제거 + IvernMinion-style 별도 분기 (LeonaCarry-specific) 추가
-- 옵션 C: IvernMinion 분기를 generic 화 — 모든 carry augment 가 abilityData.stunDuration 있으면 우선 사용
+### Fix (PR #129, Option A + Codex P2 amend)
+1. **main pipeline (line 6819-6831)**: `starLevelStun = carryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? config.stun` 분기 추가
+2. **OOR (out-of-range dash) fallback (line 7129-7140)**: 동일 패턴 추가 (`oorCarryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? outOfRangeConfig.stun`)
+3. fallback: 다른 carry (`abilityData.stunDuration` 미정의) / non-carry → 기존 `config.stun` fixed 동작 보존
 
-### 영향 범위
-- LeonaCarry: 2성/3성 stun 너프 잠재 (1.0 → 1.25/1.5)
-- IvernMinion (`abilityData.stunDuration: [1.25, 1.5, 1.75]`) 는 이미 line 1232-1234 분기로 정확 적용 — 영향 없음
-- 기타 carry: abilityData.stunDuration 정의 없음 (LeonaCarry/IvernMinion 만)
+### 워크플로우 메모리 도입 배경
+PR #129 의 Codex P2 amend (OOR 누락) 가 `feedback_wiki_ingest_verify` 메모리의 **"cast path 3종 전수 확인"** sub-rule 도입 배경. 위키 [[ability-targeting]] 페이지의 "3 cast 호출처 (main / recast / OOR fallback)" 정보가 sim fix workflow 의 도우미 역할.
+
+### 회귀 가드 (PR #129)
+- "Lint #9 해소 — main pipeline 의 stun 분기가 carry abilityData.stunDuration starLevel별 우선" — code fingerprint (main + OOR 양쪽)
+- LeonaCarry entry fact (stunDuration starLevel별 정확값)
+- integration test 는 후속 후보
 
 ## Lint 체크리스트
 
 - [x] **LEONA_CARRY_ABILITY const vs carryAugments entry duplicate 정리** — PR #127 (`9e6ddb3`) 머지 완료
-- [ ] **Lint #9: starLevel별 stunDuration main pipeline 반영** — 별도 sim 정확도 PR (옵션 A/B/C 결정 후)
+- [x] **Lint #9: starLevel별 stunDuration main pipeline 반영** — PR #129 (`8abbba0`) 머지 완료. main + OOR 양쪽 fix
+- [ ] integration test (실제 simulateCombat 으로 LeonaCarry 1★/2★/3★ stun 측정) — 후속 후보
 - [ ] statOverrides 인게임 측정 — Leona augment 활성 vs 비활성 stat 차이
 - [ ] 17.2 LIVE 초기 값 정확성 — 17.2 패치노트 명시 없음, 17.2b plan doc 의 "before" 표기로 역추정. 외부 archive 로 검증 가능
 

--- a/docs/meta/wiki/index.md
+++ b/docs/meta/wiki/index.md
@@ -36,7 +36,7 @@ _미작성_
 
 ## Augments
 
-- [[leona-carry]] (방패 여전사) — 17.2 도입, 3회 연속 변경. ✅ Lint #6 resolved (PR #127, stun 1.0 fixed). ⚠️ Lint #9 신규 (PR #128 검출): stunDuration starLevel별 main pipeline 미반영
+- [[leona-carry]] (방패 여전사) — 17.2 도입, 3회 연속 변경. ✅ Lint #6 resolved (PR #127) + ✅ Lint #9 resolved (PR #129): starLevel별 stun [1.0/1.25/1.5] sim 적용 (main + OOR cast path 양쪽)
 - [[mordekaiser-carry]] (뜨거운 죽음) — 17.2 도입, 3회 연속 변경. ✅ Lint #7 resolved (PR #124 source drift fix). Mordekaiser passive 매초 오라 N 확장 sim 미반영
 - [[gragas-carry]] (자폭) — 17.2 도입. ✅ Lint #8 resolved (PR #127) — 적군 AOE 반경 3칸 정상 작동 (이전 무력화)
 

--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,6 +8,30 @@ format: newest first
 
 ## 2026-05-18
 
+### Lint resolved: stunDuration starLevel별 main pipeline 반영 (Lint finding 9 closed)
+- **Trigger**: PR #129 (`8abbba0`) 머지 완료 — 직렬 워크플로우
+- **위키 lint 사이클 완결 사례 (6번째 full-cycle)**:
+  - PR #128 wiki cleanup 중 Codex P2 catch — Lint #9 검출 ("starLevel별 stun sim 정합" 주장이 entry 정합 뿐, main pipeline 미read)
+  - PR #129 — Option A 채택. main pipeline 분기 확장 (`carryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? config.stun`)
+  - PR #129 추가 Codex P2 catch — **OOR (out-of-range dash) cast path 누락** → main + OOR 양쪽 fix amend
+  - 본 cleanup PR — 위키 표기 drift → resolved
+- **위키 갱신 내역**:
+  - `augments/leona-carry.md` — `sim_active: partial → active`. Lint #6 + #9 모두 resolved. 패치 히스토리 PR #129 row + Lint #9 섹션 (Codex P2 amend 컨텍스트 + workflow 룰 도입 배경 명시)
+  - `mechanics/hero-augment-carry.md` Leona row — Lint #6 + #9 모두 resolved + starLevel별 stun sim 적용 명시
+  - `index.md` Leona description — Lint #6 + #9 resolved + main/OOR cast path 양쪽 fix 명시
+- **5단계 워크플로우 룰 도입 배경 — PR #129 amend 가 근거**:
+  - "cast path 3종 전수 확인" sub-rule (호출 순서 trace step 4 보강) — 위키 [[ability-targeting]] 의 "3 호출처 (main / recast / OOR fallback)" 정보를 fix workflow 도우미로 통합
+- **sim 정확도 개선 (positive impact)**:
+  - LeonaCarry starLevel별 stun [1.0, 1.25, 1.5] sim 적용 (main + OOR cast path 양쪽). 1성 변경 없음, 2★ 1.0→1.25, 3★ 1.0→1.5
+- **위키 lint 누적 (9건, 본 PR 후 6건 full-cycle 완결)**:
+  1~3: documented/resolved
+  4. Ability dead code triad — full-cycle ✅
+  5. carryAugments 17.3 drift — full-cycle ✅ (단 Mordekaiser 실제 미반영은 #7)
+  6. LeonaCarry duplicate config — full-cycle ✅ (PR #127 + #128). 단 stunDuration starLevel별은 #9 로 분리 → 본 PR 로 완결
+  7. Mordekaiser carry source drift — full-cycle ✅
+  8. GragasCarry duplicate + radius shadow — full-cycle ✅
+  9. **stunDuration starLevel별 main pipeline 미반영 — full-cycle ✅ (PR #129 main+OOR + 본 PR)**
+
 ### Lint resolved: LeonaCarry duplicate config + GragasCarry duplicate/radius shadow (Lint #6 + #8 동시 closed)
 - **Trigger**: PR #127 (`9e6ddb3`) 머지 완료 — 직렬 워크플로우
 - **위키 lint 사이클 완결 사례 — 4번째/5번째 full-cycle (동시 해소)**:

--- a/docs/meta/wiki/mechanics/hero-augment-carry.md
+++ b/docs/meta/wiki/mechanics/hero-augment-carry.md
@@ -76,7 +76,7 @@ augment 전용: `shield, shieldDuration, onAttackBonus, passiveDamage, empowered
 | `NasusCarry` (꽁!) | TFT17_Nasus | single | ✅ | ❌ | `bonusPerKill` |
 | `AatroxCarry` (별빛 연계) | TFT17_Aatrox | cone r=1 | ✅ | ❌ | 3-skill cycle (`skillCycleLabels`) + `novaDamage` + `slamDamage` |
 | `PoppyCarry` (정령단 속도) | TFT17_Poppy | single r=4 | ✅ | ❌ | `armorScale 1.0` + `spiritBounceOnKill` |
-| [[leona-carry]] (방패 여전사) | TFT17_Leona | line maxT=4, dash | ✅ | ❌ | `shield` + `baseDamageHpFrac 0.24` (17.3) + `secondaryDamage`. ✅ Lint #6 resolved (PR #127): const 제거 → stun 1.0 fixed. ⚠️ **Lint #9 (PR #128 검출)**: `abilityData.stunDuration [1.0,1.25,1.5]` starLevel별 의도 main pipeline 미반영 (config.stun fixed read) — 별도 sim PR 후보 |
+| [[leona-carry]] (방패 여전사) | TFT17_Leona | line maxT=4, dash | ✅ | ❌ | `shield` + `baseDamageHpFrac 0.24` (17.3) + `secondaryDamage`. ✅ Lint #6 resolved (PR #127) + ✅ **Lint #9 resolved (PR #129)**: starLevel별 stun `[1.0, 1.25, 1.5]` sim 적용 (main + OOR cast path 양쪽) |
 | `IvernMinionCarry` (빅뱅) | TFT17_IvernMinion | aoe_circle r=3, dash to_largest_cluster | ✅ | ❌ | `hexReduction 0.45` + `stunDuration` |
 | `JaxCarry` (저 별을 향해) | TFT17_Jax | self_buff AS+0.15 | ✅ | ❌ | `asGain` 영구 누적 + `onAttackBonus` |
 | `PykeCarry` (청부 살인마) | TFT17_Pyke | x_shape, dash to_lowest_hp | ✅ | ❌ | `tankBonusMultiplier 0.60` + `onKillRecastMultiplier 0.70` |


### PR DESCRIPTION
## Summary

**위키 lint 6번째 full-cycle 완결**.

```
PR #128 ingest 중 Codex P2 → Lint #9 검출
   ↓
PR #129 — Option A 채택 (main pipeline 분기 확장)
   ↓ (Codex P2 amend: OOR cast path 누락)
PR #129 amend — main + OOR 양쪽 fix
   ↓
본 PR — 위키 표기 drift → resolved
```

## 갱신 내역

### `augments/leona-carry.md`
- `sim_active: partial → active` (Lint #6 + #9 모두 resolved)
- 패치 히스토리 PR #129 row — main + OOR cast path 양쪽 fix + Codex P2 amend 배경 + 워크플로우 룰 도입 배경 명시
- sim 적용 상태 ✅ 활성에 starLevel별 stun `[1.0, 1.25, 1.5]` sim 적용 추가
- **Lint #9 → resolved** + 검출 시점 + Fix 5단계 + 워크플로우 메모리 룰 도입 배경
- Lint 체크리스트 — Lint #9 `[x]` 처리 + integration test 후속 후보 추가

### `mechanics/hero-augment-carry.md`
- Leona row: Lint #6 + #9 모두 resolved + starLevel별 stun sim 적용 명시

### `index.md` + `log.md`
- Leona description 갱신
- 신규 entry "Lint resolved #9" + 누적 9건 (6 full-cycle)

## 5단계 워크플로우 룰 도입 배경 (메모리 보강 사례)

PR #129 의 Codex P2 amend (OOR 누락) 가 메모리 `feedback_wiki_ingest_verify` 의 **"cast path 3종 전수 확인" sub-rule** 도입 배경. 위키 [[ability-targeting]] 의 "3 호출처 (main / recast / OOR fallback)" 정보가 sim fix workflow 도우미.

## sim 정확도 개선 (positive)

| Star | Before | After (PR #129) |
|------|:--:|:--:|
| 1★ | 1.0 | 1.0 (변경 없음) |
| 2★ | 1.0 | **1.25** (buff) |
| 3★ | 1.0 | **1.5** (buff) |

→ in-range + OOR dash cast 양쪽 모두 적용 (range-dependent 회귀 없음).

## 위키 lint 누적 상태 (9건, **6 full-cycle**)

| # | Finding | 상태 |
|---|---------|------|
| 1~3 | documented/resolved | — |
| 4 Ability dead code triad | full-cycle ✅ |
| 5 carryAugments 17.3 drift | full-cycle ✅ |
| 6 LeonaCarry duplicate config | full-cycle ✅ (PR #127+#128) |
| 7 Mordekaiser carry source drift | full-cycle ✅ (PR #124+#125) |
| 8 GragasCarry duplicate + radius shadow | full-cycle ✅ (PR #127+#128) |
| **9 stunDuration starLevel별 미반영** | **full-cycle ✅ (PR #129 main+OOR + 본 PR)** |

## Review checklist

- [ ] PR #129 의 main + OOR fix vs 위키 표기 일치
- [ ] Lint #6 + #9 동시 resolved 표기 정확성
- [ ] integration test 후속 후보 의도 명확화

## 다음 후보 (직렬 워크플로우)

1. **augments 나머지 7개** — Aatrox/Ivern/Jax/Pyke/Nasus/Poppy/Zed Carry. **5단계 워크플로우 적용** (entity-wide + cast path 전수) — 추가 lint 검출 가능성 (Aatrox 3-skill cycle / Pyke X-shape onKill 등)
2. **flag 자체 dead 정리** (`gragasCarryActive` / `leonaCarryActive`) — 테스트 8건 갱신 필요
3. **integration test** — LeonaCarry / GragasCarry starLevel별 + 적군 AOE sim 통합 검증
4. 챔피언별 / Poppy·Nasus verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)