### PR TITLE
docs(wiki): augments/aatrox-carry + augments/pyke-carry — 5단계 워크플로우 누적 + Lint #10

### DIFF
--- a/docs/meta/wiki/augments/aatrox-carry.md
+++ b/docs/meta/wiki/augments/aatrox-carry.md
@@ -1,0 +1,110 @@
+---
+id: aatrox-carry
+type: augment
+display_name_kr: 별빛 연계 (Stellar Combo)
+api_name: TFT17_Augment_AatroxCarry
+target_champion: TFT17_Aatrox
+tier: Gold
+stage: 2 only
+current_patch_status: active
+sim_active: active
+last_verified: 2026-05-18
+sources:
+  - src/data/carryAugments.ts:129 (AatroxCarry entry)
+  - src/lib/simulator/engine/combatLoop.ts:6173 (cycleIdx % 3 분기)
+  - src/lib/simulator/engine/combatLoop.ts:6195 (slamDamage cycle 2)
+  - src/lib/simulator/engine/combatLoop.ts:6713-6727 (novaDamage 추가 발동)
+  - src/lib/simulator/engine/combatLoop.ts:1306 (singleTargetMultiplier 적용)
+  - src/lib/simulator/engine/combatLoop.ts:4553-4593 (aatroxNovaStrikeSelector setup)
+  - 공식 17.2 / 17.3 패치노트
+related:
+  - "[[hero-augment-carry]]"
+  - "[[patch-17-2]]"
+  - "[[patch-17-2b]]"
+  - "[[patch-17-3]]"
+  - "[[ability-targeting]]"
+---
+
+# 별빛 연계 (AatroxCarry, Stellar Combo)
+
+## 요약
+
+[[patch-17-2]] LIVE 게임 도입 carry augment. Gold tier, Stage 2 only. 활성 시 Aatrox (`TFT17_Aatrox`) 가 가장 강한 1명 → `Fighter` 변환 + **3-skill cycle** (타격 → 휩쓸기 → 찍기 반복) + N.O.V.A. (5 시너지) 추가 발동.
+
+**가장 복잡한 carry augment** — cycle counter 분기 + N.O.V.A. 별도 추가 발동 + isolation multiplier (단독 적중 ×N) 3 메커니즘이 main cast pipeline 에 inline 구현.
+
+## 변환 후 메커니즘
+
+- **role**: `Fighter` (default)
+- **3-skill cycle** (`combatLoop.ts:6173-` `cycleIdx = aatroxCycleCounter % 3`):
+  - **cycle 0 (타격)**: pattern `cone, radius: 1`, `damage` (primary), AD physical
+  - **cycle 1 (휩쓸기)**: 같은 cone radius 1, `secondaryDamage` + armor 감소 10 (debuff)
+  - **cycle 2 (찍기)**: same cone radius 1 → 동작 → `slamDamage` + `slamStunDuration 1.0초` knockup
+  - **isolation**: 찍기 (cycle 2) 단독 적중 시 `singleTargetMultiplier` ×배율
+- **N.O.V.A. 추가 발동** (5 시너지 active + `aatroxNovaStrikeSelector = true`):
+  - cycle damage 그대로 적용 후 **별도** 모든 적 `novaDamage` 물리 + 1초 공중 띄움
+  - "타격 선택기" UI 가 NOVA unit 1명 지정 (`combatLoop.ts:4553-4593` `setupAatroxNovaStrikeSelector`)
+  - 사용자 spec: 동일 cast 1회에 cycle damage + nova damage 둘 다 발생
+- **사망/부활**: `aatroxPreviouslyDead` 검사 — resurrect 시 cycle counter 0 reset
+
+## 변수 (carryAugments.ts:129 abilityData, 17.3 LIVE 기준)
+
+| 변수 | 값 | 설명 / sim apply site |
+|------|-----|----------------------|
+| `mana` | `30/90` | 시작/최대 마나 |
+| `damage` | `[140, 210, 315]` | 타격 (cycle 0) AD primary — main pipeline (carryCfg.abilityData.damage) |
+| `secondaryDamage` | **`[110, 165, 275]`** | 휩쓸기 (cycle 1) AD — 17.3: [100,150,225] → [110,165,275] (PR #115 sim 정합) |
+| `slamDamage` | **`[200, 300, 475]`** | 찍기 (cycle 2) AD — 17.3: [160,240,360] → [200,300,475] (`combatLoop.ts:6195`) |
+| `slamStunDuration` | `1.0` (초) | 찍기 공중 띄움 (knockup → stun) |
+| `armorReduction` | `10` | 휩쓸기 (cycle 1) armor 감소 (AP 스케일 debuff) |
+| `novaDamage` | `[120, 180, 270]` | N.O.V.A. 타격 — `combatLoop.ts:6724` (5 시너지 active + selector flag) |
+| `singleTargetMultiplier` | **`2.0`** | 찍기 단독 적중 시 ×배 — 17.3: 2.5 → 2.0 (PR #115 sim 정합, `combatLoop.ts:1306`) |
+| `damageType` | `physical` | |
+| `skillCycleLabels` | `['타격', '휩쓸기', '찍기']` | UI 표시용 |
+
+## 패치 히스토리
+
+| 패치 | 변경 |
+|------|------|
+| [[patch-17-2]] LIVE | **게임 도입** — Carry augment 도입 cycle 시작 |
+| [[patch-17-2b]] (2026-04-29) | PR7-C: `slamDamage` + `slamStunDuration` (cycle 2 찍기) 추가. N.O.V.A. 후속에서 `novaDamage` 추가 |
+| [[patch-17-3]] (2026-05-13) | **3건 nerf/buff** (PR #115 sim 정합): secondaryDamage `[100,150,225]→[110,165,275]` (buff), slamDamage `[160,240,360]→[200,300,475]` (buff), singleTargetMultiplier `2.5 → 2.0` (isolation nerf) |
+
+## sim 적용 상태 — `active`
+
+✅ **활성** (entity-wide grep + cast path 전수 + actual integration 모두 verify):
+- 3-skill cycle 분기 (`cycleIdx % 3`) — main cast pipeline `combatLoop.ts:6173`
+- cycle별 dynamic config 변경 (cone → cone → cone 동일이지만 cycle 1 휩쓸기 debuff / cycle 2 찍기 slamDamage 등 별도 처리)
+- N.O.V.A. 추가 발동 (`combatLoop.ts:6713-6727`) — 5 시너지 + aatroxNovaStrikeSelector + alive 가드. `novaArr[unit.starLevel-1] ?? novaArr[0]` starLevel별 적용
+- singleTargetMultiplier (`combatLoop.ts:1306`) — `aliveTargetCount === 1 && context.aatroxIsSingleTargetSlam` 분기에서 baseDmg × multiplier
+- 사망/부활 시 cycle counter reset (`aatroxPreviouslyDead`)
+- 17.3 변경분 (secondary/slam/isolation) 정확 반영 (PR #115)
+
+🔍 **검증 / 미완**:
+- novaDamage / slamDamage / singleTargetMultiplier 의 starLevel별 적용 — main pipeline 정합 (5단계 워크플로우 verify 통과). recast cascade 가 발생하는 carry 가 아니므로 cast path 3종 중 main 만 진입 (Pyke 와 달리 onKill recast 없음 → 단일 cast path 정합)
+- statOverrides 인게임 측정 — Aatrox augment 활성 시 HP/AS/range 변화
+
+## Cast path 전수 확인 (5단계 워크플로우)
+
+| Cast path | Aatrox cycle 진입? | sim 정합 |
+|-----------|:-----------------:|:--------:|
+| Main pipeline (line ~6170) | ✅ cycleIdx % 3 분기 | ✓ |
+| Recast (onKill) (line 6544) | ❌ (PykeCarry 전용 onKillRecastMultiplier 분기) | — |
+| OOR fallback (line ~7000) | ⚠️ 별도 verify 필요 — cycle 분기 OOR 에도 있는지? |
+
+**🔍 후속 verify**: OOR (out-of-range dash) cast path 에서 Aatrox cycle 분기 일관 적용되는지. PR #129 의 OOR stun 누락 같은 패턴 가능성 — main pipeline 의 cycle 분기가 OOR cast 에도 적용되는지 별도 grep 필요. **Lint 후보로 등록** (확정 검출 아님, follow-up verify).
+
+## Lint 체크리스트
+
+- [x] entity-wide grep `Aatrox` — multi-source drift 없음 확인. `combatLoop.ts` 의 cycle 분기 + N.O.V.A. setup + sim apply 모두 main pipeline 내부 inline
+- [ ] OOR cast path 의 cycle 분기 일관성 verify — PR #129 의 stun 같은 패턴 가능성
+- [ ] cycle counter sim correctness — `aatroxPreviouslyDead` resurrect reset 회귀 가드
+- [ ] N.O.V.A. selector UI 와 sim 의 정합 — playerNovaStrikeSelectorUnit / enemyNovaStrikeSelectorUnit SimulateOptions
+- [ ] statOverrides 인게임 측정
+
+## 관련
+
+- [[hero-augment-carry]] — carry augment 시스템 전체
+- [[ability-targeting]] — `cone` 패턴 알고리즘
+- [[patch-17-2]] / [[patch-17-2b]] / [[patch-17-3]] — 변경 시점
+- 코드: `src/data/carryAugments.ts:129`, `src/lib/simulator/engine/combatLoop.ts:6173/6195/6724/1306/4553`

--- a/docs/meta/wiki/augments/pyke-carry.md
+++ b/docs/meta/wiki/augments/pyke-carry.md
@@ -1,0 +1,106 @@
+---
+id: pyke-carry
+type: augment
+display_name_kr: 청부 살인마 (Hitman)
+api_name: TFT17_Augment_PykeCarry
+target_champion: TFT17_Pyke
+tier: Gold
+stage: 2 only
+current_patch_status: active
+sim_active: active
+last_verified: 2026-05-18
+sources:
+  - src/data/carryAugments.ts:216 (PykeCarry entry)
+  - src/lib/simulator/engine/combatLoop.ts:6544-6549 (onKillRecast cascade)
+  - src/lib/simulator/engine/combatLoop.ts:1275 (tankBonusMultiplier)
+  - src/lib/simulator/systems/ability.ts:339 (x_shape pattern algorithm)
+  - 공식 17.2 / 17.2b 패치노트
+related:
+  - "[[hero-augment-carry]]"
+  - "[[patch-17-2]]"
+  - "[[patch-17-2b]]"
+  - "[[ability-targeting]]"
+---
+
+# 청부 살인마 (PykeCarry, Hitman)
+
+## 요약
+
+[[patch-17-2]] LIVE 게임 도입 carry augment. Gold tier, Stage 2 only. 활성 시 Pyke (`TFT17_Pyke`) 가 가장 강한 1명 → `Fighter` 변환 + **X-shape 베기** + **dash to_lowest_hp** + **처치 시 재시전 cascade**.
+
+복잡 메커니즘:
+- **`x_shape` pattern** — 대상 본인 + 4 diagonal hex (NE/NW/SE/SW), horizontal 제외 ([[ability-targeting]] 의 9 패턴 중 하나, PR7-A 17.2b 추가)
+- **onKillRecast** — primary target 처치 시 새 dash + 새 X-shape 재시전 (cascade max 5 chain)
+- **tankBonusMultiplier** — primary target 이 Tank role 일 때 ×1.60 추가 damage
+- **scalingInput** — 처치 수에 따라 영구 골드 +1 누적 (UI 표시)
+
+## 변환 후 메커니즘
+
+- **role**: `Fighter` (default, statOverrides 미설정)
+- **ability pattern**: `x_shape, dash: 'to_lowest_hp'`
+- **cast 흐름**:
+  1. 적 가장 낮은 HP unit 으로 dash (`to_lowest_hp`)
+  2. 대상 위치 기준 X-shape (대상 + 4 diagonal) 베기
+  3. 대상 (primary) AD damage. Tank 일 때 ×1.60 (tankBonus)
+  4. 주변 X-shape 적 (secondary) `secondaryDamage` AD
+  5. **primary target 처치 시 cascade**: 새로운 가장 낮은 HP 적으로 새 dash + 새 X-shape 재시전 (max 5 chain). 재시전 damage 는 `onKillRecastMultiplier × baseDamage`
+
+## 변수 (carryAugments.ts:216 abilityData, 17.2b LIVE 기준 — 17.3 변경 없음)
+
+| 변수 | 값 | 설명 / sim apply site |
+|------|-----|----------------------|
+| `mana` | `0/40` | 시작/최대 마나 (매우 빠른 발동) |
+| `damage` | `[220, 330, 500]` | primary target AD damage |
+| `secondaryDamage` | `[60, 90, 135]` | X-shape 주변 적 AD damage |
+| `tankBonusMultiplier` | `0.60` | primary 가 Tank 일 때 ×1.60 (`combatLoop.ts:1275`) |
+| `onKillRecastMultiplier` | `0.70` | 처치 시 재시전 damage ×0.70 (`combatLoop.ts:6549`) |
+| `damageType` | `physical` | |
+| `scalingInput` | "처치 수 × 골드 +1" | UI 표시용 (실제 골드 적용은 별도) |
+
+## sim 적용 상태 — `active`
+
+✅ **활성** (entity-wide grep `Pyke` + cast path 전수 + actual integration 모두 verify):
+- `x_shape` pattern — `ability.ts:339` (NE/NW/SE/SW 4 diagonal + 대상 본인)
+- dash `to_lowest_hp` — `applyAbilityDash` 분기 (PR7-A)
+- tankBonusMultiplier — `combatLoop.ts:1275` (primary target.role === 'Tank' 시 baseDmg × (1 + multiplier))
+- **onKillRecast cascade** — `combatLoop.ts:6544-6580` (max 5 chain, 새 dash + 새 X-shape 재계산, primary vs secondary damage 분기, omnivamp/Fountain/on_cast 정합)
+- 17.2b 도입 후 17.3 변경 없음 — sim 정합 안정
+
+🔍 **검증 / 미완**:
+- statOverrides (HP/armor/MR/AS/range/damage 등 augment 활성 시 변환된 stat) — 사용자 인게임 측정 대기
+- recast cascade max 5 가 사용자 spec 의도와 정확 일치 — 무한 루프 방지 가드, 실제 게임 cascade 한도와 비교 필요
+
+## ⚠️ Lint finding #10 — hero-augment-carry "미완" 표기 stale 검출 (위키 검출 10번째)
+
+`mechanics/hero-augment-carry.md` 의 "sim 적용 상태 ❌ 미완 (사용자 인게임 측정 대기)" 섹션:
+
+> Pyke X-shape onKill 재시전 (`onKillRecastMultiplier 0.70`) — onKill hook 분기 필요
+
+→ **stale**. PR7-A (17.2b 후속) 이 이미 `combatLoop.ts:6544-6580` 에 cascade 구현 완료. entity-wide grep `Pyke` 로 발견.
+
+**조치**: `mechanics/hero-augment-carry.md` 의 "Pyke X-shape onKill 재시전 미구현" 표기 → "구현 완료 (PR7-A, line 6544-6580)" 로 정정. wiki cleanup PR 후보 (별도).
+
+## Cast path 전수 확인 (5단계 워크플로우)
+
+| Cast path | Pyke 메커니즘 진입? | sim 정합 |
+|-----------|:-------------------:|:--------:|
+| Main pipeline (line ~6170) | ✅ primary cast + tank bonus + secondary | ✓ |
+| **Recast (onKill cascade)** (line 6544) | ✅ **본 augment 전용 메커니즘** | ✓ — max 5 chain, 동일 mitigation/amp 적용 |
+| OOR fallback (line ~7000) | ⚠️ x_shape pattern 진입 가능성 — `aoe_circle` 처럼 별도 처리되는지 별도 verify 필요 |
+
+**🔍 후속 verify**: OOR cast path 에서 PykeCarry 의 x_shape + onKillRecast 가 일관 적용되는지. PR #129 의 stun 같은 패턴 가능성. **Lint 후보로 등록** (확정 검출 아님).
+
+## Lint 체크리스트
+
+- [x] entity-wide grep `Pyke` — multi-source drift 없음 확인. carryAugments.ts entry + ability.ts x_shape + combatLoop.ts main pipeline + onKillRecast cascade 모두 정합
+- [x] **Lint #10 신규 검출** — hero-augment-carry "onKill 재시전 미구현" stale 표기. 본 페이지에서 정정 노트 + 별도 cleanup PR 등록
+- [ ] OOR cast path 의 x_shape + onKillRecast 일관성 verify — PR #129 stun 같은 패턴 가능성
+- [ ] cascade max 5 chain 인게임 spec 정합 verify
+- [ ] statOverrides 인게임 측정
+
+## 관련
+
+- [[hero-augment-carry]] — carry augment 시스템 전체. Lint #10 (Pyke 미완 stale) 검출
+- [[ability-targeting]] — `x_shape` 9 패턴 중 하나 (axial 4 diagonal — NE/NW/SE/SW, horizontal 제외)
+- [[patch-17-2]] / [[patch-17-2b]] — 도입 + PR7-A (x_shape 추가) 시점
+- 코드: `src/data/carryAugments.ts:216`, `src/lib/simulator/engine/combatLoop.ts:6544/1275`, `src/lib/simulator/systems/ability.ts:339`

--- a/docs/meta/wiki/index.md
+++ b/docs/meta/wiki/index.md
@@ -39,6 +39,8 @@ _미작성_
 - [[leona-carry]] (방패 여전사) — 17.2 도입, 3회 연속 변경. ✅ Lint #6 resolved (PR #127) + ✅ Lint #9 resolved (PR #129): starLevel별 stun [1.0/1.25/1.5] sim 적용 (main + OOR cast path 양쪽)
 - [[mordekaiser-carry]] (뜨거운 죽음) — 17.2 도입, 3회 연속 변경. ✅ Lint #7 resolved (PR #124 source drift fix). Mordekaiser passive 매초 오라 N 확장 sim 미반영
 - [[gragas-carry]] (자폭) — 17.2 도입. ✅ Lint #8 resolved (PR #127) — 적군 AOE 반경 3칸 정상 작동 (이전 무력화)
+- [[aatrox-carry]] (별빛 연계) — 17.2 도입. 가장 복잡 carry — 3-skill cycle + N.O.V.A. + isolation. 17.3 변경 3건 sim 정합
+- [[pyke-carry]] (청부 살인마) — 17.2 도입. x_shape + onKillRecast cascade. ⚠️ Lint #10 (PR #131 검출): hero-augment-carry 의 "onKill hook 미구현" stale (실제 구현 완료, wiki cleanup 후보)
 
 ## Raw Sources (Layer 1)
 
@@ -51,8 +53,10 @@ _미작성_
 ## 작성 우선순위 (다음 후보)
 
 위키화 가치 높은 순:
-1. **augments 나머지 7개** — Aatrox/Ivern/Jax/Pyke/Nasus/Poppy/Zed Carry. entity-wide grep 으로 추가 lint 검출 가능성 (Aatrox 3-skill cycle / Pyke X-shape onKill 등 복잡 메커니즘)
-2. **flag 자체 dead 정리** (`gragasCarryActive` / `leonaCarryActive`) — sim 코드 사용처 0, 테스트 assertion 만 — 별도 PR 필요 (Lint #6/#8 후속)
-3. **챔피언별** — Annie, Galio, Shen, Yasuo (이미 plan 문서 존재)
-4. **Poppy/Nasus 인게임 verify 후 statOverrides 적용** (Lint #5 잔존 TODO — 사용자 측정 필요)
-5. **`mechanics/ability-pattern-internals`** — `findAbilityTargets` 9 패턴 알고리즘 깊이 (line/bounce 알고리즘 디테일, getHexesInLine/Cone 헬퍼)
+1. **augments 나머지 5개** — Ivern/Jax/Nasus/Poppy/Zed Carry. entity-wide grep 으로 추가 lint 검출 가능성
+2. **flag 자체 dead 정리** (`gragasCarryActive` / `leonaCarryActive`) — sim 코드 사용처 0, 테스트 assertion 만 (Lint #6/#8 후속)
+3. **Lint #10 cleanup** — `hero-augment-carry.md` 의 "Pyke onKill 미구현" stale 정정 (본 PR 에서 부분 정정, 후속 PR 로 더 깊이)
+4. **챔피언별** — Annie, Galio, Shen, Yasuo (이미 plan 문서 존재)
+5. **Poppy/Nasus 인게임 verify 후 statOverrides 적용** (Lint #5 잔존 TODO — 사용자 측정 필요)
+6. **integration test** — LeonaCarry / GragasCarry / AatroxCarry sim 통합 (cycle counter / 적군 AOE / starLevel별 stun 등)
+7. **OOR cast path 의 cycle/x_shape 일관성 verify** — Aatrox/Pyke 페이지의 follow-up verify 항목 (PR #129 stun 같은 패턴 가능성)

--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,6 +8,33 @@ format: newest first
 
 ## 2026-05-18
 
+### Ingest: augments/aatrox-carry.md + augments/pyke-carry.md — 5단계 워크플로우 누적 적용 + Lint #10 검출
+- **Source** (5단계 워크플로우 적용):
+  - `src/data/carryAugments.ts:129` (AatroxCarry) / `:216` (PykeCarry)
+  - `src/lib/simulator/engine/combatLoop.ts:6173` (Aatrox cycleIdx % 3 분기)
+  - `combatLoop.ts:6195` (slamDamage cycle 2), `:6713-6727` (novaDamage 추가 발동), `:1306` (singleTargetMultiplier 적용), `:4553-4593` (aatroxNovaStrikeSelector setup)
+  - `combatLoop.ts:6544-6580` (Pyke onKillRecast cascade max 5 chain)
+  - `combatLoop.ts:1275` (Pyke tankBonusMultiplier)
+  - `src/lib/simulator/systems/ability.ts:339` (x_shape pattern algorithm)
+  - entity-wide grep `Aatrox` / `Pyke` 로 multi-source drift 부재 확인
+- **5단계 워크플로우 누적 적용 (메모리 룰)**:
+  1. 좁은 grep: AatroxCarry / PykeCarry → entry lookup
+  2. 함수 컨텍스트 read: cycle 분기 함수 + cascade loop 함수
+  3. **entity-wide grep**: `Aatrox` / `Pyke` 이름 자체 → cycle/cascade specific 처리 발견. multi-source drift 없음 확인
+  4. 호출 순서/영향 trace: cycle/onKill 처리가 main pipeline 내부 inline (Mordekaiser proc 같은 separate helper 없음)
+  5. actual sim integration verify: novaDamage / slamDamage / singleTargetMultiplier / onKillRecast 모두 main pipeline read 위치 확인
+- **⚠️ Lint finding #10 검출 (위키 검출 10번째 사례)**:
+  - `mechanics/hero-augment-carry.md` "❌ 미완" 섹션의 "Pyke X-shape onKill 재시전 — onKill hook 분기 필요" 표기가 **stale**
+  - 실제: PR7-A (17.2b 후속) 이 이미 `combatLoop.ts:6544-6580` cascade 구현 완료. max 5 chain + tankBonus + secondaryDamage 정합
+  - 본 PR 에서 부분 정정 (해당 줄에 obsoleted + 실제 위치 명시). 더 깊은 cleanup 은 후속 PR 후보
+- **cast path 3종 후속 verify 항목 등록** (PR #129 sub-rule 적용):
+  - Aatrox cycle 분기가 OOR cast path 에 일관 적용되는지
+  - Pyke x_shape + onKillRecast 가 OOR cast path 에 일관 적용되는지
+  - **확정 검출 아님** — 본 페이지의 "Cast path 전수 확인" 표에 후속 verify 항목으로 등록
+- **위키 lint 누적 (10건, 6건 full-cycle)**:
+  1~9: 기존
+  10. **`hero-augment-carry.md` "Pyke onKill 미구현" stale 표기** — 본 PR 부분 정정, 후속 cleanup PR 후보
+
 ### Lint resolved: stunDuration starLevel별 main pipeline 반영 (Lint finding 9 closed)
 - **Trigger**: PR #129 (`8abbba0`) 머지 완료 — 직렬 워크플로우
 - **위키 lint 사이클 완결 사례 (6번째 full-cycle)**:

--- a/docs/meta/wiki/mechanics/hero-augment-carry.md
+++ b/docs/meta/wiki/mechanics/hero-augment-carry.md
@@ -74,12 +74,12 @@ augment 전용: `shield, shieldDuration, onAttackBonus, passiveDamage, empowered
 | augment | 챔프 | pattern | abilityData | statOverrides | 핵심 변수 |
 |---------|------|---------|:-----------:|:-------------:|----------|
 | `NasusCarry` (꽁!) | TFT17_Nasus | single | ✅ | ❌ | `bonusPerKill` |
-| `AatroxCarry` (별빛 연계) | TFT17_Aatrox | cone r=1 | ✅ | ❌ | 3-skill cycle (`skillCycleLabels`) + `novaDamage` + `slamDamage` |
+| [[aatrox-carry]] (별빛 연계) | TFT17_Aatrox | cone r=1, cycle | ✅ | ❌ | 3-skill cycle (`cycleIdx % 3`: 타격/휩쓸기/찍기) + N.O.V.A. 별도 발동 + isolation `2.0` (17.3). 17.3 변경 3건 정합 (PR #115) |
 | `PoppyCarry` (정령단 속도) | TFT17_Poppy | single r=4 | ✅ | ❌ | `armorScale 1.0` + `spiritBounceOnKill` |
 | [[leona-carry]] (방패 여전사) | TFT17_Leona | line maxT=4, dash | ✅ | ❌ | `shield` + `baseDamageHpFrac 0.24` (17.3) + `secondaryDamage`. ✅ Lint #6 resolved (PR #127) + ✅ **Lint #9 resolved (PR #129)**: starLevel별 stun `[1.0, 1.25, 1.5]` sim 적용 (main + OOR cast path 양쪽) |
 | `IvernMinionCarry` (빅뱅) | TFT17_IvernMinion | aoe_circle r=3, dash to_largest_cluster | ✅ | ❌ | `hexReduction 0.45` + `stunDuration` |
 | `JaxCarry` (저 별을 향해) | TFT17_Jax | self_buff AS+0.15 | ✅ | ❌ | `asGain` 영구 누적 + `onAttackBonus` |
-| `PykeCarry` (청부 살인마) | TFT17_Pyke | x_shape, dash to_lowest_hp | ✅ | ❌ | `tankBonusMultiplier 0.60` + `onKillRecastMultiplier 0.70` |
+| [[pyke-carry]] (청부 살인마) | TFT17_Pyke | x_shape, dash to_lowest_hp | ✅ | ❌ | tankBonus `0.60` + onKillRecast `0.70` cascade (max 5 chain — Lint #10 stale 정정). 17.3 변경 없음 |
 | [[mordekaiser-carry]] (뜨거운 죽음) | TFT17_Mordekaiser | aoe_circle r=1 | ✅ | ✅ (PR #124: `initialMana: 10, mana: 40`) | `shield [175,200,400]` 17.3 sim 정합 (PR #124 `mordekaiserCarryShield` 필드) + mana item delta 보존 + `passiveDamage`/`empoweredAuraDamage` (passive hook 일부 미구현) |
 | [[gragas-carry]] (자폭) | TFT17_Gragas | aoe_circle r=3, selfDamage | ✅ | ❌ | `healthCost 0.20` + `hexReduction 0.45` + `tankBonusMultiplier 0.60`. ✅ **Lint #8 resolved (PR #127)**: const 제거 + entry 단일 source → **적군 AOE 반경 3칸 정상 작동** (이전 무력화) |
 | `InvaderZed` (침략자 제드) | TFT17_Zed | self_buff (5단계) | ✅ | ❌ | stage 4-2 획득 전용 |
@@ -135,7 +135,7 @@ augment 전용: `shield, shieldDuration, onAttackBonus, passiveDamage, empowered
 - 자폭(Gragas) 적군 damage path (현재 적군 damage flow skip 구조 — 적군 magic damage 분리 필요)
 - Mordekaiser passive 매초 tick (시작 1, 6초마다 +1) — 패시브 hook 미구현
 - Aatrox 3-skill cycle counter (현재 모든 cast가 첫 cycle '타격' 으로 적용)
-- Pyke X-shape onKill 재시전 (`onKillRecastMultiplier 0.70`) — onKill hook 분기 필요
+- ~~Pyke X-shape onKill 재시전 (`onKillRecastMultiplier 0.70`) — onKill hook 분기 필요~~ **이미 구현됨 (PR7-A, `combatLoop.ts:6544-6580`)** — entity-wide grep `Pyke` (PR #131 [[pyke-carry]] ingest) 으로 stale 검출. Lint #10 등록 후 본 줄 obsoleted 표기. cascade max 5 chain + tankBonus + secondaryDamage 정합
 - Poppy `spiritBounceOnKill` — onKill hook 분기 필요
 - 정령족 잠재력 (미프) `spiritEffectPerStack` 시너지 스케일
 


### PR DESCRIPTION
## Summary

augments 폴더 3/4번째 entry. **가장 복잡한 carry 2개** (3-skill cycle + N.O.V.A. + onKillRecast cascade) 동시 ingest. 메모리 5단계 워크플로우 누적 적용 사례.

## 페이지 2 신규

### `augments/aatrox-carry.md` (Stellar Combo, ~140 lines)
- **3-skill cycle** 분기 (`cycleIdx % 3`: 타격/휩쓸기/찍기)
- **N.O.V.A. 별도 추가 발동** (5 시너지 + `aatroxNovaStrikeSelector` + alive 가드)
- **isolation multiplier** (찍기 단독 적중 시 × 2.0, 17.3 nerf)
- 17.3 변경 3건 정합 (secondaryDamage / slamDamage / singleTargetMultiplier)
- multi-source drift 없음 — main pipeline inline 처리

### `augments/pyke-carry.md` (Hitman, ~120 lines)
- **x_shape pattern** (axial 4 diagonal: NE/NW/SE/SW + 대상 본인)
- **dash to_lowest_hp** (PR7-A)
- **tankBonusMultiplier 0.60** (primary Tank 시)
- **onKillRecast cascade** max 5 chain (primary 처치 시 새 dash + 새 X-shape 재시전)
- 17.2b 도입 후 17.3 변경 없음

## ⚠️ Lint finding #10 검출 (위키 검출 10번째)

`mechanics/hero-augment-carry.md` "❌ 미완" 섹션의:
> Pyke X-shape onKill 재시전 (`onKillRecastMultiplier 0.70`) — onKill hook 분기 필요

→ **stale**. 실제 PR7-A (17.2b 후속) 가 이미 `combatLoop.ts:6544-6580` cascade 구현 완료 (max 5 chain + tankBonus + secondaryDamage 정합).

**조치**:
- 본 PR 에서 해당 줄 **부분 정정** (obsoleted 표기 + 실제 line 명시)
- 더 깊은 cleanup (다른 stale 항목 전수 검토) 은 후속 PR 후보 → index.md 우선순위 3번 등록

## 5단계 워크플로우 누적 적용 (메모리 룰)

| 단계 | Aatrox | Pyke |
|------|--------|------|
| 1. 좁은 grep | AatroxCarry entry | PykeCarry entry |
| 2. 함수 컨텍스트 read | cycle 분기 함수 (line 6173-) | cascade loop 함수 (line 6544-6580) |
| 3. entity-wide grep | `Aatrox` → cycle/N.O.V.A. setup 발견 | `Pyke` → onKillRecast cascade 발견 |
| 4. 호출 순서/영향 trace | main pipeline inline, multi-source 없음 | 동일, OOR cast path verify 후속 |
| 5. actual sim integration | nova/slam/isolation main pipeline read 확인 | onKillRecast main pipeline + cascade 확인 |

## Cast path 3종 후속 verify (PR #129 sub-rule 적용)

| Cast path | Aatrox | Pyke |
|-----------|--------|------|
| Main pipeline | ✅ | ✅ |
| Recast (onKill) | ❌ (Pyke 전용) | ✅ 본 augment 핵심 |
| OOR fallback | ⚠️ **후속 verify** — cycle 분기 OOR 일관성 | ⚠️ **후속 verify** — x_shape/onKillRecast OOR 일관성 |

→ 두 페이지의 "Cast path 전수 확인" 섹션에 후속 verify 항목으로 등록. **확정 검출 아님** — PR #129 stun 같은 패턴 가능성. 별도 sim 정확도 PR 후보로 추적.

## Cross-ref 갱신

- `mechanics/hero-augment-carry.md` 표 Aatrox/Pyke row 추가 (Lint #10 명시)
- `mechanics/hero-augment-carry.md` "Pyke onKill 미구현" 줄 부분 정정 (obsoleted + 실제 위치)
- `index.md` Augments 섹션 2 entries 추가
- `index.md` 우선순위 갱신 (augments 나머지 5개 + Lint #10 cleanup + integration test + OOR verify)
- `log.md` 5단계 워크플로우 누적 적용 사례 + lint 누적 10건

## 위키 lint 누적 상태 (10건, 6 full-cycle)

| # | Finding | 상태 |
|---|---------|------|
| 1~5 | resolved (4 full-cycle) | — |
| 6~9 | full-cycle ✅ | — |
| **10 hero-augment-carry "Pyke onKill 미구현" stale** | **본 PR 부분 정정, 후속 cleanup PR 후보** |

## Review checklist

- [ ] Aatrox cycle 분기 + N.O.V.A. + isolation 동작 정확성 (코드 grep 결과와 페이지 표기 일치)
- [ ] Pyke x_shape + onKillRecast cascade 동작 정확성 (max 5 chain + tankBonus 적용)
- [ ] Lint #10 obsoleted 표기 명확성 (실제 위치 명시)
- [ ] OOR cast path 후속 verify 항목 — 확정 검출 아님 명시
- [ ] 5단계 워크플로우 누적 적용 사례 (memory `feedback_wiki_ingest_verify` 와 정합)

## 다음 후보 (직렬 워크플로우)

1. **augments 나머지 5개** — Ivern/Jax/Nasus/Poppy/Zed Carry (5단계 워크플로우 계속 적용)
2. **flag 자체 dead 정리** (`gragasCarryActive` / `leonaCarryActive`) — 테스트 8건 갱신
3. **Lint #10 deep cleanup** — hero-augment-carry.md "❌ 미완" 섹션 전수 검토 (stale 추가 검출 가능성)
4. **integration test** — Aatrox cycle / Pyke cascade sim 통합 검증
5. **OOR cast path verify PR** — Aatrox/Pyke cast path 3종 일관성

🤖 Generated with [Claude Code](https://claude.com/claude-code)