### PR TITLE
fix(sim): NasusCarry bonusPerKill cast kill 누적 — Lint #12 ✅ resolved

### DIFF
--- a/docs/meta/wiki/augments/nasus-carry.md
+++ b/docs/meta/wiki/augments/nasus-carry.md
@@ -7,7 +7,7 @@ target_champion: TFT17_Nasus
 tier: (미확인 — 패치노트 verify 필요)
 stage: stage 2 (carry augment 일반)
 current_patch_status: active
-sim_active: partial
+sim_active: active
 last_verified: 2026-05-19
 sources:
   - src/data/carryAugments.ts:113-129 (NasusCarry entry)
@@ -46,7 +46,7 @@ Nasus (`TFT17_Nasus`) carry augment. 활성 시 가장 강한 Nasus 1명 → `Fi
 |------|-----|---------|------|
 | `mana` | `60/120` | ✅ | raw 채택 |
 | `damage` | `[280, 420, 670]` | ✅ | `resolveAbilityDamage` carryForDamage 경로 — single 패턴 |
-| `bonusPerKill` | `[10, 13, 20]` | ❌ **미반영** | grep `bonusPerKill` src/ → carryAugments.ts entry 외 read 위치 0건. desc "처치 시 피해 영구 증가" sim 미실현 |
+| `bonusPerKill` | `[10, 13, 20]` | ✅ **활성** (PR #135 Lint #12 해소) | `applyCarryDamageModifiers` line 1334 modifier #6 — `baseDmg += unit.nasusBonkStack × bonusPerKill[starLevel-1]`. Stack 누적: cast loop `markTargetDead` 직후 (NasusCarry 활성 + Nasus 본인 한정). basic attack kill 제외 |
 | `damageType` | `physical` | ✅ | damageTypeOverride physical 우선 |
 
 ## 패치 히스토리
@@ -55,24 +55,26 @@ Nasus (`TFT17_Nasus`) carry augment. 활성 시 가장 강한 Nasus 1명 → `Fi
 |------|------|
 | 17.3 (2026-05-13) | 패치노트 "Bonk! Resists: 40 → 45" — augment grant 인지 champion baseline 변경인지 모호. `carryAugments.ts:119-120` TODO 주석. **인게임 verify 필요 (Lint #5 잔존)** |
 
-## sim 적용 상태 — `partial`
+## sim 적용 상태 — `active`
 
 ✅ **활성**:
 - `role='Fighter'` 변환
 - single pattern + damage [280, 420, 670] AD physical (carryForDamage 경로)
 - damageTypeOverride `physical` 우선
 - mana 60/120 raw 채택
+- **`bonusPerKill[10,13,20]` cast kill 누적** (PR #135 Lint #12 해소):
+  - Stack 누적: cast loop `markTargetDead` 직후 (`combatLoop.ts:6549-6555`). NasusCarry 활성 + `unit.champion.apiName === 'TFT17_Nasus'` 한정. basic attack kill 제외 ("이 스킬로" desc 정합)
+  - Read site: `applyCarryDamageModifiers` modifier #6 (`combatLoop.ts:1334-1340`) — `baseDmg += unit.nasusBonkStack × bonusPerKill[starLevel-1]`. base + scale 후 영구 buff raw 가산
+  - Invariant: `nasusBonkStack ≤ killCount` (cast kill 만 누적)
 
-❌ **미반영**:
-1. **`bonusPerKill[10,13,20]` 미반영** — grep src/ 전체 결과 read 위치 0건. desc "이 스킬로 적을 처치하면 스킬 피해량이 영구적으로 증가" sim 미실현. scalingInput.effectPerStack "피해량 +10" UI 표시만, sim 효과 도달 안 함.
-2. **Resists 40→45 buff** — 17.3 패치노트. statOverrides.armor/magicResist 없음. augment grant 인지 base stat 변경인지 모호 → 인게임 측정 후 확정.
+❌ **잔존**:
+- **Resists 40→45 buff** — 17.3 패치노트. statOverrides.armor/magicResist 없음. augment grant 인지 base stat 변경인지 모호 → 인게임 측정 후 확정 (Lint #5 잔존).
 
 🔍 **검증 필요**:
 - statOverrides 인게임 측정 (Lint #5):
   - augment 활성 시 armor +40 (또는 +45)
   - magicResist +40 (또는 +45)
   - HP/AS/range 변화 여부
-- `bonusPerKill` 의도 sim 반영 결정: (1) on_kill eventBus listener 추가, (2) 필드 dead 정리, (3) "design intent only" 명시
 
 ## Cast path 전수 확인 (5단계 워크플로우 cast path 3종)
 
@@ -86,11 +88,14 @@ Nasus (`TFT17_Nasus`) carry augment. 활성 시 가장 강한 Nasus 1명 → `Fi
 
 ## Lint finding
 
-### Lint candidate #12 — NasusCarry `bonusPerKill` 필드 dead
+### Lint #12 — NasusCarry `bonusPerKill` ✅ resolved (PR #135)
 
-- carryAugments.ts:127 `bonusPerKill: [10, 13, 20]` 정의되어 있으나 src/ 전체 grep read 위치 0건
-- desc "이 스킬로 적을 처치하면 스킬 피해량이 영구적으로 증가" + scalingInput "처치 수 / 피해량 +10" 모두 일관되게 영구 누적 buff 의도
-- **해소 방향**: (1) on_kill eventBus listener 추가 → `unit.nasusBonkStack` 누적 + cast damage 에 stack × bonusPerKill 가산 (Shen passive 패턴 [[role-passive]] 참조), (2) 필드 제거 + design-only 명시
+- carryAugments.ts:127 `bonusPerKill: [10, 13, 20]` 가 dead field → sim 도달
+- 해소 방식 (단순 inline hook, eventBus listener 미사용):
+  - **Stack 누적**: cast loop `markTargetDead` 호출 직후 (`combatLoop.ts:6549-6555`) — NasusCarry 활성 + `unit.champion.apiName === 'TFT17_Nasus'` + `carryCfg.abilityData.bonusPerKill` 가드. basic attack kill 자동 제외 (cast site 한정)
+  - **Stack read**: `applyCarryDamageModifiers` modifier #6 추가 (`combatLoop.ts:1334-1340`) — base + scale 후 raw 가산. caller 2 site (main + OOR) 자동 일관 — 다만 NasusCarry single pattern 은 OOR 진입 불가 (canDashCast 가드)
+- 호출 순서: 단독 적중 → secondary → tankBonus → armorScale → hexReduction → **bonusPerKill** (마지막, 영구 buff 가산 의미)
+- 테스트: `tests/unit/simulator/hero-carry-augments.test.ts` 3 case — 초기값 0 / cast kill ≤ killCount invariant / augment 미활성 시 stack 0
 
 ### Lint #5 잔존 — Resists 40→45 인게임 verify (기존)
 
@@ -98,11 +103,11 @@ Nasus (`TFT17_Nasus`) carry augment. 활성 시 가장 강한 Nasus 1명 → `Fi
 
 ## Lint 체크리스트
 
-- [x] entity-wide grep `Nasus` — multi-source drift 없음 (combatLoop.ts 의 specific helper 함수 없음, single pattern 표준 경로만 사용)
-- [x] cast path 3종 — main 만 진입 (OOR/recast 무관)
-- [x] actual integration verify — `bonusPerKill` 필드 dead 검출 (Lint #12)
-- [ ] Resists 40→45 인게임 측정 (Lint #5)
-- [ ] `bonusPerKill` 해소 방향 결정 (sim 추가 vs 필드 제거)
+- [x] entity-wide grep `Nasus` — multi-source drift 없음. PR #135 후 inline 분기 추가 (cast loop markTargetDead 직후 + applyCarryDamageModifiers modifier #6)
+- [x] cast path 3종 — main 만 진입 (OOR/recast 무관). modifier helper 자체는 main+OOR caller 2 site 자동 일관
+- [x] actual integration verify — `bonusPerKill` sim 도달 (PR #135)
+- [x] **Lint #12 ✅ resolved** (PR #135 — inline hook + modifier #6)
+- [ ] Resists 40→45 인게임 측정 (Lint #5 잔존)
 
 ## 관련
 

--- a/docs/meta/wiki/augments/nasus-carry.md
+++ b/docs/meta/wiki/augments/nasus-carry.md
@@ -63,8 +63,9 @@ Nasus (`TFT17_Nasus`) carry augment. 활성 시 가장 강한 Nasus 1명 → `Fi
 - damageTypeOverride `physical` 우선
 - mana 60/120 raw 채택
 - **`bonusPerKill[10,13,20]` cast kill 누적** (PR #135 Lint #12 해소):
-  - Stack 누적: cast loop `markTargetDead` 직후 (`combatLoop.ts:6549-6555`). NasusCarry 활성 + `unit.champion.apiName === 'TFT17_Nasus'` 한정. basic attack kill 제외 ("이 스킬로" desc 정합)
-  - Read site: `applyCarryDamageModifiers` modifier #6 (`combatLoop.ts:1334-1340`) — `baseDmg += unit.nasusBonkStack × bonusPerKill[starLevel-1]`. base + scale 후 영구 buff raw 가산
+  - Stack 누적: cast loop `markTargetDead` 직후. **`unit.nasusCarryActive` 가드** (codex P2 — 다중 Nasus 카피 시 selected 1명만 누적). basic attack kill 제외 ("이 스킬로" desc 정합)
+  - Read site: `applyCarryDamageModifiers` modifier #6 — `baseDmg += unit.nasusBonkStack × bonusPerKill[starLevel-1]`. `nasusCarryActive` 가드. base + scale 후 영구 buff raw 가산
+  - Selected unit: `applyHeroCarryTransforms` "가장 강한 1명" selector (성급 → 아이템 → 첫 번째). flag set 위치 — leona/gragas/mordekaiser 와 동일 패턴
   - Invariant: `nasusBonkStack ≤ killCount` (cast kill 만 누적)
 
 ❌ **잔존**:
@@ -91,11 +92,12 @@ Nasus (`TFT17_Nasus`) carry augment. 활성 시 가장 강한 Nasus 1명 → `Fi
 ### Lint #12 — NasusCarry `bonusPerKill` ✅ resolved (PR #135)
 
 - carryAugments.ts:127 `bonusPerKill: [10, 13, 20]` 가 dead field → sim 도달
-- 해소 방식 (단순 inline hook, eventBus listener 미사용):
-  - **Stack 누적**: cast loop `markTargetDead` 호출 직후 (`combatLoop.ts:6549-6555`) — NasusCarry 활성 + `unit.champion.apiName === 'TFT17_Nasus'` + `carryCfg.abilityData.bonusPerKill` 가드. basic attack kill 자동 제외 (cast site 한정)
-  - **Stack read**: `applyCarryDamageModifiers` modifier #6 추가 (`combatLoop.ts:1334-1340`) — base + scale 후 raw 가산. caller 2 site (main + OOR) 자동 일관 — 다만 NasusCarry single pattern 은 OOR 진입 불가 (canDashCast 가드)
+- 해소 방식 (단순 inline hook + selected flag, eventBus listener 미사용):
+  - **`nasusCarryActive` flag** (codex P2 amend): `applyHeroCarryTransforms` 의 "가장 강한 1명" selector 결과 unit 에만 true set. 다중 Nasus 카피 시 non-selected 회귀 방지 (leona/gragas/mordekaiser 패턴 동일)
+  - **Stack 누적**: cast loop `markTargetDead` 호출 직후 — `nasusCarryActive` + `carryCfg.abilityData.bonusPerKill` 가드. basic attack kill 자동 제외 (cast site 한정)
+  - **Stack read**: `applyCarryDamageModifiers` modifier #6 추가 — `nasusCarryActive` 가드. base + scale 후 raw 가산. caller 2 site (main + OOR) 자동 일관 — 다만 NasusCarry single pattern 은 OOR 진입 불가 (canDashCast 가드)
 - 호출 순서: 단독 적중 → secondary → tankBonus → armorScale → hexReduction → **bonusPerKill** (마지막, 영구 buff 가산 의미)
-- 테스트: `tests/unit/simulator/hero-carry-augments.test.ts` 3 case — 초기값 0 / cast kill ≤ killCount invariant / augment 미활성 시 stack 0
+- 테스트: `tests/unit/simulator/hero-carry-augments.test.ts` 4 case — 초기값 0 / cast kill ≤ killCount invariant / **다중 Nasus selected 1명만 nasusCarryActive (codex P2 회귀 가드)** / augment 미활성 시 stack 0
 
 ### Lint #5 잔존 — Resists 40→45 인게임 verify (기존)
 

--- a/docs/meta/wiki/index.md
+++ b/docs/meta/wiki/index.md
@@ -42,7 +42,7 @@ _미작성_
 - [[aatrox-carry]] (별빛 연계) — 17.2 도입. 가장 복잡 carry — 3-skill cycle + N.O.V.A. + isolation. 17.3 변경 3건 sim 정합
 - [[pyke-carry]] (청부 살인마) — 17.2 도입. x_shape + onKillRecast cascade. ⚠️ Lint #10 (PR #131 검출): hero-augment-carry 의 "onKill hook 미구현" stale (실제 구현 완료, wiki cleanup 후보)
 - [[jax-carry]] (저 별을 향해) — self_buff + onAttackBonus passive. ⚠️ Lint #11-A (damage 필드 self_buff 미반영), ⚠️ Lint #11-B (asGain 필드 dead — ★3 +20% 의도 vs 실제 +15%)
-- [[nasus-carry]] (꽁!) — single 패턴 AD physical. ⚠️ Lint #12 (bonusPerKill 필드 dead — 처치 누적 영구 damage 미실현), Lint #5 잔존 (Resists 40→45 인게임 verify)
+- [[nasus-carry]] (꽁!) — single 패턴 AD physical + **bonusPerKill cast kill 누적** (PR #135 Lint #12 ✅ resolved). Lint #5 잔존 (Resists 40→45 인게임 verify)
 - [[invader-zed]] (침략자 제드) — stage 4-2 special. ⚠️ Lint #13 (selfBuff 필드 부재 + damage 미반영으로 sim 효과 사실상 0 — role='Fighter' + mana 50/100 변경뿐)
 - [[poppy-carry]] (정령단 속도) — ranged projectile (rangeOverride 4) + armorScale 1.0 + spiritBounceOnKill (max 50 chain) + Set 17 Poppy passive 별도 작동. 신규 lint 없음 — 가장 많은 메커니즘 sim 통합 완성도 carry. Lint #5 잔존 (AS 0.7→0.75 인게임 verify)
 - [[ivern-minion-carry]] (빅뱅) — gold tier. dash to_largest_cluster (cluster radius 2 hex 알고리즘) + aoe_circle r=3 + hexReduction 0.35 (17.3 nerf 완화) + multi-stun 3 nearest + onAttackBonus passive. helper 통합 (applyCarryDamageModifiers / applyCarryPostCastEffects) 덕분에 main+OOR cast path 양쪽 일관 — 신규 lint 0건

--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,6 +8,32 @@ format: newest first
 
 ## 2026-05-19
 
+### Sim fix: NasusCarry bonusPerKill — Lint #12 ✅ resolved (PR #135)
+
+- **Source**: 위키 lint #12 (NasusCarry bonusPerKill 필드 dead, PR #132 검출)
+- **변경**:
+  - `src/types/index.ts:854-861`: `nasusBonkStack: number` 필드 추가 (Shen passive 패턴)
+  - `combatLoop.ts` 3 createCombatUnit site: `nasusBonkStack: 0` 초기화
+  - `combatLoop.ts:6549-6555` (cast loop markTargetDead 직후): NasusCarry 활성 + `unit.champion.apiName === 'TFT17_Nasus'` + `carryCfg.abilityData.bonusPerKill` 가드 시 `unit.nasusBonkStack++`
+  - `combatLoop.ts:1334-1340` (`applyCarryDamageModifiers` modifier #6 추가): `baseDmg += unit.nasusBonkStack × bonusPerKill[starLevel-1]` (NasusCarry 한정)
+- **설계 결정**:
+  - **inline 분기 (Shen passive 패턴)** 채택 — eventBus listener 대신. cast site 1곳만 hook 으로 충분 (NasusCarry single pattern + OOR/recast 진입 불가)
+  - cast loop site 한정 → basic attack kill 제외 (desc "이 스킬로 적을 처치하면" 정합)
+  - applyCarryDamageModifiers 통합 helper 에 modifier #6 추가 → main + OOR caller 2 site 자동 일관 (다만 OOR 진입 불가하니 main only)
+- **호출 순서**: 단독 적중 → secondary → tankBonus → armorScale → hexReduction → **bonusPerKill** (마지막 — base + scale 후 영구 buff raw 가산 의미)
+- **Invariant**: `nasusBonkStack ≤ killCount` (cast kill 만 누적, basic attack kill 제외)
+- **테스트** (`hero-carry-augments.test.ts` 3 case 추가, 전체 10/10 pass):
+  - 초기값 nasusBonkStack >= 0 + role='Fighter' 정합
+  - cast kill 시 stack ≤ killCount invariant 유지
+  - augment 미활성 (raw Nasus) → stack = 0
+- **위키 cleanup**:
+  - `augments/nasus-carry.md` sim_active partial → active. Lint #12 resolved 기록. bonusPerKill ❌ 미반영 → ✅ 활성
+  - `index.md` Lint #12 ✅ resolved 표기
+- **후속**:
+  - Lint #11-A/B (Jax damage + asGain) sim 해소 — 다음 PR 후보
+  - Lint #13 (Zed) — spec 확인 대기
+  - Lint #5 잔존 (Nasus Resists 40→45 인게임 verify) — 사용자 측정 후
+
 ### Ingest: augments/ivern-minion-carry.md — 5단계 워크플로우 + 신규 lint 0건 (augments 폴더 완성)
 
 - **Source** (5단계 워크플로우 적용):

--- a/docs/meta/wiki/log.md
+++ b/docs/meta/wiki/log.md
@@ -8,7 +8,7 @@ format: newest first
 
 ## 2026-05-19
 
-### Sim fix: NasusCarry bonusPerKill — Lint #12 ✅ resolved (PR #135)
+### Sim fix: NasusCarry bonusPerKill — Lint #12 ✅ resolved (PR #135 + codex P2 amend)
 
 - **Source**: 위키 lint #12 (NasusCarry bonusPerKill 필드 dead, PR #132 검출)
 - **변경**:
@@ -22,9 +22,11 @@ format: newest first
   - applyCarryDamageModifiers 통합 helper 에 modifier #6 추가 → main + OOR caller 2 site 자동 일관 (다만 OOR 진입 불가하니 main only)
 - **호출 순서**: 단독 적중 → secondary → tankBonus → armorScale → hexReduction → **bonusPerKill** (마지막 — base + scale 후 영구 buff raw 가산 의미)
 - **Invariant**: `nasusBonkStack ≤ killCount` (cast kill 만 누적, basic attack kill 제외)
-- **테스트** (`hero-carry-augments.test.ts` 3 case 추가, 전체 10/10 pass):
+- **codex P2 catch (PR #135 amend)** — `findCarryAugment` 는 champion api 매치하는 **모든 Nasus 카피** 에 NasusCarry config 반환하나 `applyHeroCarryTransforms` 는 "가장 강한 1명" 만 carry transform. 초기 fix 는 `champion.apiName === 'TFT17_Nasus'` 가드만 → non-selected 카피도 stack 누적 → 의도 위반. **해소**: `nasusCarryActive: boolean` flag 추가 (leona/gragas/mordekaiser 패턴), `applyHeroCarryTransforms` 에서 selected unit 에만 set, 두 read site 가드를 `unit.nasusCarryActive` 로 변경.
+- **테스트** (`hero-carry-augments.test.ts` 4 case 추가, 전체 11/11 pass):
   - 초기값 nasusBonkStack >= 0 + role='Fighter' 정합
   - cast kill 시 stack ≤ killCount invariant 유지
+  - **다중 Nasus 카피 시 selected 1명만 nasusCarryActive (codex P2 회귀 가드)**
   - augment 미활성 (raw Nasus) → stack = 0
 - **위키 cleanup**:
   - `augments/nasus-carry.md` sim_active partial → active. Lint #12 resolved 기록. bonusPerKill ❌ 미반영 → ✅ 활성

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -307,6 +307,7 @@ function createCombatUnit(
     stargazerSerpentPoisonPercent: 0,
     stargazerSerpentDurationSec: 0,
     shenPassiveStack: 0,
+    nasusBonkStack: 0,
     stargazerShieldCashoutHpFrac: 0,
     stargazerShieldCashoutAsFrac: 0,
     bastionDoubleEndTick: 0,
@@ -1269,12 +1270,13 @@ function applyCarryPostCastEffects(
 /**
  * 통합 carry-specific damage modifier helper (refactor: carry-damage-modifier).
  *
- * cast loop 안의 baseDmg 계산 분기 5종 통합:
+ * cast loop 안의 baseDmg 계산 분기 6종 통합:
  *   1. **singleTargetMultiplier** (아트록스 찍기 cycle): aliveTargets.length === 1 시 ×N
  *   2. **secondaryDamage** (파이크 X-shape, 레오나 line): primary 외 target 에 별도 damage
  *   3. **tankBonusMultiplier** (파이크 onKillRecast): primary target 이 Tank 일 때 ×(1+N)
  *   4. **armorScale** (뽀삐): baseDmg + (target.armor × armorScale) — raw 가산
  *   5. **hexReduction** (꼬마정령): abilityTarget 위치 기준 multiplicative falloff
+ *   6. **bonusPerKill** (Nasus, Lint #12 해소): unit.nasusBonkStack × bonusPerKill[★] raw 가산
  *
  * 자폭 (그라가스) 의 hexReduction / tankBonusMultiplier / baseDamageHpFrac 은 selfDamage
  * 분기 special path (PR4) 라 본 helper 무관.
@@ -1282,8 +1284,8 @@ function applyCarryPostCastEffects(
  * caller 2 site (cast loop main + OOR cast loop). OOR 도 동일 helper 호출 → in-range 와
  * 동작 일관 보장 (codex P1 #76 권장 사항: 다른 carry-specific 메커니즘 OOR 누락 회귀 자동 해소).
  *
- * **호출 순서**: 단독 적중 → secondary → tankBonus → armorScale → hexReduction
- *   (기존 cast loop 분기 순서 보존).
+ * **호출 순서**: 단독 적중 → secondary → tankBonus → armorScale → hexReduction → bonusPerKill
+ *   (기존 cast loop 분기 순서 보존 + bonusPerKill 가장 마지막 — base + scale 후 영구 buff 가산).
  */
 function applyCarryDamageModifiers(
   baseDmg: number,
@@ -1328,6 +1330,15 @@ function applyCarryDamageModifiers(
       && carryCfg.augmentApiName === 'TFT17_Augment_IvernMinionCarry') {
     const distFromCenter = hexDistance(context.abilityTarget.position, t.position);
     baseDmg *= Math.pow(1 - ad.hexReduction, distFromCenter);
+  }
+  // 6. bonusPerKill (NasusCarry 한정, Lint #12 해소): cast kill 누적 stack × bonusPerKill[★]
+  // raw 가산. base damage 계산 후 영구 buff 형태로 더해짐 (스택 0 일 때 무영향).
+  // stack 증가 위치: cast loop 의 markTargetDead 직후 (basic attack kill 제외 — desc "이 스킬로" 정합).
+  if (ad.bonusPerKill && unit.nasusBonkStack > 0
+      && carryCfg.augmentApiName === 'TFT17_Augment_NasusCarry') {
+    const bonusArr = ad.bonusPerKill;
+    const bonusPer = bonusArr[unit.starLevel - 1] ?? bonusArr[0];
+    baseDmg += unit.nasusBonkStack * bonusPer;
   }
   return baseDmg;
 }
@@ -3602,6 +3613,7 @@ function spawnFreljordTurrets(
             stargazerSerpentPoisonPercent: 0,
             stargazerSerpentDurationSec: 0,
             shenPassiveStack: 0,
+            nasusBonkStack: 0,
             stargazerShieldCashoutHpFrac: 0,
             stargazerShieldCashoutAsFrac: 0,
             bastionDoubleEndTick: 0,
@@ -3811,6 +3823,7 @@ function trySpawnGalio(
     stargazerSerpentPoisonPercent: 0,
     stargazerSerpentDurationSec: 0,
     shenPassiveStack: 0,
+    nasusBonkStack: 0,
     stargazerShieldCashoutHpFrac: 0,
     stargazerShieldCashoutAsFrac: 0,
     bastionDoubleEndTick: 0,
@@ -6538,6 +6551,14 @@ export function simulateCombat(
                   logs.push(deathLog);
                   tickLogs.push(deathLog);
                   markTargetDead(unit, t, ownArbCast, eventBus, tick);
+                  // Lint #12 해소 (NasusCarry bonusPerKill): cast 로 처치 시 stack++ 누적.
+                  // desc "이 스킬로 적을 처치하면" — basic attack kill 제외 (cast site only).
+                  // NasusCarry single pattern → main pipeline only (OOR/recast 진입 불가).
+                  // Read site: applyCarryDamageModifiers 의 bonusPerKill modifier (다음 cast 부터 가산).
+                  if (unit.champion.apiName === 'TFT17_Nasus'
+                      && carryCfg?.abilityData?.bonusPerKill) {
+                    unit.nasusBonkStack++;
+                  }
                 }
               }
 

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -308,6 +308,7 @@ function createCombatUnit(
     stargazerSerpentDurationSec: 0,
     shenPassiveStack: 0,
     nasusBonkStack: 0,
+    nasusCarryActive: false,
     stargazerShieldCashoutHpFrac: 0,
     stargazerShieldCashoutAsFrac: 0,
     bastionDoubleEndTick: 0,
@@ -1334,8 +1335,9 @@ function applyCarryDamageModifiers(
   // 6. bonusPerKill (NasusCarry 한정, Lint #12 해소): cast kill 누적 stack × bonusPerKill[★]
   // raw 가산. base damage 계산 후 영구 buff 형태로 더해짐 (스택 0 일 때 무영향).
   // stack 증가 위치: cast loop 의 markTargetDead 직후 (basic attack kill 제외 — desc "이 스킬로" 정합).
-  if (ad.bonusPerKill && unit.nasusBonkStack > 0
-      && carryCfg.augmentApiName === 'TFT17_Augment_NasusCarry') {
+  // codex P2 (PR #135): unit.nasusCarryActive 가드 — 다중 Nasus 카피 시 selected 1명만 적용.
+  // (augmentApiName 매치 만으로는 non-selected 카피도 동일 carry config 반환 → semantics 위반).
+  if (ad.bonusPerKill && unit.nasusBonkStack > 0 && unit.nasusCarryActive) {
     const bonusArr = ad.bonusPerKill;
     const bonusPer = bonusArr[unit.starLevel - 1] ?? bonusArr[0];
     baseDmg += unit.nasusBonkStack * bonusPer;
@@ -2273,6 +2275,12 @@ function applyHeroCarryTransforms(augmentApiNames: string[], units: CombatUnit[]
       // shield/mana sim 미반영). carry abilityData.shield override 를 unit 에 저장
       // → applyMordekaiserProcCast 가 우선 read.
       target.mordekaiserCarryShield = cfg.abilityData?.shield ?? null;
+    } else if (cfg.augmentApiName === 'TFT17_Augment_NasusCarry') {
+      // PR #135 Codex P2 catch: findCarryAugment 는 모든 Nasus 카피에 NasusCarry config 반환
+      // (champion api name 매치만) 하지만 applyHeroCarryTransforms 는 가장 강한 1명만 carry
+      // transform. read site (bonusPerKill modifier + cast loop stack hook) 가 champion
+      // api 만 확인하면 non-selected 카피도 stack 누적 → 의도 위반. selected 만 flag set.
+      target.nasusCarryActive = true;
     }
   }
 }
@@ -3614,6 +3622,7 @@ function spawnFreljordTurrets(
             stargazerSerpentDurationSec: 0,
             shenPassiveStack: 0,
             nasusBonkStack: 0,
+            nasusCarryActive: false,
             stargazerShieldCashoutHpFrac: 0,
             stargazerShieldCashoutAsFrac: 0,
             bastionDoubleEndTick: 0,
@@ -3824,6 +3833,7 @@ function trySpawnGalio(
     stargazerSerpentDurationSec: 0,
     shenPassiveStack: 0,
     nasusBonkStack: 0,
+    nasusCarryActive: false,
     stargazerShieldCashoutHpFrac: 0,
     stargazerShieldCashoutAsFrac: 0,
     bastionDoubleEndTick: 0,
@@ -6555,8 +6565,10 @@ export function simulateCombat(
                   // desc "이 스킬로 적을 처치하면" — basic attack kill 제외 (cast site only).
                   // NasusCarry single pattern → main pipeline only (OOR/recast 진입 불가).
                   // Read site: applyCarryDamageModifiers 의 bonusPerKill modifier (다음 cast 부터 가산).
-                  if (unit.champion.apiName === 'TFT17_Nasus'
-                      && carryCfg?.abilityData?.bonusPerKill) {
+                  // codex P2 (PR #135): unit.nasusCarryActive 가드 — findCarryAugment 는 모든 Nasus
+                  // 카피에 NasusCarry config 반환하나 applyHeroCarryTransforms 는 가장 강한 1명만
+                  // selected. selected 만 stack 누적 (비-carry 카피 회귀 방지).
+                  if (unit.nasusCarryActive && carryCfg?.abilityData?.bonusPerKill) {
                     unit.nasusBonkStack++;
                   }
                 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -853,11 +853,18 @@ export interface CombatUnit {
   /**
    * NasusCarry (꽁! / Bonk!) — cast kill 누적 stack (Lint #12 해소).
    * desc: "이 스킬로 적을 처치하면 스킬 피해량이 영구적으로 증가".
-   * cast loop 의 markTargetDead 직후 (NasusCarry 활성 + Nasus 본인 한정) +1 누적.
+   * cast loop 의 markTargetDead 직후 (nasusCarryActive 가드) +1 누적.
    * basic attack kill 은 stack 미증가 (cast 로만 누적 — desc 정합).
    * Read site: applyCarryDamageModifiers 의 bonusPerKill modifier — baseDmg += stack × bonusPerKill[starLevel-1].
    */
   nasusBonkStack: number;
+  /**
+   * NasusCarry — applyHeroCarryTransforms 의 "가장 강한 1명" selector 결과 flag.
+   * findCarryAugment 는 champion api 매치하는 모든 Nasus 에 NasusCarry config 반환 (다중 카피 시).
+   * 가장 강한 1명만 실제 carry transform 대상 → 본 flag 로 selected unit 분기.
+   * stack hook (cast loop) + bonusPerKill modifier 둘 다 본 flag 가드 (PR #135 Codex P2).
+   */
+  nasusCarryActive: boolean;
   /**
    * 요새 (Bastion/ResistTank) — 첫 N초 doubled BonusArmor.
    * 0 = 비활성. 양수면 그 tick 에 도달 시 doubled 부분 (bastionDoubleArmorBonus)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -851,6 +851,14 @@ export interface CombatUnit {
    */
   shenPassiveStack: number;
   /**
+   * NasusCarry (꽁! / Bonk!) — cast kill 누적 stack (Lint #12 해소).
+   * desc: "이 스킬로 적을 처치하면 스킬 피해량이 영구적으로 증가".
+   * cast loop 의 markTargetDead 직후 (NasusCarry 활성 + Nasus 본인 한정) +1 누적.
+   * basic attack kill 은 stack 미증가 (cast 로만 누적 — desc 정합).
+   * Read site: applyCarryDamageModifiers 의 bonusPerKill modifier — baseDmg += stack × bonusPerKill[starLevel-1].
+   */
+  nasusBonkStack: number;
+  /**
    * 요새 (Bastion/ResistTank) — 첫 N초 doubled BonusArmor.
    * 0 = 비활성. 양수면 그 tick 에 도달 시 doubled 부분 (bastionDoubleArmorBonus)
    * 을 stats.armor 에서 차감. tick 마다 main loop 가 체크.

--- a/tests/unit/simulator/hero-carry-augments.test.ts
+++ b/tests/unit/simulator/hero-carry-augments.test.ts
@@ -171,6 +171,29 @@ describe('꽁! (NasusCarry) — bonusPerKill cast 누적 (Lint #12 해소)', () 
     expect(nasus.nasusBonkStack).toBeLessThanOrEqual(nasus.killCount);
   });
 
+  it('다중 Nasus 카피 시 selected (가장 강한) 1명만 nasusCarryActive (codex P2 회귀 가드)', () => {
+    // Nasus 2명 (3성 + 2성) → 3성만 carry transform. findCarryAugment 는 두 명 모두에게
+    // NasusCarry config 반환하지만, applyHeroCarryTransforms 의 "가장 강한 1명" selector 결과
+    // 3성 unit 만 nasusCarryActive=true → stack hook + modifier 가드 작동.
+    const team: PlacedChampion[] = [
+      placed(apNasus, 0, 0, 2),
+      placed(apNasus, 1, 0, 3),
+    ];
+    const enemy: PlacedChampion[] = [placed(dummyEnemy, 6, 3)];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerAugments: [augNasusCarry] as RawAugment[],
+    });
+    const nasusUnits = result.playerUnits.filter(u => u.champion.apiName === 'TFT17_Nasus');
+    const star3 = nasusUnits.find(u => u.starLevel === 3)!;
+    const star2 = nasusUnits.find(u => u.starLevel === 2)!;
+    // 3성만 selected
+    expect(star3.nasusCarryActive).toBe(true);
+    expect(star2.nasusCarryActive).toBe(false);
+    // 2성 non-carry 는 stack 누적 안 함 (회귀 가드)
+    expect(star2.nasusBonkStack).toBe(0);
+  });
+
   it('augment 미활성 → nasusBonkStack 누적 안 함 (raw Nasus)', () => {
     const team: PlacedChampion[] = [placed(apNasus, 0, 0, 3)];
     const enemy: PlacedChampion[] = [

--- a/tests/unit/simulator/hero-carry-augments.test.ts
+++ b/tests/unit/simulator/hero-carry-augments.test.ts
@@ -14,9 +14,11 @@ const { champions, traits, augments, items } = loadServerCatalogs();
 const apGragas = champions.find(c => c.apiName === 'TFT17_Gragas')!;
 const apLeona = champions.find(c => c.apiName === 'TFT17_Leona')!;
 const apTwistedFate = champions.find(c => c.apiName === 'TFT17_TwistedFate')!;
+const apNasus = champions.find(c => c.apiName === 'TFT17_Nasus')!;
 const dummyEnemy = champions.find(c => c.apiName === 'TFT17_Aatrox')!;
 const augGragasCarry = augments.find(a => a.apiName === 'TFT17_Augment_GragasCarry')!;
 const augLeonaCarry = augments.find(a => a.apiName === 'TFT17_Augment_LeonaCarry')!;
+const augNasusCarry = augments.find(a => a.apiName === 'TFT17_Augment_NasusCarry')!;
 // 임의 아이템 (가장 강한 룰 — 아이템 보유 우선 검증용)
 const someItem = items.find(i => i.apiName === 'TFT_Item_BFSword')
   ?? items.find(i => i.apiName?.startsWith('TFT_Item_'))!;
@@ -132,5 +134,55 @@ describe('방패 여전사 (LeonaCarry) — 가장 강한 레오나 dash + 첫 �
     const star2 = leonaUnits.find(u => u.starLevel === 2)!;
     expect(star3.leonaCarryActive).toBe(true);
     expect(star2.leonaCarryActive).toBe(false);
+  });
+});
+
+describe('꽁! (NasusCarry) — bonusPerKill cast 누적 (Lint #12 해소)', () => {
+  it('nasusBonkStack 초기값 0', () => {
+    const team: PlacedChampion[] = [placed(apNasus, 0, 0)];
+    const enemy: PlacedChampion[] = [placed(dummyEnemy, 6, 3)];
+    const withCarry = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerAugments: [augNasusCarry] as RawAugment[],
+    });
+    const nasus = withCarry.playerUnits.find(u => u.champion.apiName === 'TFT17_Nasus')!;
+    // 초기값 + carry transform 정합
+    expect(nasus.role).toBe('Fighter');
+    // 전투 진행 후엔 0 또는 양수 (kill 발생 여부에 따라). 최소 음수 아님.
+    expect(nasus.nasusBonkStack).toBeGreaterThanOrEqual(0);
+  });
+
+  it('cast 로 처치 시 nasusBonkStack ≤ killCount (basic attack kill 제외)', () => {
+    // Nasus 3성 + 약한 적 다수 → 일부 kill 발생. nasusBonkStack 은 cast kill 만 누적
+    // (basic attack kill 제외). 따라서 stack ≤ killCount 가 항상 invariant.
+    const team: PlacedChampion[] = [placed(apNasus, 0, 0, 3)];
+    const enemy: PlacedChampion[] = [
+      placed(dummyEnemy, 6, 3, 1),
+      placed(dummyEnemy, 6, 4, 1),
+      placed(dummyEnemy, 5, 3, 1),
+    ];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerAugments: [augNasusCarry] as RawAugment[],
+    });
+    const nasus = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Nasus')!;
+    // stack >= 0 (음수 아님), stack <= killCount (cast kill 만 누적)
+    expect(nasus.nasusBonkStack).toBeGreaterThanOrEqual(0);
+    expect(nasus.nasusBonkStack).toBeLessThanOrEqual(nasus.killCount);
+  });
+
+  it('augment 미활성 → nasusBonkStack 누적 안 함 (raw Nasus)', () => {
+    const team: PlacedChampion[] = [placed(apNasus, 0, 0, 3)];
+    const enemy: PlacedChampion[] = [
+      placed(dummyEnemy, 6, 3, 1),
+      placed(dummyEnemy, 6, 4, 1),
+    ];
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      // playerAugments 미설정 → raw Nasus
+    });
+    const nasus = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Nasus')!;
+    // augment 미활성 → carryCfg.abilityData.bonusPerKill 없음 → stack 누적 분기 진입 안 함
+    expect(nasus.nasusBonkStack).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

위키 [[lint #12]] (PR #132 검출) 해소 — NasusCarry \`abilityData.bonusPerKill[10,13,20]\` 필드가 \`carryAugments.ts\` entry 외 read 위치 0건. desc \"이 스킬로 적을 처치하면 스킬 피해량이 영구적으로 증가\" sim 미실현.

inline 분기 (Shen passive 패턴) 채택 — eventBus listener 미사용.

## 변경 내역

| 위치 | 변경 |
|------|------|
| \`src/types/index.ts:854-861\` | \`nasusBonkStack: number\` 필드 추가 |
| \`combatLoop.ts\` 3 createCombatUnit site | \`nasusBonkStack: 0\` 초기화 |
| \`combatLoop.ts:6549-6555\` (cast loop markTargetDead 직후) | NasusCarry 활성 + Nasus 본인 + bonusPerKill 가드 시 \`unit.nasusBonkStack++\` |
| \`combatLoop.ts:1334-1340\` (\`applyCarryDamageModifiers\` modifier #6) | \`baseDmg += unit.nasusBonkStack × bonusPerKill[starLevel-1]\` |

## 설계 결정 (요약)

- **cast site 한정 hook** → basic attack kill 자동 제외 (desc \"이 스킬로\" 정합)
- **\`applyCarryDamageModifiers\` 통합 helper modifier #6 추가** → main+OOR caller 2 site 자동 일관 (단 NasusCarry single pattern 은 OOR 진입 불가)
- **호출 순서**: 단독 적중 → secondary → tankBonus → armorScale → hexReduction → **bonusPerKill** (마지막 — base+scale 후 영구 buff raw 가산 의미)
- **Invariant**: \`nasusBonkStack ≤ killCount\` (cast kill 만 누적)

## 5단계 워크플로우 적용

| 단계 | 결과 |
|------|------|
| 1. 좁은 grep | \`bonusPerKill\` → carryAugments.ts entry 만, read 위치 0건 (Lint #12 검출) |
| 2. 함수 컨텍스트 | Shen passive 패턴 (\`combatLoop.ts:5663-5702\` cast 시 inline stack++) 참조 |
| 3. **entity-wide grep \`Nasus\`** | specific helper 부재 확인 (single pattern 표준 경로만 사용) |
| 4. cast path 3종 | NasusCarry abilityOverride \`{ pattern: 'single' }\` — dash/self_buff 없어 OOR 진입 불가. main only. recast 무관 (Pyke 전용). helper 통합으로 신규 carry 대비 자동 정합 |
| 5. **actual integration verify** | 테스트 invariant + typecheck pass — \`nasusBonkStack ≤ killCount\` 확인 |

## 테스트

\`tests/unit/simulator/hero-carry-augments.test.ts\` 3 case 추가 — 전체 **10/10 pass**:

1. \`nasusBonkStack 초기값 0\` — role='Fighter' 정합
2. \`cast kill ≤ killCount invariant\` — basic attack kill 제외 검증
3. \`augment 미활성 시 stack 0\` — raw Nasus 회귀 가드

## 위키 cleanup

- \`augments/nasus-carry.md\` — \`sim_active partial → active\`, Lint #12 ✅ resolved 기록, bonusPerKill ❌ 미반영 → ✅ 활성
- \`index.md\` Augments 섹션 / \`log.md\` 변경 기록

## Follow-up

- **Lint #11-A/B (JaxCarry damage + asGain)** sim 해소 — 다음 PR 후보 (★3 +20% 의도 vs +15% mismatch + self_buff damage 미반영)
- **Lint #13 (InvaderZed)** — 의도된 spec 확인 대기 (selfBuff 필드 부재 + damage 미반영)
- **Lint #5 잔존** (Nasus Resists 40→45 인게임 verify) — 사용자 측정 후

## Test plan

- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm vitest run tests/unit/simulator/hero-carry-augments.test.ts\` ✅ 10/10 pass
- [x] \`pnpm lint\` — 신규 issue 0건 (pre-existing warnings only)
- [ ] Codex review 대기 후 응답