### PR TITLE
docs(wiki): augments/jax-carry + nasus-carry + invader-zed — 5단계 워크플로우 + Lint #11/#12/#13 신규 검출

### DIFF
--- a/docs/meta/wiki/augments/invader-zed.md
+++ b/docs/meta/wiki/augments/invader-zed.md
@@ -1,0 +1,132 @@
+---
+id: invader-zed
+type: augment
+display_name_kr: 침략자 제드 (Invader Zed)
+api_name: TFT17_Augment_InvaderZed
+target_champion: TFT17_Zed
+tier: special (스테이지 4-2 전용 획득)
+stage: stage 4-2 only
+current_patch_status: active
+sim_active: minimal
+last_verified: 2026-05-19
+sources:
+  - src/data/carryAugments.ts:274-286 (InvaderZed entry)
+  - src/lib/simulator/engine/combatLoop.ts:618-622 (getAbilityConfigForUnit)
+  - src/lib/simulator/engine/combatLoop.ts:2220-2267 (applyHeroCarryTransforms role='Fighter')
+  - src/lib/simulator/engine/combatLoop.ts:1565-1582 (applyZedShadow trait — augment 무관)
+  - src/lib/simulator/engine/combatLoop.ts:6146-6149 (self_buff carry damage override 미적용 주석)
+  - src/lib/simulator/engine/combatLoop.ts:6226 (self_buff → rawAbilityDmgBase=0)
+  - src/lib/simulator/engine/combatLoop.ts:6885-6891 (config.selfBuff stat 적용 — selfBuff undefined 시 skip)
+  - src/lib/simulator/systems/ability.ts:251 (TFT17_Zed raw `{ pattern: 'self_buff' }` — 분신 소환, 시뮬 stat-only)
+related:
+  - "[[hero-augment-carry]]"
+  - "[[ability-targeting]]"
+  - "[[role-passive]]"
+---
+
+# 침략자 제드 (InvaderZed)
+
+## 요약
+
+Zed (`TFT17_Zed`) carry augment, **스테이지 4-2 전용 special**. desc: "5단계 공격력 전사로 변하며 자신의 분신을 생성".
+
+raw Zed 는 이미 `TFT17_ZedUniqueTrait` (은하계 사냥꾼) trait 으로 +40% AD 가산을 받는다 (분신 alive 가정 단순화, `combatLoop.ts:1565-1582`). InvaderZed augment 가 추가하는 sim 효과는 **role 변환 + mana 조정** 외에는 사실상 없음 — abilityOverride `{ pattern: 'self_buff' }` 만 정의되어 있고 `selfBuff` 필드 자체 없어 cast 효과 0.
+
+**가장 sim 효과 적은 carry augment**.
+
+## 변환 후 메커니즘
+
+- **role**: `Fighter` (default — `applyHeroCarryTransforms` line 2227)
+- **abilityOverride**: `{ pattern: 'self_buff' }` (`carryAugments.ts:277`) — `selfBuff` 필드 **없음**
+- **damageTypeOverride**: `physical` (line 278) — damage 자체가 미반영이라 무의미
+- **cast 효과**:
+  - self_buff 패턴 → `rawAbilityDmgBase = 0` 강제 (`combatLoop.ts:6226`)
+  - `config.selfBuff` undefined → `combatLoop.ts:6886` if 가드 false → 어떤 stat 변경도 발생 안 함
+  - 결론: **cast 자체는 mana 소비 외 sim 효과 없음**
+- **mana**: 50/100 (raw 채택, statOverrides 없음)
+- **분신 (shadow)**: sim 에 분신 unit 메커니즘 자체 없음 (`combatLoop.ts:1569` 명시). raw Zed `TFT17_Zed: { pattern: 'self_buff' }` (`ability.ts:251`) 도 동일하게 stat-only 단순화.
+
+### applyZedShadow 와의 관계 (별도 메커니즘)
+
+- `applyZedShadow` (`combatLoop.ts:1572`) 는 **trait `TFT17_ZedUniqueTrait`** 활성 조건. InvaderZed augment 와 무관.
+- 분신 alive 가정 → Zed 본인에게 즉시 +40% AD 가산 (`u.stats.damage *= 1.40`).
+- InvaderZed augment 없이도 Zed + trait active 면 동일 buff 적용.
+
+## 변수 (carryAugments.ts:279-285 abilityData)
+
+| 변수 | 값 | sim 적용 | 비고 |
+|------|-----|---------|------|
+| `mana` | `50/100` | ✅ | raw 채택 |
+| `damage` | `[300, 450, 720]` | ❌ **미반영** | self_buff 패턴 → rawAbilityDmgBase=0 |
+| `damageType` | `physical` | ❌ **무의미** | damage 미반영 |
+
+abilityOverride.selfBuff: **필드 자체 없음** → 어떤 stat buff 도 적용 안 됨.
+
+## 패치 히스토리
+
+| 패치 | 변경 |
+|------|------|
+| (도입 시점 미verify) | InvaderZed entry 등록 (carryAugments.ts) |
+
+패치 변경 이력 verify 안 됨 — 17.3 패치노트 등에서 변경분 미발견. **TODO: stage 4-2 special augment 의 정확한 도입 시점 verify**.
+
+## sim 적용 상태 — `minimal`
+
+✅ **활성** (사실상 이것뿐):
+- `role='Fighter'` 변환 (`applyHeroCarryTransforms`)
+- mana 50/100 raw 채택
+
+❌ **미반영**:
+1. **`damage[300,450,720]` 미반영** — self_buff 패턴 + rawAbilityDmgBase=0
+2. **`damageType='physical'` 무의미** — damage 자체 0
+3. **분신 (shadow) unit 생성** — sim 에 분신 메커니즘 자체 없음 (line 1569 stat-only)
+4. **"5단계 공격력 전사" desc** — 단순 role='Fighter' 변환만, 별도 단계별 메커니즘 없음
+5. **selfBuff 필드 부재** — config.selfBuff undefined → cast 시 어떤 stat 변경도 없음
+
+🔍 **검증 필요**:
+- InvaderZed 의 의도된 메커니즘 spec 확인 (desc "분신 생성" 외 구체적 효과)
+- raw 패치노트 / lolchess.gg / CDragon json source 확인
+- Zed 본인 statOverrides 의도 (HP/AS/AD 추가 등)
+
+## Cast path 전수 확인 (5단계 워크플로우 cast path 3종)
+
+| Cast path | Zed self_buff 진입? | sim 정합 |
+|-----------|:-------------------:|:--------:|
+| Main pipeline (line ~6137) | ✅ self_buff 분기 (line 6226 damage 0) | ✓ (효과 0) |
+| Recast (onKill) (line ~6544) | ❌ (PykeCarry 전용) | — |
+| OOR fallback (line 6973-7037) | ✅ self_buff OOR 경로 (line 7001-2 self-hit 회귀 방지) | ✓ (효과 0) |
+
+**확인**: self_buff 패턴 cast path 자체는 main + OOR 양쪽 일관. 단, selfBuff 필드 부재로 어떤 stat 변경도 발생 안 함 → cast path 정합성과 무관하게 효과 0.
+
+## Lint finding
+
+### Lint candidate #13 — InvaderZed augment 실효성 거의 0
+
+- abilityOverride `{ pattern: 'self_buff' }` 만 정의, selfBuff 필드 부재 → cast 시 stat 변경 0
+- abilityData.damage 정의되어 있으나 self_buff 패턴이라 미반영
+- desc "5단계 공격력 전사 + 분신 생성" 표현 vs 실제 sim 효과 = role='Fighter' + mana 50/100 뿐
+- **해소 방향**:
+  - (1) abilityOverride 에 selfBuff 추가 (예: `{ attackSpeed: 0.5, ad: 0.5, duration: 999 }` 같이 stage 4-2 special 답게 강력한 buff)
+  - (2) statOverrides 추가 (HP/AS/AD 등 5단계 강화 표현)
+  - (3) raw spec 측 의도 확인 후 정합 — 사용자 인게임 측정 / 패치노트 출처 verify 필요
+
+### applyZedShadow 와 augment 의 관계 모호
+
+- raw Zed 의 `self_buff` 패턴이 "분신 소환" desc 이나 sim 은 stat-only (`applyZedShadow` 가 별도 trait 기반 처리)
+- InvaderZed augment 가 추가로 무엇을 더 해야 하는지 spec 불분명
+- **TODO**: augment vs trait 의 분리 의도 확인 (augment 가 trait 효과를 강화? 별도 효과 추가?)
+
+## Lint 체크리스트
+
+- [x] entity-wide grep `Zed` — applyZedShadow / TFT17_ZedUniqueTrait 발견 (augment 무관, trait 기반)
+- [x] cast path 3종 — main + OOR 진입 (단 효과 0)
+- [x] actual integration verify — sim 효과 사실상 0 검출 (Lint #13)
+- [ ] InvaderZed 의도된 메커니즘 spec 확인 (사용자 / 패치노트 source)
+- [ ] statOverrides 측정
+
+## 관련
+
+- [[hero-augment-carry]] — carry augment 시스템 전체
+- [[role-passive]] — Fighter role mana/타게팅 규칙
+- [[ability-targeting]] — `self_buff` 패턴 (3 cast path, single fix 회귀 가드)
+- 코드: `src/data/carryAugments.ts:274-286`, `src/lib/simulator/engine/combatLoop.ts:618/2220/1572/6226/6886`

--- a/docs/meta/wiki/augments/jax-carry.md
+++ b/docs/meta/wiki/augments/jax-carry.md
@@ -1,0 +1,125 @@
+---
+id: jax-carry
+type: augment
+display_name_kr: 저 별을 향해 (Reach for the Stars)
+api_name: TFT17_Augment_JaxCarry
+target_champion: TFT17_Jax
+tier: (미확인 — 패치노트 verify 필요)
+stage: stage 2 (carry augment 일반)
+current_patch_status: active
+sim_active: partial
+last_verified: 2026-05-19
+sources:
+  - src/data/carryAugments.ts:205-218 (JaxCarry entry)
+  - src/lib/simulator/engine/combatLoop.ts:618-622 (getAbilityConfigForUnit)
+  - src/lib/simulator/engine/combatLoop.ts:2220-2267 (applyHeroCarryTransforms role='Fighter')
+  - src/lib/simulator/engine/combatLoop.ts:5618-5660 (onAttackBonus passive)
+  - src/lib/simulator/engine/combatLoop.ts:6146-6149 (self_buff carry damage override 미적용 주석)
+  - src/lib/simulator/engine/combatLoop.ts:6226 (self_buff → rawAbilityDmgBase=0)
+  - src/lib/simulator/engine/combatLoop.ts:6885-6891 (config.selfBuff stat 적용)
+  - 공식 17.3 패치노트 (damage 변경분)
+related:
+  - "[[hero-augment-carry]]"
+  - "[[patch-17-3]]"
+  - "[[ability-targeting]]"
+  - "[[role-passive]]"
+---
+
+# 저 별을 향해 (JaxCarry, Reach for the Stars)
+
+## 요약
+
+Jax (`TFT17_Jax`) carry augment. 활성 시 가장 강한 Jax 1명 → `Fighter` 변환 + **self_buff 패턴** (cast 시 attackSpeed 영구 가산) + 매 기본 공격마다 `onAttackBonus` 추가 magic damage.
+
+abilityOverride 가 `self_buff` 라서 cast 자체는 damage 없음. 실질 효과는 **(1) onAttackBonus 패시브** (매 기본 공격 추가 magic) + **(2) cast 마다 AS *= 1.15 누적** 두 가지.
+
+## 변환 후 메커니즘
+
+- **role**: `Fighter` (default — `applyHeroCarryTransforms` line 2227)
+- **abilityOverride**: `{ pattern: 'self_buff', selfBuff: { attackSpeed: 0.15, duration: 999 } }` (`carryAugments.ts:208`)
+- **cast 효과** (`combatLoop.ts:6885-6891`):
+  - `unit.stats.attackSpeed *= (1 + 0.15)` — duration:999 무시 (sim 에 expiry 추적 없음 → 영구). 매 cast 마다 multiplicative 누적.
+  - selfBuff.ad / ap / durability 없음
+  - cast damage: `self_buff` 패턴이므로 `rawAbilityDmgBase = 0` 강제 (`combatLoop.ts:6226`) — carry abilityData.damage override 미적용
+- **passive (onAttackBonus)**: 매 기본 공격마다 `onAttackBonus[starLevel-1]` AP scaling magic damage 추가 (`combatLoop.ts:5618-5660`)
+  - target.state ≠ 'dead' && currentHp > 0 가드 (PR #74)
+  - 통합 mitigation (resistance + DR + non-target reduction + shield + invulnerable)
+- **mana**: 20/80 (raw 채택, statOverrides 없음 → calculateStats item bonus 그대로)
+
+## 변수 (carryAugments.ts:209-217 abilityData, 17.3 LIVE 기준)
+
+| 변수 | 값 | sim 적용 | 비고 |
+|------|-----|---------|------|
+| `mana` | `20/80` | ✅ | raw 채택 |
+| `damage` | `[170, 250, 450]` | ❌ **미반영** | self_buff 패턴 → rawAbilityDmgBase=0 (line 6226). 17.3: `[155, 230, 375] → [170, 250, 450]` (entry 정합만) |
+| `onAttackBonus` | `[45, 70, 105]` | ✅ | `combatLoop.ts:5626` AP scaling magic. 매 기본 공격마다 추가 |
+| `asGain` | `[0.15, 0.15, 0.20]` | ❌ **미반영** | grep `asGain` src/ → carryAugments.ts entry 외 read 위치 0건. **starLevel 3 +20% 의도 vs 실제 +15%** (Lint 검출) |
+| `damageType` | `magic` | n/a | damage 미반영이라 무의미. onAttackBonus 는 hardcoded 'magic' (line 5637) |
+
+**abilityOverride.selfBuff.attackSpeed**: `0.15` (fixed, abilityData.asGain 와 별개) — 실제 sim 적용되는 AS 가산값. starLevel 무관.
+
+## 패치 히스토리
+
+| 패치 | 변경 |
+|------|------|
+| [[patch-17-3]] (2026-05-13) | damage `[155, 230, 375] → [170, 250, 450]` (entry 정합 — 단 sim 미반영) |
+| 17.3 이전 | 정확한 도입 패치 미verify (carryAugments.ts entry 외 source 없음) |
+
+## sim 적용 상태 — `partial`
+
+✅ **활성**:
+- `role='Fighter'` 변환 (`applyHeroCarryTransforms`)
+- selfBuff.attackSpeed 0.15 cast 마다 multiplicative 누적 (raw `config.selfBuff` 분기, line 6886-7)
+- `onAttackBonus[starLevel]` AP scaling magic 매 기본 공격 (line 5618-5660)
+- mana 20/80 raw 채택 (item bonus delta 보존)
+
+❌ **미반영** (sim 효과 누락):
+1. **`damage[170,250,450]` 미반영** — self_buff 패턴 → `rawAbilityDmgBase=0` (line 6226). user spec "사용: 대상 magic damage" 의도 vs 실제 cast damage 0.
+2. **`asGain[0.15, 0.15, 0.20]` 미반영** — grep `asGain` → 0건 read. starLevel 3 의도 +20% AS gain vs 실제 +15% (selfBuff.attackSpeed fixed 0.15 가 대체). desc "영구 AS/MS +15/15/20%" 의도 미실현.
+3. **MS (이동속도) gain** — abilityData 에 movementSpeed 필드 없음. desc "AS/MS" 중 MS 부분 sim 미반영.
+
+🔍 **검증 필요**:
+- selfBuff.duration 999 와 매 cast multiplicative AS *= 1.15 의 의도 일치성 — desc "전투 종료까지 누적" 표현이 multiplicative 인지 additive 인지 모호. PR #71 (codex P1) 가 self_buff 패턴 자체는 처리하나 starLevel별 분기는 별도.
+- statOverrides 인게임 측정 (HP/AS base/range 변화 여부)
+
+## Cast path 전수 확인 (5단계 워크플로우 cast path 3종)
+
+| Cast path | Jax self_buff 진입? | sim 정합 |
+|-----------|:-------------------:|:--------:|
+| Main pipeline (line ~6137) | ✅ self_buff 분기 (line 6226 damage 0) | ✓ |
+| Recast (onKill) (line ~6544) | ❌ (PykeCarry 전용 onKillRecastMultiplier 분기, Jax 무관) | — |
+| OOR fallback (line 6973-7037) | ✅ self_buff OOR 경로 (line 7001-2 self-hit 회귀 방지) | ✓ |
+
+**확인**: self_buff 패턴 자체는 main + OOR 양쪽 일관 — PR #98 codex P1 회귀 가드 (line 6222-6226 + 7001-7002). single fix 회귀 위험 없음.
+
+## Lint finding (신규 검출)
+
+### Lint candidate #11-A — JaxCarry `damage` 필드 sim 미반영
+
+- carryAugments.ts:213 `damage: [170, 250, 450]` 와 desc "사용: 대상 magic damage" 명시
+- combatLoop.ts:6149 주석 "self_buff pattern 은 carry damage override 적용 안 함" + line 6226 `if (config.pattern === 'self_buff') rawAbilityDmgBase = 0;`
+- 17.3 patch entry 정합 (PR #115 같은 정합) 만 진행, sim 효과 도달 안 함
+- **해소 방향**: (1) damage 필드 자체 deprecate + entry 에서 제거, (2) self_buff 패턴에서 별도 single-target damage 추가 분기, (3) "design intent" 로 sim 미반영 명시
+
+### Lint candidate #11-B — JaxCarry `asGain` 필드 dead
+
+- carryAugments.ts:215 `asGain: [0.15, 0.15, 0.20]` 정의되어 있으나 src/ 전체 grep 결과 read 위치 0건
+- selfBuff.attackSpeed 0.15 fixed 가 starLevel 분기 없이 대체
+- desc "영구 AS/MS +15/15/20%" 와 ★3 mismatch (+20% 의도 vs +15% 실제)
+- **해소 방향**: (1) selfBuff.attackSpeed 를 starLevel별 array 로 확장 + asGain read site 추가, (2) asGain 필드 제거 + selfBuff fixed 명시
+
+## Lint 체크리스트
+
+- [x] entity-wide grep `Jax` — multi-source drift 없음 (combatLoop.ts 의 self_buff 분기 + onAttackBonus 패시브 외 specific helper 함수 없음)
+- [x] cast path 3종 (main + recast + OOR) — main + OOR 정합, recast 무관
+- [x] actual integration verify — damage / asGain 필드 미반영 검출 (Lint #11-A, #11-B)
+- [ ] statOverrides 인게임 측정 (HP/AS base/range)
+- [ ] selfBuff.attackSpeed multiplicative 누적 의도 vs additive 의도 확정
+
+## 관련
+
+- [[hero-augment-carry]] — carry augment 시스템 전체
+- [[role-passive]] — Fighter role mana/타게팅 규칙
+- [[ability-targeting]] — `self_buff` 패턴 (3 cast path)
+- [[patch-17-3]] — damage 변경 시점
+- 코드: `src/data/carryAugments.ts:205-218`, `src/lib/simulator/engine/combatLoop.ts:618/2220/5618/6226/6886`

--- a/docs/meta/wiki/augments/nasus-carry.md
+++ b/docs/meta/wiki/augments/nasus-carry.md
@@ -1,0 +1,112 @@
+---
+id: nasus-carry
+type: augment
+display_name_kr: 꽁! (Bonk!)
+api_name: TFT17_Augment_NasusCarry
+target_champion: TFT17_Nasus
+tier: (미확인 — 패치노트 verify 필요)
+stage: stage 2 (carry augment 일반)
+current_patch_status: active
+sim_active: partial
+last_verified: 2026-05-19
+sources:
+  - src/data/carryAugments.ts:113-129 (NasusCarry entry)
+  - src/lib/simulator/engine/combatLoop.ts:618-622 (getAbilityConfigForUnit)
+  - src/lib/simulator/engine/combatLoop.ts:2220-2267 (applyHeroCarryTransforms role='Fighter')
+  - src/lib/simulator/engine/combatLoop.ts:643-665 (resolveAbilityDamage carry damage 분기)
+  - 공식 17.3 패치노트 (Bonk! Resists 40→45 — verify 필요)
+related:
+  - "[[hero-augment-carry]]"
+  - "[[ability-targeting]]"
+  - "[[role-passive]]"
+---
+
+# 꽁! (NasusCarry, Bonk!)
+
+## 요약
+
+Nasus (`TFT17_Nasus`) carry augment. 활성 시 가장 강한 Nasus 1명 → `Fighter` 변환 + **single 패턴** AD physical cast. desc 상 "이 스킬로 적을 처치하면 스킬 피해량이 영구적으로 증가" (처치 누적) — 그러나 `bonusPerKill` 필드는 sim 미반영.
+
+가장 단순한 carry augment 구조: abilityOverride `{ pattern: 'single' }` 만 정의, abilityData 의 damage 가 표준 `resolveAbilityDamage` 경로로 사용됨.
+
+## 변환 후 메커니즘
+
+- **role**: `Fighter` (default — `applyHeroCarryTransforms` line 2227)
+- **abilityOverride**: `{ pattern: 'single' }` (`carryAugments.ts:116`)
+- **damageTypeOverride**: `physical` (line 117) — `resolveAbilityDamage` damageType 우선 physical
+- **cast 효과**:
+  - single pattern → 가장 가까운 적 1명에게 `damage[starLevel-1]` AD physical (carry damage override 경로, `combatLoop.ts:6216-6220` resolveAbilityDamage → carryForDamage)
+  - physical 이므로 `baseValue * (1 + bonusAdPercent)` — carry abilityData 에 bonusAdPercent 없음 → baseValue 그대로
+- **mana**: 60/120 (raw 채택)
+- **scalingInput**: `{ label: '처치 수', unit: '회', max: 999, effectPerStack: '피해량 +10' }` — UI 표시용 (sim 미반영, scalingInput 자체는 sim 효과 분기 없음)
+
+## 변수 (carryAugments.ts:121-128 abilityData, 17.3 LIVE 기준)
+
+| 변수 | 값 | sim 적용 | 비고 |
+|------|-----|---------|------|
+| `mana` | `60/120` | ✅ | raw 채택 |
+| `damage` | `[280, 420, 670]` | ✅ | `resolveAbilityDamage` carryForDamage 경로 — single 패턴 |
+| `bonusPerKill` | `[10, 13, 20]` | ❌ **미반영** | grep `bonusPerKill` src/ → carryAugments.ts entry 외 read 위치 0건. desc "처치 시 피해 영구 증가" sim 미실현 |
+| `damageType` | `physical` | ✅ | damageTypeOverride physical 우선 |
+
+## 패치 히스토리
+
+| 패치 | 변경 |
+|------|------|
+| 17.3 (2026-05-13) | 패치노트 "Bonk! Resists: 40 → 45" — augment grant 인지 champion baseline 변경인지 모호. `carryAugments.ts:119-120` TODO 주석. **인게임 verify 필요 (Lint #5 잔존)** |
+
+## sim 적용 상태 — `partial`
+
+✅ **활성**:
+- `role='Fighter'` 변환
+- single pattern + damage [280, 420, 670] AD physical (carryForDamage 경로)
+- damageTypeOverride `physical` 우선
+- mana 60/120 raw 채택
+
+❌ **미반영**:
+1. **`bonusPerKill[10,13,20]` 미반영** — grep src/ 전체 결과 read 위치 0건. desc "이 스킬로 적을 처치하면 스킬 피해량이 영구적으로 증가" sim 미실현. scalingInput.effectPerStack "피해량 +10" UI 표시만, sim 효과 도달 안 함.
+2. **Resists 40→45 buff** — 17.3 패치노트. statOverrides.armor/magicResist 없음. augment grant 인지 base stat 변경인지 모호 → 인게임 측정 후 확정.
+
+🔍 **검증 필요**:
+- statOverrides 인게임 측정 (Lint #5):
+  - augment 활성 시 armor +40 (또는 +45)
+  - magicResist +40 (또는 +45)
+  - HP/AS/range 변화 여부
+- `bonusPerKill` 의도 sim 반영 결정: (1) on_kill eventBus listener 추가, (2) 필드 dead 정리, (3) "design intent only" 명시
+
+## Cast path 전수 확인 (5단계 워크플로우 cast path 3종)
+
+| Cast path | Nasus single 진입? | sim 정합 |
+|-----------|:------------------:|:--------:|
+| Main pipeline (line ~6137) | ✅ single 패턴 cast (carryForDamage 경로) | ✓ |
+| Recast (onKill) (line ~6544) | ❌ (PykeCarry 전용 분기) | — |
+| OOR fallback (line 6973-7037) | ⚠️ dash 없음 → OOR 진입 안 함 (line 6977-78: `dash || self_buff` 가드) | n/a |
+
+**확인**: NasusCarry abilityOverride 에 dash 없음 + self_buff 아님 → OOR fallback path 진입 자체 없음. main pipeline single cast 만 사용 → single fix path.
+
+## Lint finding
+
+### Lint candidate #12 — NasusCarry `bonusPerKill` 필드 dead
+
+- carryAugments.ts:127 `bonusPerKill: [10, 13, 20]` 정의되어 있으나 src/ 전체 grep read 위치 0건
+- desc "이 스킬로 적을 처치하면 스킬 피해량이 영구적으로 증가" + scalingInput "처치 수 / 피해량 +10" 모두 일관되게 영구 누적 buff 의도
+- **해소 방향**: (1) on_kill eventBus listener 추가 → `unit.nasusBonkStack` 누적 + cast damage 에 stack × bonusPerKill 가산 (Shen passive 패턴 [[role-passive]] 참조), (2) 필드 제거 + design-only 명시
+
+### Lint #5 잔존 — Resists 40→45 인게임 verify (기존)
+
+`carryAugments.ts:119-120` TODO 주석 — 17.3 패치노트 변경분이 augment grant 인지 base 인지 verify 필요. **사용자 인게임 측정 데이터 제공 후 statOverrides.armor/magicResist 채움**.
+
+## Lint 체크리스트
+
+- [x] entity-wide grep `Nasus` — multi-source drift 없음 (combatLoop.ts 의 specific helper 함수 없음, single pattern 표준 경로만 사용)
+- [x] cast path 3종 — main 만 진입 (OOR/recast 무관)
+- [x] actual integration verify — `bonusPerKill` 필드 dead 검출 (Lint #12)
+- [ ] Resists 40→45 인게임 측정 (Lint #5)
+- [ ] `bonusPerKill` 해소 방향 결정 (sim 추가 vs 필드 제거)
+
+## 관련
+
+- [[hero-augment-carry]] — carry augment 시스템 전체
+- [[role-passive]] — Fighter role mana/타게팅 규칙
+- [[ability-targeting]] — `single` 패턴 (main 만 진입)
+- 코드: `src/data/carryAugments.ts:113-129`, `src/lib/simulator/engine/combatLoop.ts:618/2220/643`

--- a/docs/meta/wiki/index.md
+++ b/docs/meta/wiki/index.md
@@ -1,7 +1,7 @@
 ---
 name: TFT Domain Wiki — Index
 purpose: 위키 전체 페이지 카탈로그 (content-oriented)
-updated: 2026-05-18
+updated: 2026-05-19
 ---
 
 # TFT Domain Wiki — Index
@@ -41,6 +41,9 @@ _미작성_
 - [[gragas-carry]] (자폭) — 17.2 도입. ✅ Lint #8 resolved (PR #127) — 적군 AOE 반경 3칸 정상 작동 (이전 무력화)
 - [[aatrox-carry]] (별빛 연계) — 17.2 도입. 가장 복잡 carry — 3-skill cycle + N.O.V.A. + isolation. 17.3 변경 3건 sim 정합
 - [[pyke-carry]] (청부 살인마) — 17.2 도입. x_shape + onKillRecast cascade. ⚠️ Lint #10 (PR #131 검출): hero-augment-carry 의 "onKill hook 미구현" stale (실제 구현 완료, wiki cleanup 후보)
+- [[jax-carry]] (저 별을 향해) — self_buff + onAttackBonus passive. ⚠️ Lint #11-A (damage 필드 self_buff 미반영), ⚠️ Lint #11-B (asGain 필드 dead — ★3 +20% 의도 vs 실제 +15%)
+- [[nasus-carry]] (꽁!) — single 패턴 AD physical. ⚠️ Lint #12 (bonusPerKill 필드 dead — 처치 누적 영구 damage 미실현), Lint #5 잔존 (Resists 40→45 인게임 verify)
+- [[invader-zed]] (침략자 제드) — stage 4-2 special. ⚠️ Lint #13 (selfBuff 필드 부재 + damage 미반영으로 sim 효과 사실상 0 — role='Fighter' + mana 50/100 변경뿐)
 
 ## Raw Sources (Layer 1)
 
@@ -53,10 +56,11 @@ _미작성_
 ## 작성 우선순위 (다음 후보)
 
 위키화 가치 높은 순:
-1. **augments 나머지 5개** — Ivern/Jax/Nasus/Poppy/Zed Carry. entity-wide grep 으로 추가 lint 검출 가능성
-2. **flag 자체 dead 정리** (`gragasCarryActive` / `leonaCarryActive`) — sim 코드 사용처 0, 테스트 assertion 만 (Lint #6/#8 후속)
-3. **Lint #10 cleanup** — `hero-augment-carry.md` 의 "Pyke onKill 미구현" stale 정정 (본 PR 에서 부분 정정, 후속 PR 로 더 깊이)
-4. **챔피언별** — Annie, Galio, Shen, Yasuo (이미 plan 문서 존재)
-5. **Poppy/Nasus 인게임 verify 후 statOverrides 적용** (Lint #5 잔존 TODO — 사용자 측정 필요)
-6. **integration test** — LeonaCarry / GragasCarry / AatroxCarry sim 통합 (cycle counter / 적군 AOE / starLevel별 stun 등)
-7. **OOR cast path 의 cycle/x_shape 일관성 verify** — Aatrox/Pyke 페이지의 follow-up verify 항목 (PR #129 stun 같은 패턴 가능성)
+1. **augments 나머지 2개** — Poppy / IvernMinion Carry. 복잡 메커니즘 (bouncing / multi-stun) 으로 5단계 워크플로우 적용 시 추가 lint 검출 가능성
+2. **Lint #11-A/B (Jax) + #12 (Nasus) + #13 (Zed) sim 해소** — sim fix PR (필드 read 추가 vs 필드 dead 정리)
+3. **flag 자체 dead 정리** (`gragasCarryActive` / `leonaCarryActive`) — sim 코드 사용처 0, 테스트 assertion 만 (Lint #6/#8 후속)
+4. **Lint #10 cleanup** — `hero-augment-carry.md` 의 "Pyke onKill 미구현" stale 정정 (PR #131 에서 부분 정정, 후속 PR 로 더 깊이)
+5. **챔피언별** — Annie, Galio, Shen, Yasuo (이미 plan 문서 존재)
+6. **Poppy/Nasus 인게임 verify 후 statOverrides 적용** (Lint #5 잔존 TODO — 사용자 측정 필요)
+7. **integration test** — LeonaCarry / GragasCarry / AatroxCarry sim 통합 (cycle counter / 적군 AOE / starLevel별 stun 등)
+8. **OOR cast path 의 cycle/x_shape 일관성 verify** — Aatrox/Pyke 페이지의 follow-up verify 항목 (PR #129 stun 같은 패턴 가능성)

--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -6,6 +6,45 @@ format: newest first
 
 # TFT Domain Wiki — Log
 
+## 2026-05-19
+
+### Ingest: augments/jax-carry.md + augments/nasus-carry.md + invader-zed.md — 5단계 워크플로우 + Lint #11/#12/#13 신규 검출
+
+- **Source** (5단계 워크플로우 적용):
+  - `src/data/carryAugments.ts:113-129` (NasusCarry), `:205-218` (JaxCarry), `:274-286` (InvaderZed)
+  - `src/lib/simulator/engine/combatLoop.ts:618-622` (getAbilityConfigForUnit), `:2220-2267` (applyHeroCarryTransforms role='Fighter')
+  - `combatLoop.ts:5618-5660` (onAttackBonus passive — Jax)
+  - `combatLoop.ts:6146-6149` (self_buff carry damage override 미적용 주석), `:6226` (rawAbilityDmgBase=0 강제)
+  - `combatLoop.ts:6885-6891` (config.selfBuff stat 적용 — selfBuff undefined 시 skip → InvaderZed 효과 0)
+  - `combatLoop.ts:1565-1582` (applyZedShadow — augment 무관, trait `TFT17_ZedUniqueTrait` 기반 +40% AD)
+  - `src/lib/simulator/systems/ability.ts:251` (TFT17_Zed raw `{ pattern: 'self_buff' }` 분신 stat-only)
+  - entity-wide grep `Jax` / `Nasus` / `Zed` → specific helper 함수 부재 확인
+- **5단계 워크플로우 적용 결과**:
+  1. 좁은 grep: JaxCarry / NasusCarry / InvaderZed → carryAugments.ts entry lookup
+  2. 함수 컨텍스트 read: `getAbilityConfigForUnit` (carry.abilityOverride 직접 반환), `resolveAbilityDamage` (self_buff 패턴 미반영), `config.selfBuff` 적용 분기
+  3. **entity-wide grep**: `Jax` / `Nasus` / `Zed` 이름 자체 → Jax 는 onAttackBonus passive (line 5618-) 만 별도, Nasus 는 specific helper 0건, Zed 는 trait 기반 applyZedShadow (augment 무관)
+  4. 호출 순서/영향 trace: self_buff cast path 가 main + OOR 양쪽 일관 (PR #98 codex P1 회귀 가드). recast 무관 (Pyke 전용)
+  5. **actual sim integration verify (결정적)**: `grep "asGain\|bonusPerKill" src/` → carryAugments.ts entry 외 read 위치 **0건** → Jax `asGain`, Nasus `bonusPerKill` 필드 dead 검출. self_buff 패턴 + damage 필드 미반영 (Jax/Zed) 추가 검출
+- **⚠️ Lint finding #11-A 검출 — JaxCarry `damage` 필드 sim 미반영**:
+  - carryAugments.ts:213 `damage: [170, 250, 450]` + desc "사용: 대상 magic damage" vs combatLoop.ts:6226 self_buff 패턴 rawAbilityDmgBase=0 강제
+  - 17.3 patch entry 정합 (PR #115 같은 정합) 만 진행, sim 효과 도달 안 함
+- **⚠️ Lint finding #11-B 검출 — JaxCarry `asGain` 필드 dead**:
+  - carryAugments.ts:215 `asGain: [0.15, 0.15, 0.20]` 정의되어 있으나 read 위치 0건
+  - selfBuff.attackSpeed 0.15 fixed 가 starLevel 분기 없이 대체 → **★3 의도 +20% vs 실제 +15%** (starLevel별 mismatch)
+- **⚠️ Lint finding #12 검출 — NasusCarry `bonusPerKill` 필드 dead**:
+  - carryAugments.ts:127 `bonusPerKill: [10, 13, 20]` + desc "처치 시 영구 증가" vs read 위치 0건
+  - scalingInput "처치 수 / 피해량 +10" UI 표시만, sim 효과 도달 안 함
+- **⚠️ Lint finding #13 검출 — InvaderZed augment 실효성 거의 0**:
+  - abilityOverride `{ pattern: 'self_buff' }` 만 정의, **selfBuff 필드 부재** → cast 시 stat 변경 0
+  - damage `[300, 450, 720]` 정의되어 있으나 self_buff 패턴이라 미반영
+  - 실제 sim 효과 = role='Fighter' + mana 50/100 뿐 (raw Zed trait `applyZedShadow` 의 +40% AD 는 augment 무관)
+- **메모리/워크플로우 변경 없음** — 5단계 워크플로우 그대로 적용. Lint #11-B 가 starLevel별 mismatch 패턴 (Lint #9 같은) 재발견 — actual sim integration verify (Step 5) 가 핵심 검출 단계.
+- **후속 작업 후보**:
+  - Lint #11-A/B sim 해소 PR — selfBuff.attackSpeed 를 starLevel별 array 화 + asGain read site 추가 (or 필드 dead 정리)
+  - Lint #12 sim 해소 PR — on_kill eventBus listener + `nasusBonkStack` 누적 + cast damage stack 가산 (Shen passive 패턴)
+  - Lint #13 sim 해소 PR — InvaderZed 의도된 메커니즘 spec 확인 후 abilityOverride.selfBuff 또는 statOverrides 추가
+  - augments 나머지 2개 (Poppy / IvernMinion) ingest
+
 ## 2026-05-18
 
 ### Ingest: augments/aatrox-carry.md + augments/pyke-carry.md — 5단계 워크플로우 누적 적용 + Lint #10 검출


### PR DESCRIPTION
## Summary

augments 폴더 정립 후속 — Jax / Nasus / Zed carry augment 3종 위키 페이지 추가. 5단계 워크플로우 (좁은 grep → 함수 컨텍스트 → entity-wide grep → 호출 순서·cast path 3종 → actual sim integration verify) 적용.

**actual sim integration verify (Step 5)** 가 핵심 — Lint #9 (starLevel별 stunDuration 미read), Lint #10 (stale 표기) 에 이어 본 PR 도 **신규 lint 4건** 검출.

## 신규 Lint 검출

### Lint #11-A — JaxCarry \`damage\` 필드 sim 미반영
- \`carryAugments.ts:213\` \`damage: [170, 250, 450]\` + desc \"사용: 대상 magic damage\"
- vs \`combatLoop.ts:6226\` \`if (config.pattern === 'self_buff') rawAbilityDmgBase = 0;\` 강제
- 17.3 patch entry 정합 (PR #115 같은 정합) 만 진행, sim 효과 도달 안 함

### Lint #11-B — JaxCarry \`asGain\` 필드 dead
- \`carryAugments.ts:215\` \`asGain: [0.15, 0.15, 0.20]\` 정의되어 있으나 src/ 전체 grep 결과 read 위치 **0건**
- selfBuff.attackSpeed 0.15 fixed 가 starLevel 분기 없이 대체
- **★3 의도 +20% vs 실제 +15%** (starLevel별 mismatch — Lint #9 같은 패턴 재발견)

### Lint #12 — NasusCarry \`bonusPerKill\` 필드 dead
- \`carryAugments.ts:127\` \`bonusPerKill: [10, 13, 20]\` + desc \"이 스킬로 적을 처치하면 스킬 피해량이 영구적으로 증가\"
- vs read 위치 0건. scalingInput \"처치 수 / 피해량 +10\" UI 표시만, sim 효과 도달 안 함

### Lint #13 — InvaderZed augment 실효성 사실상 0
- abilityOverride \`{ pattern: 'self_buff' }\` 만 정의, **\`selfBuff\` 필드 부재** → \`combatLoop.ts:6886\` if 가드 false → 어떤 stat 변경도 발생 안 함
- damage \`[300, 450, 720]\` 정의되어 있으나 self_buff 패턴이라 미반영
- 실제 sim 효과 = \`role='Fighter'\` + mana 50/100 변경뿐. raw Zed trait \`applyZedShadow\` 의 +40% AD 는 trait 기반 (augment 무관)

## 5단계 워크플로우 적용 결과

| 단계 | 결과 |
|------|------|
| 1. 좁은 grep | JaxCarry / NasusCarry / InvaderZed entry lookup |
| 2. 함수 컨텍스트 | \`getAbilityConfigForUnit\` (carry.abilityOverride 직접 반환), \`resolveAbilityDamage\` (self_buff 미반영), config.selfBuff 적용 분기 |
| 3. **entity-wide grep** | Jax 는 onAttackBonus passive (line 5618-) 만 별도. Nasus specific helper 0건. Zed 는 trait 기반 \`applyZedShadow\` (augment 무관) |
| 4. 호출 순서·cast path 3종 | Jax/Zed self_buff: main + OOR 정합 (PR #98 P1 가드). Nasus single: main 만. recast: Pyke 전용, 셋 다 무관 |
| 5. **actual integration verify** | \`grep \"asGain\\|bonusPerKill\" src/\` → entry 외 read 0건 → Lint #11-B/#12 검출. self_buff + damage 미반영 → Lint #11-A/#13 검출 |

## sim 적용 상태 요약

- **JaxCarry**: \`partial\` — role='Fighter' + selfBuff.attackSpeed 0.15 cast 마다 누적 + onAttackBonus passive (★별 magic) ✅ / damage + asGain ❌
- **NasusCarry**: \`partial\` — role='Fighter' + single AD physical (carryForDamage 경로) ✅ / bonusPerKill ❌ / Lint #5 잔존 (Resists 40→45 인게임 verify)
- **InvaderZed**: \`minimal\` — role='Fighter' + mana 50/100 만 적용. cast 효과 0

## Follow-up 후보

- Lint #11-A/B sim 해소 PR: selfBuff.attackSpeed → starLevel별 array + asGain read site 추가 (or 필드 dead 정리)
- Lint #12 sim 해소 PR: on_kill eventBus listener + \`nasusBonkStack\` 누적 + cast damage stack 가산 (Shen passive 패턴 참조)
- Lint #13 sim 해소 PR: InvaderZed 의도된 메커니즘 spec 확인 (사용자/패치노트) 후 abilityOverride.selfBuff 또는 statOverrides 추가
- augments 나머지 2개 (Poppy / IvernMinion) ingest — 복잡 메커니즘 (bouncing / multi-stun) 으로 추가 lint 검출 가능성

## Test plan

- [ ] PR diff 가 위키 페이지 3개 + index/log 갱신만 포함 (sim 코드 변경 없음 확인)
- [ ] Codex review 대기 후 응답
- [ ] index.md \"augments\" 섹션 5개 entry 표기 일관