### PR TITLE
fix(augments): "재빠른 무장" + "태양불꽃판" 추가 (CDragon fetch 누락) + audit 정책

### DIFF
--- a/public/data/tft_set17_augments.json
+++ b/public/data/tft_set17_augments.json
@@ -3,7 +3,7 @@
     "set": 17,
     "source": "CommunityDragon TFT ko_kr.json (PBE 5/12)",
     "extractedAt": "2026-05-13T00:30:00.000Z",
-    "totalAugments": 437,
+    "totalAugments": 439,
     "patch_version": "17.3 LIVE",
     "fetched_at": "2026-05-13",
     "set17_active_pool_size": 35
@@ -8413,6 +8413,51 @@
         "{d12ae4b6}",
         "{d22ae649}",
         "{84a6d904}"
+      ],
+      "disable": false
+    },
+    {
+      "name": "재빠른 무장",
+      "apiName": "TFT11_Augment_Slammin",
+      "desc": "@Gold@골드를 획득합니다. 플레이어 대상 전투를 마친 후 대기석에 아이템(소모품 제외)이 없을 때마다 @XP@의 경험치를 획득합니다.",
+      "effects": {
+        "Gold": 3,
+        "XP": 2
+      },
+      "icon": "ASSETS/Maps/TFT/Icons/Augments/Hexcore/Slammin_II.TFT_Set17.tex",
+      "associatedTraits": [],
+      "tags": [
+        "{ce1fd21c}",
+        "{b72bd3bf}",
+        "{d22ae649}",
+        "{d12ae4b6}",
+        "{7aaa3b47}",
+        "{c5c463aa}",
+        "{77b330ea}",
+        "{24d36c27}",
+        "{4529fead}"
+      ],
+      "disable": false
+    },
+    {
+      "name": "재빠른 무장+",
+      "apiName": "TFT11_Augment_Slammin_Plus",
+      "desc": "즉시 @Gold@골드를 획득하고 경험치를 @XPNow@ 얻습니다. 플레이어 대상 전투를 마친 후 대기석에 아이템(소모품 제외)이 없을 때마다 @XP@의 경험치를 획득합니다.",
+      "effects": {
+        "Gold": 8,
+        "XP": 2,
+        "XPNow": 10
+      },
+      "icon": "ASSETS/Maps/TFT/Icons/Augments/Hexcore/Slammin_II.TFT_Set17.tex",
+      "associatedTraits": [],
+      "tags": [
+        "{ce1fd21c}",
+        "{b72bd3bf}",
+        "{d22ae649}",
+        "{d02ae323}",
+        "{7aaa3b47}",
+        "{77b330ea}",
+        "{24d36c27}"
       ],
       "disable": false
     }

--- a/public/data/tft_set17_augments.json
+++ b/public/data/tft_set17_augments.json
@@ -3,7 +3,7 @@
     "set": 17,
     "source": "CommunityDragon TFT ko_kr.json (PBE 5/12)",
     "extractedAt": "2026-05-13T00:30:00.000Z",
-    "totalAugments": 439,
+    "totalAugments": 440,
     "patch_version": "17.3 LIVE",
     "fetched_at": "2026-05-13",
     "set17_active_pool_size": 35
@@ -8458,6 +8458,24 @@
         "{7aaa3b47}",
         "{77b330ea}",
         "{24d36c27}"
+      ],
+      "disable": false
+    },
+    {
+      "name": "태양불꽃판",
+      "apiName": "TFT6_Augment_SunfireBoard",
+      "desc": "전투 시작: 모든 적을 불태워 @Duration@초 동안 대상 최대 체력의 @TotalBurnPercent@%만큼 피해를 입히고 받는 회복 효과를 @GrievousWoundsPercent@% 감소시킵니다.",
+      "effects": {
+        "Duration": 15,
+        "GrievousWoundsPercent": 33,
+        "TotalBurnPercent": 15
+      },
+      "icon": "ASSETS/Maps/TFT/Icons/Augments/Hexcore/SunfireBoard2.TFT_Set17.tex",
+      "associatedTraits": [],
+      "tags": [
+        "{b72bd3bf}",
+        "{ce1fd21c}",
+        "{ee04db7b}"
       ],
       "disable": false
     }


### PR DESCRIPTION
## Summary

사용자 발견 누락 augment **2건** 추가. PR 진행 중 추가 발견 패턴.

CDragon Set 17 fetch 결과에서 set17 active pool 필터가 다른 set 의 generic augment 누락하는 경향 확인 — TFT11_/TFT6_ 접두사 carryover augment 들이 빠짐. raw-data/tft_ko_kr.json 에는 존재.

## 추가 (3 entry)

| apiName | name | 출신 | desc 요약 |
|---------|------|------|----------|
| \`TFT11_Augment_Slammin\` | 재빠른 무장 | Set 11 | 3골드 + 대기석 아이템 없을 때 2 XP |
| \`TFT11_Augment_Slammin_Plus\` | 재빠른 무장+ | Set 11 | 즉시 8골드 + 10 XP + 대기석 아이템 없을 때 2 XP |
| \`TFT6_Augment_SunfireBoard\` | 태양불꽃판 | Set 6 | 전투 시작 모든 적 15초 불태우기 (체력 15% + 회복 33% 감소) |

- icon path: set17 형식 (\`.TFT_Set17.tex\` 접미사) 적용
- tags: raw CDragon 그대로 보존
- effects: noise 필드 (components/null) 제거

## meta 갱신

- \`totalAugments\`: 437 → **440**

## audit 정책 (사용자 명시)

- **disable 처리 보존**: 사용자가 set17 미사용 분류한 **253건** (\`disable: true\`) 절대 수정 안 함. \`augment-management.md\` 룰 + \`feedback_data_edit\` 룰 일관
- **추가 only 방식**: 누락된 active augment 만 \`disable: false\` 로 추가. 기존 entry 의 disable 값 변경 금지
- **reactive 접근**: 사용자가 게임에서 안 보이는 augment 발견 시 알려주면 같은 패턴으로 부분 Edit 추가. 자동 광범위 audit (raw 1634 augments 중 set17 active 식별) 은 별도 큰 작업 — lolchess 전체 cross-check 필요

## 검증

| 항목 | 값 |
|------|---|
| \`meta.totalAugments\` | 440 |
| \`len(augments)\` | 440 |
| \`disable=true\` count | 253 (보존) |
| \`disable=false\` count | 187 |
| JSON parse | ✅ pass |
| \`pnpm typecheck\` | ✅ pass |

## Follow-up

- 추가 누락 발견 시 같은 패턴으로 부분 Edit
- 광범위 cross-check (lolchess.gg/augments/set17 전체 카탈로그 fetch) 별도 PR 후보

## Test plan

- [x] JSON parse + 440 일관
- [x] disable=true 253건 그대로 보존 확인
- [x] typecheck pass
- [ ] Codex review 대기
- [ ] 인게임에서 두 augment 선택 → UI 표시 + augment lookup 정상 작동 (사용자)