### PR TITLE
docs(wiki): augments/ivern-minion-carry — 5단계 + 신규 lint 0건 (augments 폴더 완성)

### DIFF
--- a/docs/meta/wiki/augments/ivern-minion-carry.md
+++ b/docs/meta/wiki/augments/ivern-minion-carry.md
@@ -1,0 +1,129 @@
+---
+id: ivern-minion-carry
+type: augment
+display_name_kr: "빅뱅 (Big Bang / Meepsie)"
+api_name: TFT17_Augment_IvernMinionCarry
+target_champion: TFT17_IvernMinion
+tier: gold
+stage: stage 2 (carry augment 일반)
+current_patch_status: active
+sim_active: active
+last_verified: 2026-05-19
+sources:
+  - "src/data/carryAugments.ts:188-204 (IvernMinionCarry entry)"
+  - "src/lib/simulator/systems/augment.ts:58 (tier='gold')"
+  - "src/lib/simulator/systems/ability.ts:209 (TFT17_IvernMinion raw — aoe_circle r=1, heal:true — augment 활성 시 override)"
+  - "src/lib/simulator/engine/combatLoop.ts:694-711 (findLargestClusterTarget — cluster radius 2 hex)"
+  - "src/lib/simulator/engine/combatLoop.ts:713-758 (applyAbilityDash to_largest_cluster 분기)"
+  - "src/lib/simulator/engine/combatLoop.ts:1226-1252 (applyCarryPostCastEffects multi-stun 3 nearest)"
+  - "src/lib/simulator/engine/combatLoop.ts:1326-1331 (applyCarryDamageModifiers hexReduction falloff)"
+  - "src/lib/simulator/engine/combatLoop.ts:5618-5660 (onAttackBonus passive — Jax 와 공유)"
+  - "src/lib/simulator/engine/combatLoop.ts:6820-6824 (IvernMinion abilityOverride.stun 없음 — applyCarryPostCastEffects 별도 분기)"
+  - "공식 17.3 패치노트 (Big Bang hexReduction: 0.45 → 0.35)"
+related:
+  - "[[hero-augment-carry]]"
+  - "[[ability-targeting]]"
+  - "[[role-passive]]"
+  - "[[patch-17-3]]"
+---
+
+# 빅뱅 (IvernMinionCarry, Big Bang / Meepsie)
+
+## 요약
+
+꼬마정령 (`TFT17_IvernMinion`) carry augment, **gold tier**. 활성 시 가장 강한 꼬마정령 1명 → `Fighter` 변환 + 매 기본 공격 추가 magic (`onAttackBonus`) + **dash to_largest_cluster** (가장 큰 적 무리 중심으로 도약) + **aoe_circle radius 3** magic damage + 1칸당 35% multiplicative falloff (`hexReduction`) + **가장 가까운 3명 starLevel별 multi-stun**.
+
+**가장 복잡한 dash-based carry** — cluster 탐지 알고리즘 + hexReduction multiplicative falloff + multi-stun post-cast 3 메커니즘이 main + OOR cast path 양쪽 일관 적용 (`applyCarryPostCastEffects` 통합 helper 덕분).
+
+## 변환 후 메커니즘
+
+- **role**: `Fighter` (default — `applyHeroCarryTransforms` line 2227)
+- **abilityOverride**: `{ pattern: 'aoe_circle', radius: 3, dash: 'to_largest_cluster' }` (`carryAugments.ts:192`)
+- **damageType**: `magic` (abilityData.damageType, damageTypeOverride 없음 → resolveAbilityDamage 의 abilityData.damageType fallback)
+- **cast 효과**:
+  - **dash**: `applyAbilityDash` line 734 → `findLargestClusterTarget(aliveEnemies)` (line 694-711) — 각 alive 적 위치 중심으로 radius 2 내 타 적 개수 카운트, max count 적 반환. tie 시 첫 번째 (stable). dashTarget 인접 빈 칸 중 가장 가까운 곳으로 unit 이동
+  - **abilityTarget = dashTarget** (cluster center) 기준 `findAbilityTargets` aoe_circle r=3 — center 로부터 hex distance ≤ 3 의 모든 적
+  - **base damage**: `damage[starLevel-1]` magic → `baseValue × (1 + ap/100)` (resolveAbilityDamage carryForDamage)
+  - **`hexReduction 0.35` falloff** (`applyCarryDamageModifiers` line 1326-1331): `baseDmg *= Math.pow(1 - 0.35, dist)` — dist = abilityTarget (cluster center) 로부터 hex distance. IvernMinionCarry 한정 (augmentApiName 검사)
+  - **multi-stun** (`applyCarryPostCastEffects` line 1232-1252): IvernMinionCarry 한정. abilityTargets 를 caster (unit) 위치 기준 sort → 가장 가까운 3명 (IVERN_STUN_TARGETS=3) starLevel별 `stunDuration[starLevel-1]` 초 stun (state='idle', attackCooldown=0)
+- **passive (onAttackBonus)**: 매 기본 공격마다 `onAttackBonus[starLevel-1]` AP scaling magic damage 추가 (`combatLoop.ts:5618-5660`, Jax 와 공유)
+  - target.state ≠ 'dead' && currentHp > 0 가드 (PR #74)
+  - 통합 mitigation (resistance + DR + non-target reduction + shield + invulnerable)
+- **`spiritEffectPerStack 0`** (`carryAugments.ts:201`): falsy → line 6231 if 가드 false → no-op (Poppy 와 달리 미프 trait stack damage amp 미적용)
+- **mana**: 50/100 (raw 채택)
+
+## 변수 (carryAugments.ts:193-203 abilityData, 17.3 LIVE 기준)
+
+| 변수 | 값 | sim 적용 | 비고 |
+|------|-----|---------|------|
+| `mana` | `50/100` | ✅ | raw 채택 |
+| `damage` | `[240, 360, 560]` | ✅ | aoe_circle base — magic AP scaling. resolveAbilityDamage carryForDamage |
+| `onAttackBonus` | `[40, 60, 90]` | ✅ | 매 기본 공격 추가 magic (line 5626). Jax 와 동일 helper |
+| `hexReduction` | `0.35` | ✅ | line 1330 `Math.pow(1 - 0.35, dist)`. **17.3: `0.45 → 0.35`** (3성 falloff 완화 = buff). center=cluster center (abilityTarget) |
+| `stunDuration` | `[1.25, 1.5, 1.75]` | ✅ | line 1234-1235 starLevel별. 3명 (IVERN_STUN_TARGETS=3 hardcoded). PR #129 Lint #9 fix 이전부터 이미 IvernMinion 전용 분기에서 정합 |
+| `spiritEffectPerStack` | `0` | ✅ (no-op) | falsy → 미프 stack damage amp 미적용 |
+| `damageType` | `magic` | ✅ | resolveAbilityDamage 의 abilityData.damageType fallback |
+
+**radius**: top-level abilityOverride 의 `radius: 3` (`carryAugments.ts:192`) — abilityData.radius 아님. config.radius 통해 findAbilityTargets 에 전달.
+
+## 패치 히스토리
+
+| 패치 | 변경 |
+|------|------|
+| [[patch-17-2b]] (2026-04-29) | PR7-B 구현 — `dash: to_largest_cluster` + `aoe_circle radius 3` + `applyCarryPostCastEffects` multi-stun 통합 helper 도입 (PR #76 의 OOR multi-stun 누락 회귀 자동 해소) |
+| [[patch-17-3]] (2026-05-13) | `hexReduction 0.45 → 0.35` (3성 falloff 완화 — buff). 다른 필드 (damage / onAttackBonus / stunDuration) 변경 없음 (verify 필요) |
+| 17.2 도입 시점 | carry augment 1세대 — `gold` tier |
+
+## sim 적용 상태 — `active`
+
+✅ **활성** (entity-wide grep + cast path 전수 + actual integration 모두 verify):
+- `role='Fighter'` 변환
+- dash to_largest_cluster (cluster 탐지 알고리즘 — radius 2 hex 내 적 카운트)
+- aoe_circle radius 3 + damage AP scaling magic
+- `hexReduction 0.35` multiplicative falloff (cluster center 기준)
+- `stunDuration[starLevel]` 3 nearest multi-stun (caster 위치 기준 sort)
+- `onAttackBonus[starLevel]` AP scaling magic 매 기본 공격
+- `spiritEffectPerStack 0` no-op (의도된 unused)
+
+🔍 **검증 필요**:
+- 17.3 패치노트 의 IvernMinion 관련 추가 변경분 verify (damage / onAttackBonus / stunDuration 변경 여부)
+- statOverrides 인게임 측정 (HP/AS/range 변화 — 사용자 측정 후 채움)
+- desc "2칸 내 가장 큰 적 무리에 도약" 해석 — sim 은 cluster radius=2 (cluster 정의의 거리, line 706) 로 구현. desc 가 "Ivern 으로부터 2칸" 의미일 가능성 → 사용자 의도 확정 필요
+- IVERN_STUN_TARGETS=3 hardcoded — desc "가장 가까운 3명" 정합. starLevel별 변동 의도 여부 확인 (현재 모든 star 3명 fixed)
+
+## Cast path 전수 확인 (5단계 워크플로우 cast path 3종)
+
+| Cast path | IvernMinion 진입? | sim 정합 |
+|-----------|:----------------:|:--------:|
+| Main pipeline (line ~6137) | ✅ aoe_circle + dash + hexReduction + multi-stun 모두 적용 | ✓ |
+| Recast (onKill) (line ~6544) | ❌ (PykeCarry 전용 `onKillRecastMultiplier` 분기) | — |
+| OOR fallback (line 6973-7037) | ✅ `canDashCast = dash` true (to_largest_cluster) — 진입. dash + damage + hexReduction (applyCarryDamageModifiers line 7098) + multi-stun (applyCarryPostCastEffects line 7151) 모두 일관 | ✓ |
+
+**확인** (PR #76 / codex P1 #76 helper 통합 효과):
+- `applyAbilityDash` to_largest_cluster: main + OOR 양쪽 동일 helper 호출
+- `applyCarryDamageModifiers` (hexReduction): caller 2 site main+OOR. IvernMinionCarry 한정 분기 양쪽 일관 (line 1328)
+- `applyCarryPostCastEffects` (multi-stun): caller 2 site main+OOR. PR #76 의 "다른 carry-specific 메커니즘 OOR 누락 회귀 자동 해소" — 신규 carry post-cast 추가 시 helper 한 곳만 수정
+- `outOfRangeConfig.stun` 분기 (line 7129) 와 무관 — IvernMinion abilityOverride.stun 없음 (`combatLoop.ts:6820-6824` 명시). multi-stun 은 별도 line 1232 분기 전용
+
+## Lint finding
+
+**신규 lint 검출 0건** — IvernMinionCarry 는 dash + hexReduction + multi-stun 모두 cast path 양쪽 일관. helper 통합 (`applyCarryDamageModifiers`, `applyCarryPostCastEffects`) 덕분에 PR #129 같은 OOR 누락 패턴 위험 자체 없음.
+
+대신 desc 해석 ambiguity (cluster "2칸 내" 의미) 와 17.3 패치노트 다른 변경분 verify 정도가 후속 항목.
+
+## Lint 체크리스트
+
+- [x] entity-wide grep `Ivern` — multi-source: `findLargestClusterTarget` (line 694, dash helper) + `applyCarryDamageModifiers` (line 1328, hexReduction IvernMinionCarry 한정) + `applyCarryPostCastEffects` (line 1232, multi-stun IvernMinionCarry 한정) + `onAttackBonus` (line 5626, Jax 와 공유 helper) — 모두 의도된 분리, drift 없음
+- [x] cast path 3종 — main + OOR 양쪽 일관 (helper 통합). recast 무관
+- [x] actual integration verify — 6 필드 (damage/onAttackBonus/hexReduction/stunDuration/dash/spiritEffectPerStack) 모두 read 위치 확인. 신규 lint 0건
+- [ ] 17.3 패치노트 IvernMinion 추가 변경분 verify (damage / onAttackBonus / stunDuration)
+- [ ] statOverrides 인게임 측정
+- [ ] desc "2칸 내" 해석 확정 (cluster radius vs Ivern-relative distance)
+
+## 관련
+
+- [[hero-augment-carry]] — carry augment 시스템 전체
+- [[role-passive]] — Fighter role mana/타게팅 규칙
+- [[ability-targeting]] — `aoe_circle` 패턴 + `to_largest_cluster` dash
+- [[patch-17-2b]] / [[patch-17-3]] — PR7-B 도입 + hexReduction 변경
+- 코드: `src/data/carryAugments.ts:188-204`, `src/lib/simulator/engine/combatLoop.ts:694/1226/1326/5618`

--- a/docs/meta/wiki/index.md
+++ b/docs/meta/wiki/index.md
@@ -45,6 +45,7 @@ _미작성_
 - [[nasus-carry]] (꽁!) — single 패턴 AD physical. ⚠️ Lint #12 (bonusPerKill 필드 dead — 처치 누적 영구 damage 미실현), Lint #5 잔존 (Resists 40→45 인게임 verify)
 - [[invader-zed]] (침략자 제드) — stage 4-2 special. ⚠️ Lint #13 (selfBuff 필드 부재 + damage 미반영으로 sim 효과 사실상 0 — role='Fighter' + mana 50/100 변경뿐)
 - [[poppy-carry]] (정령단 속도) — ranged projectile (rangeOverride 4) + armorScale 1.0 + spiritBounceOnKill (max 50 chain) + Set 17 Poppy passive 별도 작동. 신규 lint 없음 — 가장 많은 메커니즘 sim 통합 완성도 carry. Lint #5 잔존 (AS 0.7→0.75 인게임 verify)
+- [[ivern-minion-carry]] (빅뱅) — gold tier. dash to_largest_cluster (cluster radius 2 hex 알고리즘) + aoe_circle r=3 + hexReduction 0.35 (17.3 nerf 완화) + multi-stun 3 nearest + onAttackBonus passive. helper 통합 (applyCarryDamageModifiers / applyCarryPostCastEffects) 덕분에 main+OOR cast path 양쪽 일관 — 신규 lint 0건
 
 ## Raw Sources (Layer 1)
 
@@ -57,7 +58,7 @@ _미작성_
 ## 작성 우선순위 (다음 후보)
 
 위키화 가치 높은 순:
-1. **augments 나머지 1개** — IvernMinion Carry. multi-stun (이미 `applyCarryPostCastEffects` 통합) 으로 추가 lint 검출 가능성
+1. **augments 완료** — 10 carry augments 전체 위키화 완료 (Leona/Mord/Gragas/Aatrox/Pyke/Jax/Nasus/Zed/Poppy/Ivern). 신규 작업 → sim 해소 또는 champion 페이지로 이동
 2. **Lint #11-A/B (Jax) + #12 (Nasus) + #13 (Zed) sim 해소** — sim fix PR (필드 read 추가 vs 필드 dead 정리)
 3. **flag 자체 dead 정리** (`gragasCarryActive` / `leonaCarryActive`) — sim 코드 사용처 0, 테스트 assertion 만 (Lint #6/#8 후속)
 4. **Lint #10 cleanup** — `hero-augment-carry.md` 의 "Pyke onKill 미구현" stale 정정 (PR #131 에서 부분 정정, 후속 PR 로 더 깊이)

--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,6 +8,36 @@ format: newest first
 
 ## 2026-05-19
 
+### Ingest: augments/ivern-minion-carry.md — 5단계 워크플로우 + 신규 lint 0건 (augments 폴더 완성)
+
+- **Source** (5단계 워크플로우 적용):
+  - `src/data/carryAugments.ts:188-204` (IvernMinionCarry entry)
+  - `src/lib/simulator/systems/augment.ts:58` (tier='gold')
+  - `combatLoop.ts:694-711` (findLargestClusterTarget — cluster radius 2 hex 알고리즘)
+  - `combatLoop.ts:713-758` (applyAbilityDash to_largest_cluster 분기, line 734)
+  - `combatLoop.ts:1226-1252` (applyCarryPostCastEffects — multi-stun IvernMinionCarry 한정 분기)
+  - `combatLoop.ts:1326-1331` (applyCarryDamageModifiers — hexReduction multiplicative falloff IvernMinionCarry 한정)
+  - `combatLoop.ts:5618-5660` (onAttackBonus passive — Jax 와 공유 helper)
+  - `combatLoop.ts:6820-6824` (IvernMinion abilityOverride.stun 없음 → applyCarryPostCastEffects 별도 분기)
+- **5단계 워크플로우 적용 결과**:
+  1. 좁은 grep: IvernMinionCarry / to_largest_cluster / hexReduction / spiritEffectPerStack
+  2. 함수 컨텍스트: `findLargestClusterTarget` (각 alive 적 중심 radius 2 카운트 → max), `applyCarryPostCastEffects` (caller 2 site main+OOR), `applyCarryDamageModifiers` (5 modifier 통합)
+  3. **entity-wide grep `Ivern`**: 4 specific 적용 위치 발견 — dash helper + hexReduction modifier + multi-stun post-cast + onAttackBonus (Jax 공유). 모두 의도된 분리 (drift 아님)
+  4. 호출 순서·cast path: dash + hexReduction + multi-stun 모두 helper 통합 → main + OOR 양쪽 일관. PR #76 (multi-stun OOR 누락 회귀 자동 해소) 효과 검증
+  5. actual integration verify: 6 필드 (damage/onAttackBonus/hexReduction/stunDuration/dash/spiritEffectPerStack) 모두 read 위치 확인
+- **✅ 신규 lint 검출 0건** — PR7-B (17.2b dash to_largest_cluster + aoe_circle r=3 + multi-stun) + PR #76 (helper 통합) + PR #115 (17.3 hexReduction 정합) 누적 fix 효과적.
+- **🔍 후속 verify 항목**:
+  - 17.3 패치노트 IvernMinion 다른 변경분 (damage / onAttackBonus / stunDuration 변경 여부) verify
+  - desc "2칸 내 가장 큰 적 무리에 도약" 해석 — sim 은 cluster 정의 (radius 2 hex) 로 구현. desc 가 "Ivern 으로부터 2칸" 의미일 가능성 → 사용자 의도 확정 필요
+  - statOverrides 인게임 측정
+- **✅ augments 폴더 완성** — 10 carry augments (Leona/Mord/Gragas/Aatrox/Pyke/Jax/Nasus/Zed/Poppy/Ivern) 전체 위키화 완료
+- **다음 후보**:
+  - Lint #11-A/B (Jax damage 미반영 + asGain dead) sim 해소 PR
+  - Lint #12 (Nasus bonusPerKill dead) sim 해소 PR
+  - Lint #13 (Zed augment 실효성 0) sim 해소 PR
+  - 챔피언 페이지 진입 (Annie / Galio / Shen / Yasuo)
+  - `mechanics/ability-pattern-internals` — 9 pattern 알고리즘 + dash helper 깊이
+
 ### Ingest: augments/poppy-carry.md — 5단계 워크플로우 + 신규 lint 0건 (가장 통합 완성도 carry)
 
 - **Source** (5단계 워크플로우 적용):


### PR DESCRIPTION
## Summary

IvernMinionCarry (**빅뱅 / Big Bang**) 위키 페이지 추가. gold tier carry augment.

dash to_largest_cluster (cluster radius 2 hex 알고리즘) + aoe_circle r=3 + hexReduction 0.35 (17.3 nerf 완화) + multi-stun 3 nearest + onAttackBonus passive.

**✅ augments 폴더 완성** — 10 carry augments 전체 위키화 완료 (Leona / Mord / Gragas / Aatrox / Pyke / Jax / Nasus / Zed / Poppy / Ivern)

5단계 워크플로우 결과: **신규 lint 검출 0건**.

## 5단계 워크플로우 적용 결과

| 단계 | 결과 |
|------|------|
| 1. 좁은 grep | IvernMinionCarry / to_largest_cluster / hexReduction / spiritEffectPerStack |
| 2. 함수 컨텍스트 | \`findLargestClusterTarget\` (각 alive 적 중심 radius 2 카운트 → max), \`applyCarryPostCastEffects\` (caller 2 site main+OOR), \`applyCarryDamageModifiers\` (5 modifier 통합) |
| 3. **entity-wide grep \`Ivern\`** | 4 specific 적용 위치 발견 — dash helper + hexReduction modifier + multi-stun post-cast + onAttackBonus (Jax 공유). 모두 의도된 분리 (drift 아님) |
| 4. 호출 순서·cast path | dash + hexReduction + multi-stun 모두 helper 통합 → main + OOR 양쪽 일관 (PR #76 multi-stun OOR 누락 회귀 자동 해소 효과 검증) |
| 5. **actual integration verify** | 6 필드 (damage/onAttackBonus/hexReduction/stunDuration/dash/spiritEffectPerStack) 모두 read 위치 확인 |

## sim 적용 상태 — \`active\`

✅ **활성** (모든 메커니즘 sim 도달):
- \`role='Fighter'\` 변환
- dash to_largest_cluster (cluster 탐지 — radius 2 hex 내 적 카운트)
- aoe_circle radius 3 + damage AP scaling magic
- \`hexReduction 0.35\` multiplicative falloff (cluster center 기준)
- \`stunDuration[starLevel]\` 3 nearest multi-stun (caster 위치 기준 sort)
- \`onAttackBonus[starLevel]\` AP scaling magic 매 기본 공격
- \`spiritEffectPerStack 0\` no-op (의도된 unused)

## Cast path 확인

| Cast path | Ivern 진입? | 정합 |
|-----------|:-----------:|:----:|
| Main | ✅ aoe_circle + dash + hexReduction + multi-stun 모두 적용 | ✓ |
| Recast | ❌ (Pyke 전용) | — |
| **OOR** | ✅ \`canDashCast = dash\` true (to_largest_cluster) — 진입. dash + damage + hexReduction (line 7098) + multi-stun (line 7151) 모두 일관 | ✓ |

→ \`applyCarryDamageModifiers\` / \`applyCarryPostCastEffects\` helper 통합 덕분에 main+OOR 양쪽 자동 일관. PR #76 의 "다른 carry-specific 메커니즘 OOR 누락 회귀 자동 해소" 효과 검증.

## Lint finding

**신규 lint 0건**. PR7-B (17.2b dash + aoe + multi-stun) + PR #76 (helper 통합) + PR #115 (17.3 hexReduction 정합) 누적 fix 효과적.

## Follow-up 후보

- **17.3 패치노트 IvernMinion 추가 변경분 verify** (damage / onAttackBonus / stunDuration 변경 여부)
- desc \"2칸 내 가장 큰 적 무리에 도약\" 해석 — sim 은 cluster 정의 (radius 2 hex) 로 구현. desc 가 \"Ivern 으로부터 2칸\" 의미일 가능성 → 사용자 의도 확정 필요
- statOverrides 인게임 측정
- **다음 작업**:
  - Lint #11-A/B / #12 / #13 sim 해소 PR (Jax damage/asGain + Nasus bonusPerKill + Zed selfBuff 부재)
  - 챔피언 페이지 진입 (Annie / Galio / Shen / Yasuo)
  - \`mechanics/ability-pattern-internals\` — 9 pattern 알고리즘 + dash helper 깊이

## Test plan

- [ ] PR diff 가 위키 페이지 1개 (ivern-minion-carry.md) + index/log 갱신만 (sim 코드 변경 없음)
- [ ] YAML quote 적용 예방 — PR #133 의 \`AS: 0.7\` 같은 mapping 회귀 없음 (모든 sources double quote, Ruby Psych 으로 10 항목 모두 String 확인)
- [ ] Codex review 대기 후 응답