### PR TITLE
fix(sim): JaxCarry self_buff + damage 양립 분기 — Lint #11-A ✅ resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ next-env.d.ts
 !/docs/02-design/
 !/docs/meta/
 !/docs/superpowers/
+!/docs/wiki/
 /scripts/*.playwright-mcp/
 raw-data/
 scripts/

--- a/actual-data/game-20260519-001.json
+++ b/actual-data/game-20260519-001.json
@@ -1,0 +1,573 @@
+{
+  "gameId": "game-20260519-001",
+  "videoSource": {
+    "kind": "local",
+    "filename": "game-20260519-001.mp4",
+    "mimeType": "video/mp4",
+    "sizeBytes": 4032930070,
+    "durationSeconds": 2129.251667,
+    "uploadedAt": "2026-05-19T04:06:14.937Z"
+  },
+  "patchVersion": "17.3",
+  "playerRiotId": "무례한 친구#0129",
+  "finalPlacement": 2,
+  "shrinesInPlay": [
+    "ahri",
+    "evelynn"
+  ],
+  "timeline": [],
+  "createdAt": "2026-05-19T04:03:26.031Z",
+  "updatedAt": "2026-05-19T04:18:29.459Z",
+  "rounds": [
+    {
+      "type": "pvp",
+      "roundName": "2-1",
+      "videoStartTime": 269.4,
+      "videoEndTime": 292.2,
+      "playerTeam": {
+        "units": [
+          {
+            "championId": "TFT17_Lissandra",
+            "hex": {
+              "q": 0,
+              "r": 3
+            },
+            "starLevel": 2,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Kaisa",
+            "hex": {
+              "q": -1,
+              "r": 3
+            },
+            "starLevel": 1,
+            "items": [
+              "TFT_Item_InfinityEdge",
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Chogath",
+            "hex": {
+              "q": 2,
+              "r": 0
+            },
+            "starLevel": 1,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Mordekaiser",
+            "hex": {
+              "q": 3,
+              "r": 0
+            },
+            "starLevel": 1,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          }
+        ],
+        "augments": [
+          "TFT17_Augment_DarkStar_WhiteHole",
+          null,
+          null,
+          null
+        ],
+        "level": 4,
+        "hp": 100,
+        "hexModifiers": []
+      },
+      "opponent": {
+        "units": [
+          {
+            "championId": "TFT17_IvernMinion",
+            "hex": {
+              "q": 2,
+              "r": 3
+            },
+            "starLevel": 1,
+            "items": [
+              "TFT_Item_FrozenHeart",
+              "TFT_Item_NegatronCloak",
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Mordekaiser",
+            "hex": {
+              "q": 3,
+              "r": 3
+            },
+            "starLevel": 1,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Pyke",
+            "hex": {
+              "q": 4,
+              "r": 3
+            },
+            "starLevel": 1,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          }
+        ],
+        "augments": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "level": 3,
+        "hp": 100,
+        "hexModifiers": [],
+        "survivors": [
+          {
+            "hex": {
+              "q": 2,
+              "r": 3
+            },
+            "championId": "TFT17_IvernMinion",
+            "alive": true,
+            "hpPercent": 0
+          },
+          {
+            "hex": {
+              "q": 3,
+              "r": 3
+            },
+            "championId": "TFT17_Mordekaiser",
+            "alive": true,
+            "hpPercent": 0
+          },
+          {
+            "hex": {
+              "q": 4,
+              "r": 3
+            },
+            "championId": "TFT17_Pyke",
+            "alive": false,
+            "hpPercent": 0
+          }
+        ],
+        "riotId": "coinTFT#1234"
+      },
+      "winner": "player",
+      "playerDamageChart": [
+        {
+          "unitHex": {
+            "q": -1,
+            "r": 3
+          },
+          "championId": "TFT17_Kaisa",
+          "damage": 1708
+        },
+        {
+          "unitHex": {
+            "q": 0,
+            "r": 3
+          },
+          "championId": "TFT17_Lissandra",
+          "damage": 1317
+        },
+        {
+          "unitHex": {
+            "q": 2,
+            "r": 0
+          },
+          "championId": "TFT17_Chogath",
+          "damage": 629
+        },
+        {
+          "unitHex": {
+            "q": 3,
+            "r": 0
+          },
+          "championId": "TFT17_Mordekaiser",
+          "damage": 505
+        }
+      ],
+      "opponentDamageChart": [
+        {
+          "unitHex": {
+            "q": 4,
+            "r": 3
+          },
+          "championId": "TFT17_Pyke",
+          "damage": 946
+        },
+        {
+          "unitHex": {
+            "q": 3,
+            "r": 3
+          },
+          "championId": "TFT17_Mordekaiser",
+          "damage": 460
+        },
+        {
+          "unitHex": {
+            "q": 2,
+            "r": 3
+          },
+          "championId": "TFT17_IvernMinion",
+          "damage": 352
+        }
+      ]
+    },
+    {
+      "type": "pvp",
+      "roundName": "2-2",
+      "videoStartTime": 340,
+      "videoEndTime": 360.2,
+      "playerTeam": {
+        "units": [
+          {
+            "championId": "TFT17_Lissandra",
+            "hex": {
+              "q": 0,
+              "r": 3
+            },
+            "starLevel": 2,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Kaisa",
+            "hex": {
+              "q": -1,
+              "r": 3
+            },
+            "starLevel": 1,
+            "items": [
+              "TFT_Item_InfinityEdge",
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Chogath",
+            "hex": {
+              "q": 2,
+              "r": 0
+            },
+            "starLevel": 1,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Mordekaiser",
+            "hex": {
+              "q": 3,
+              "r": 0
+            },
+            "starLevel": 1,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          }
+        ],
+        "augments": [
+          "TFT17_Augment_DarkStar_WhiteHole",
+          null,
+          null,
+          null
+        ],
+        "level": 4,
+        "hp": 100,
+        "hexModifiers": [],
+        "survivors": [
+          {
+            "hex": {
+              "q": 0,
+              "r": 3
+            },
+            "championId": "TFT17_Lissandra",
+            "alive": true,
+            "hpPercent": 95
+          },
+          {
+            "hex": {
+              "q": 3,
+              "r": 0
+            },
+            "championId": "TFT17_Mordekaiser",
+            "alive": true,
+            "hpPercent": 50
+          },
+          {
+            "hex": {
+              "q": 2,
+              "r": 0
+            },
+            "championId": "TFT17_Chogath",
+            "alive": true,
+            "hpPercent": 55
+          },
+          {
+            "hex": {
+              "q": -1,
+              "r": 3
+            },
+            "championId": "TFT17_Kaisa",
+            "alive": true,
+            "hpPercent": 98
+          }
+        ]
+      },
+      "opponent": {
+        "units": [
+          {
+            "championId": "TFT17_Leona",
+            "hex": {
+              "q": 3,
+              "r": 3
+            },
+            "starLevel": 1,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Illaoi",
+            "hex": {
+              "q": 2,
+              "r": 3
+            },
+            "starLevel": 1,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Zoe",
+            "hex": {
+              "q": 6,
+              "r": 0
+            },
+            "starLevel": 1,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          }
+        ],
+        "augments": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "level": 3,
+        "hp": 100,
+        "hexModifiers": [],
+        "survivors": [
+          {
+            "hex": {
+              "q": 3,
+              "r": 3
+            },
+            "championId": "TFT17_Leona",
+            "alive": false,
+            "hpPercent": 0
+          },
+          {
+            "hex": {
+              "q": 2,
+              "r": 3
+            },
+            "championId": "TFT17_Illaoi",
+            "alive": false,
+            "hpPercent": 0
+          },
+          {
+            "hex": {
+              "q": 6,
+              "r": 0
+            },
+            "championId": "TFT17_Zoe",
+            "alive": false,
+            "hpPercent": 0
+          }
+        ],
+        "riotId": "함식이#KR1"
+      },
+      "winner": "player",
+      "playerDamageChart": [
+        {
+          "unitHex": {
+            "q": -1,
+            "r": 3
+          },
+          "championId": "TFT17_Kaisa",
+          "damage": 1282
+        },
+        {
+          "unitHex": {
+            "q": 0,
+            "r": 3
+          },
+          "championId": "TFT17_Lissandra",
+          "damage": 1097
+        },
+        {
+          "unitHex": {
+            "q": 2,
+            "r": 0
+          },
+          "championId": "TFT17_Chogath",
+          "damage": 644
+        },
+        {
+          "unitHex": {
+            "q": 3,
+            "r": 0
+          },
+          "championId": "TFT17_Mordekaiser",
+          "damage": 421
+        }
+      ],
+      "opponentDamageChart": [
+        {
+          "unitHex": {
+            "q": 6,
+            "r": 0
+          },
+          "championId": "TFT17_Zoe",
+          "damage": 515
+        },
+        {
+          "unitHex": {
+            "q": 2,
+            "r": 3
+          },
+          "championId": "TFT17_Illaoi",
+          "damage": 303
+        },
+        {
+          "unitHex": {
+            "q": 3,
+            "r": 3
+          },
+          "championId": "TFT17_Leona",
+          "damage": 262
+        }
+      ]
+    },
+    {
+      "type": "pvp",
+      "roundName": "2-3",
+      "videoStartTime": 407.5,
+      "playerTeam": {
+        "units": [
+          {
+            "championId": "TFT17_Lissandra",
+            "hex": {
+              "q": 0,
+              "r": 3
+            },
+            "starLevel": 2,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Kaisa",
+            "hex": {
+              "q": -1,
+              "r": 3
+            },
+            "starLevel": 1,
+            "items": [
+              "TFT_Item_InfinityEdge",
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Chogath",
+            "hex": {
+              "q": 2,
+              "r": 0
+            },
+            "starLevel": 1,
+            "items": [
+              null,
+              null,
+              null
+            ]
+          },
+          {
+            "championId": "TFT17_Mordekaiser",
+            "hex": {
+              "q": 3,
+              "r": 0
+            },
+            "starLevel": 1,
+            "items": [
+              "TFT_Item_NegatronCloak",
+              null,
+              null
+            ]
+          }
+        ],
+        "augments": [
+          "TFT17_Augment_DarkStar_WhiteHole",
+          null,
+          null,
+          null
+        ],
+        "level": 4,
+        "hp": 100,
+        "hexModifiers": []
+      },
+      "opponent": {
+        "units": [],
+        "augments": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "level": 4,
+        "hp": 100,
+        "hexModifiers": [],
+        "riotId": "karl Marx#자본론"
+      },
+      "winner": "draw"
+    }
+  ]
+}

--- a/docs/wiki/augments/jax-carry.md
+++ b/docs/wiki/augments/jax-carry.md
@@ -7,8 +7,8 @@ target_champion: TFT17_Jax
 tier: (미확인 — 패치노트 verify 필요)
 stage: stage 2 (carry augment 일반)
 current_patch_status: active
-sim_active: partial
-last_verified: 2026-05-19 (Lint #11-B resolved PR #136)
+sim_active: active
+last_verified: 2026-05-19 (Lint #11-A + #11-B resolved PR #140 / #136)
 sources:
   - src/data/carryAugments.ts:205-218 (JaxCarry entry)
   - src/lib/simulator/engine/combatLoop.ts:618-622 (getAbilityConfigForUnit)
@@ -51,7 +51,7 @@ abilityOverride 가 `self_buff` 라서 cast 자체는 damage 없음. 실질 효�
 | 변수 | 값 | sim 적용 | 비고 |
 |------|-----|---------|------|
 | `mana` | `20/80` | ✅ | raw 채택 |
-| `damage` | `[170, 250, 450]` | ❌ **미반영** | self_buff 패턴 → rawAbilityDmgBase=0 (line 6226). 17.3: `[155, 230, 375] → [170, 250, 450]` (entry 정합만) |
+| `damage` | `[170, 250, 450]` | ✅ **활성** (PR #140 Lint #11-A 해소) | self_buff 분기 직후 신규 분기 — `unit.jaxCarryActive` + abilityData.damage 가드 시 target 에 magic damage 적용. damageAmp + Tank 보너스 + sniper + crit + mitigation pipeline 표준. 17.3: `[155, 230, 375] → [170, 250, 450]` |
 | `onAttackBonus` | `[45, 70, 105]` | ✅ | `combatLoop.ts:5626` AP scaling magic. 매 기본 공격마다 추가 |
 | `asGain` | `[0.15, 0.15, 0.20]` | ✅ **활성** (PR #136 Lint #11-B 해소) | cast loop selfBuff 분기 (main `combatLoop.ts:6926` + OOR `:7071`) 에 starLevel별 우선 read. `unit.jaxCarryActive` 가드 (selected single-carry semantics). ★3 +20% 정합 |
 | `damageType` | `magic` | n/a | damage 미반영이라 무의미. onAttackBonus 는 hardcoded 'magic' (line 5637) |
@@ -76,9 +76,11 @@ abilityOverride 가 `self_buff` 라서 cast 자체는 damage 없음. 실질 효�
 ✅ **활성** (PR #136 Lint #11-B 해소):
 - **`asGain[0.15, 0.15, 0.20]` starLevel별 적용** — cast loop selfBuff 분기 (main + OOR 양쪽) `unit.jaxCarryActive` 가드. ★3 +20% 정합. selected single-carry semantics 적용
 
+✅ **활성** (PR #140 Lint #11-A 해소):
+- **`damage[170,250,450]` self_buff cast target magic damage** — main pipeline + OOR cast path 양쪽. `unit.jaxCarryActive` 가드 + abilityData.damage 존재 가드. damageAmp + Tank 보너스 + sniper + crit + mitigation pipeline 표준 + Serpent poison
+
 ❌ **미반영** (잔존):
-1. **`damage[170,250,450]` 미반영** — self_buff 패턴 → `rawAbilityDmgBase=0` (line 6226). user spec "사용: 대상 magic damage" 의도 vs 실제 cast damage 0. **Lint #11-A 잔존** — 별도 PR 필요 (single-target damage 분기 추가 vs 필드 dead 명시 결정)
-2. **MS (이동속도) gain** — abilityData 에 movementSpeed 필드 없음. desc "AS/MS" 중 MS 부분 sim 미반영
+1. **MS (이동속도) gain** — abilityData 에 movementSpeed 필드 없음. desc "AS/MS" 중 MS 부분 sim 미반영 (낮은 우선순위)
 
 🔍 **검증 필요**:
 - selfBuff.duration 999 와 매 cast multiplicative AS *= 1.15 의 의도 일치성 — desc "전투 종료까지 누적" 표현이 multiplicative 인지 additive 인지 모호. PR #71 (codex P1) 가 self_buff 패턴 자체는 처리하나 starLevel별 분기는 별도.
@@ -96,12 +98,15 @@ abilityOverride 가 `self_buff` 라서 cast 자체는 damage 없음. 실질 효�
 
 ## Lint finding (신규 검출)
 
-### Lint candidate #11-A — JaxCarry `damage` 필드 sim 미반영
+### Lint #11-A — JaxCarry `damage` ✅ resolved (PR #140)
 
-- carryAugments.ts:213 `damage: [170, 250, 450]` 와 desc "사용: 대상 magic damage" 명시
-- combatLoop.ts:6149 주석 "self_buff pattern 은 carry damage override 적용 안 함" + line 6226 `if (config.pattern === 'self_buff') rawAbilityDmgBase = 0;`
-- 17.3 patch entry 정합 (PR #115 같은 정합) 만 진행, sim 효과 도달 안 함
-- **해소 방향**: (1) damage 필드 자체 deprecate + entry 에서 제거, (2) self_buff 패턴에서 별도 single-target damage 추가 분기, (3) "design intent" 로 sim 미반영 명시
+- carryAugments.ts:213 `damage: [170, 250, 450]` 가 self_buff 패턴이라 미반영 → sim 도달
+- 해소 방식 (Option A: self_buff + damage 양립 분기 신규):
+  - **main pipeline 분기** (`combatLoop.ts:6953+`): self_buff 분기 직후 — `unit.jaxCarryActive` + `carryCfg.abilityData.damage` 가드 시 target 에 magic damage 적용
+  - **OOR cast path 분기** (`combatLoop.ts:7134+`): 동일 패턴 (cast path 3종 룰). 처치 시 markTargetDead 직접 호출
+  - **표준 적용**: damageAmp / Tank 보너스 (invention/madreds/graves) / sniper / mfReplicator / spellCanCrit / mitigation pipeline + Serpent poison
+  - **selected single-carry semantics**: `unit.jaxCarryActive` 가드 (PR #135 Layer 1 패턴)
+- 테스트: cast 시 target magic damage 적용 (totalDamageDealt > 0 + carry cast log)
 
 ### Lint #11-B — JaxCarry `asGain` ✅ resolved (PR #136)
 
@@ -114,11 +119,11 @@ abilityOverride 가 `self_buff` 라서 cast 자체는 damage 없음. 실질 효�
 
 ## Lint 체크리스트
 
-- [x] entity-wide grep `Jax` — multi-source drift 없음 (combatLoop.ts 의 self_buff 분기 + onAttackBonus 패시브 외 specific helper 함수 없음)
-- [x] cast path 3종 (main + recast + OOR) — main + OOR 정합 (PR #136 asGain 양쪽 fix), recast 무관
-- [x] actual integration verify — asGain ✅ resolved (PR #136), damage 잔존 (Lint #11-A)
+- [x] entity-wide grep `Jax` — multi-source drift 없음 (combatLoop.ts 의 self_buff 분기 + onAttackBonus 패시브 + Jax cast damage 분기 외 specific helper 함수 없음)
+- [x] cast path 3종 (main + recast + OOR) — main + OOR 양쪽 fix (PR #136 asGain + PR #140 damage), recast 무관
+- [x] actual integration verify — asGain ✅ resolved (PR #136), damage ✅ resolved (PR #140)
+- [x] **Lint #11-A ✅ resolved** (PR #140 — Option A: self_buff + damage 양립 분기, main + OOR + selected 가드)
 - [x] **Lint #11-B ✅ resolved** (PR #136 — asGain starLevel별 우선 + jaxCarryActive 가드)
-- [ ] **Lint #11-A 잔존** — damage 필드 미반영 (설계 결정 필요)
 - [ ] statOverrides 인게임 측정 (HP/AS base/range)
 
 ## 관련

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -41,7 +41,7 @@ _미작성_
 - [[gragas-carry]] (자폭) — 17.2 도입. ✅ Lint #8 resolved (PR #127) — 적군 AOE 반경 3칸 정상 작동 (이전 무력화)
 - [[aatrox-carry]] (별빛 연계) — 17.2 도입. 가장 복잡 carry — 3-skill cycle + N.O.V.A. + isolation. 17.3 변경 3건 sim 정합
 - [[pyke-carry]] (청부 살인마) — 17.2 도입. x_shape + onKillRecast cascade. ⚠️ Lint #10 (PR #131 검출): hero-augment-carry 의 "onKill hook 미구현" stale (실제 구현 완료, wiki cleanup 후보)
-- [[jax-carry]] (저 별을 향해) — self_buff + onAttackBonus passive + **asGain starLevel별 정합** (PR #136 Lint #11-B ✅ resolved, jaxCarryActive 가드). ⚠️ Lint #11-A 잔존 (damage 필드 self_buff 미반영)
+- [[jax-carry]] (저 별을 향해) — self_buff + onAttackBonus passive + **asGain starLevel별 정합** (PR #136 Lint #11-B ✅) + **cast damage target magic 적용** (PR #140 Lint #11-A ✅). cast path 3종 (main + OOR) + selected single-carry 가드
 - [[nasus-carry]] (꽁!) — single 패턴 AD physical + **bonusPerKill cast kill 누적** (PR #135 Lint #12 ✅ resolved). Lint #5 잔존 (Resists 40→45 인게임 verify)
 - [[invader-zed]] (침략자 제드) — stage 4-2 special. ⚠️ Lint #13 (selfBuff 필드 부재 + damage 미반영으로 sim 효과 사실상 0 — role='Fighter' + mana 50/100 변경뿐)
 - [[poppy-carry]] (정령단 속도) — ranged projectile (rangeOverride 4) + armorScale 1.0 + spiritBounceOnKill (max 50 chain) + Set 17 Poppy passive 별도 작동. 신규 lint 없음 — 가장 많은 메커니즘 sim 통합 완성도 carry. Lint #5 잔존 (AS 0.7→0.75 인게임 verify)

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -8,7 +8,7 @@ format: newest first
 
 ## 2026-05-19
 
-### Sim fix: JaxCarry damage self_buff + damage 양립 분기 — Lint #11-A ✅ resolved (PR #140)
+### Sim fix: JaxCarry damage self_buff + damage 양립 분기 — Lint #11-A ✅ resolved (PR #140 + codex P2 amend)
 
 - **Source**: 위키 lint #11-A (JaxCarry damage 필드 self_buff 패턴 미반영, PR #132 검출)
 - **설계 결정**: Option A 채택 — self_buff 패턴 + abilityData.damage 양립 분기 신규 추가
@@ -27,6 +27,8 @@ format: newest first
 - **테스트** (`hero-carry-augments.test.ts` 1 case 추가, 전체 16/16 pass):
   - JaxCarry cast 시 target magic damage 적용 (totalDamageDealt > 0 + carry cast log 검출)
 - **위키 cleanup**: jax-carry.md sim_active partial → active. Lint #11-A ✅ resolved 기록. damage 필드 ❌ → ✅
+- **codex P2 amend (PR #140 amend)** — Jax damage 분기가 self_buff 분기 다음에 위치 (line 6953+) 했으나 main pipeline omnivamp/Fountain hook (line 6858-6866) 보다 **뒤에** 있어 Jax damage 가 omnivamp/Fountain heal 에 누락. **해소**: Jax damage 분기를 `applyCarryPostCastEffects` 직후 + omnivamp/Fountain hook 직전 (line 6857 즈음) 으로 이동. self_buff 분기는 그대로 (sequence 변경 무해 — selfBuff.attackSpeed 는 future attack 영향이라 cast damage 와 무관).
+- **Lint #15 후보 등록**: OOR cast path 에 omnivamp hook 자체 부재 — `triggerFountainHeal` 만 있고 omnivamp 없음. main 와 OOR 의 cast post-processing 비대칭. 별도 PR (영향: dash/self_buff cast 의 omnivamp heal 모두 누락 — Talon/Corki/Warwick/MasterYi 등)
 - **잔존**:
   - **MS (이동속도) gain** — abilityData movementSpeed 필드 없음. desc "AS/MS" 중 MS 부분 sim 미반영 (낮은 우선순위)
   - **statOverrides** 인게임 측정 (HP/AS base/range)

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -8,6 +8,29 @@ format: newest first
 
 ## 2026-05-19
 
+### Sim fix: JaxCarry damage self_buff + damage 양립 분기 — Lint #11-A ✅ resolved (PR #140)
+
+- **Source**: 위키 lint #11-A (JaxCarry damage 필드 self_buff 패턴 미반영, PR #132 검출)
+- **설계 결정**: Option A 채택 — self_buff 패턴 + abilityData.damage 양립 분기 신규 추가
+  - Option B (필드 dead 명시) 거부 — desc 와 sim 미스매치 유지하면 lint 종결 안 됨
+  - Option C (abilityOverride pattern 변경) 거부 — selfBuff.attackSpeed + onAttackBonus 의도 깨짐
+- **변경**:
+  - `combatLoop.ts` main pipeline self_buff 분기 직후 (line 6953-7001 사이, 6952 다음): `unit.jaxCarryActive` + `carryCfg.abilityData.damage` 가드 시 target magic damage 적용
+  - `combatLoop.ts` OOR cast path Illaoi result 직후 (line 7133+, abilityDmg 분기 전): 동일 패턴 (cast path 3종 룰 — PR #129 OOR 누락 회귀 가드). 처치 시 `markTargetDead` 직접 호출
+- **표준 적용** (main cast loop 와 일관):
+  - damageAmp + Tank 보너스 (invention/madreds/graves) + sniper + mfReplicator
+  - spellCanCrit + critMultiplier
+  - applyAbilityMitigation pipeline (resistance + DR + non-target reduction + shield + invul)
+  - triggerSerpentPoison (별돌보미 뱀 강화 칸 ability 명중 시 중독)
+  - totalAbilityDmg / totalRawAbilityDmg 누적 — omnivamp / Fountain heal / on_cast emit 일관
+- **selected single-carry semantics** (PR #135 Layer 1 패턴): `unit.jaxCarryActive` 가드 — 다중 Jax 카피 시 selected 만 cast damage 적용
+- **테스트** (`hero-carry-augments.test.ts` 1 case 추가, 전체 16/16 pass):
+  - JaxCarry cast 시 target magic damage 적용 (totalDamageDealt > 0 + carry cast log 검출)
+- **위키 cleanup**: jax-carry.md sim_active partial → active. Lint #11-A ✅ resolved 기록. damage 필드 ❌ → ✅
+- **잔존**:
+  - **MS (이동속도) gain** — abilityData movementSpeed 필드 없음. desc "AS/MS" 중 MS 부분 sim 미반영 (낮은 우선순위)
+  - **statOverrides** 인게임 측정 (HP/AS base/range)
+
 ### Archive: docs/meta/ leftover 2 파일 — Phase 2 첫 정리
 
 - **Source**: 사용자 요청 — docs/meta/ leftover 점진 정리

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6950,6 +6950,52 @@ export function simulateCombat(
               if (config.selfBuff.durability) unit.damageReduction += config.selfBuff.durability;
             }
 
+            // === PR #140 Lint #11-A 해소: JaxCarry self_buff cast 시 target magic damage ===
+            // desc: "사용: 대상 magic damage". self_buff 패턴이 rawAbilityDmgBase=0 강제 (line 6266,
+            // self-hit 회귀 방지) 라 carry abilityData.damage 미반영. jaxCarryActive 가드
+            // (selected single-carry semantics — PR #135 Layer 1 패턴) + abilityData.damage 존재 가드.
+            // damageAmp / Tank 보너스 (invention/madreds/graves) / sniper / mfReplicator / crit
+            // 모두 main cast loop (line ~6435+) 와 일관 적용. mitigation pipeline 표준 helper 사용.
+            // cast path 3종 룰 (PR #129): OOR cast path 에도 동일 분기 추가 (아래 line 7133+).
+            if (unit.jaxCarryActive && carryCfg?.abilityData?.damage && target.state !== 'dead') {
+              const jaxDmgArr = carryCfg.abilityData.damage;
+              const jaxDmgBase = jaxDmgArr[unit.starLevel - 1] ?? jaxDmgArr[0];
+              const jaxDmgType: DamageType = carryCfg.damageTypeOverride
+                ?? carryCfg.abilityData.damageType
+                ?? 'magic';
+              const jaxRawDmg = jaxDmgType === 'magic'
+                ? jaxDmgBase * (1 + unit.stats.ap / 100)
+                : jaxDmgBase;
+              let jaxDamageAmp = unit.damageAmp;
+              if (unit.inventionTankDamageAmp > 0 && target.role === 'Tank') jaxDamageAmp += unit.inventionTankDamageAmp;
+              if (unit.madredsTankDamageAmp > 0 && target.role === 'Tank') jaxDamageAmp += unit.madredsTankDamageAmp;
+              if (unit.gravesTankDamageAmp > 0 && target.role === 'Tank') jaxDamageAmp += unit.gravesTankDamageAmp;
+              jaxDamageAmp += computeSniperDamageAmp(unit, target);
+              if (unit.mfReplicatorEffectiveness > 0) jaxDamageAmp += unit.mfReplicatorEffectiveness;
+              let jaxAmplified = jaxRawDmg * (1 + jaxDamageAmp);
+              if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
+                jaxAmplified *= unit.stats.critMultiplier;
+              }
+              totalRawAbilityDmg += jaxAmplified;
+              const jaxEffectiveDmg = applyAbilityMitigation(unit, target, jaxAmplified, jaxDmgType, eventBus, tick);
+              target.currentHp -= jaxEffectiveDmg;
+              target.totalDamageTaken += jaxEffectiveDmg;
+              unit.totalDamageDealt += jaxEffectiveDmg;
+              totalAbilityDmg += jaxEffectiveDmg;
+
+              const jaxLog: CombatLog = {
+                tick, time, type: 'ability',
+                sourceId: unit.id, targetId: target.id,
+                value: Math.round(jaxEffectiveDmg),
+                message: `${unit.champion.name} carry cast! ${target.champion.name}에게 ${Math.round(jaxEffectiveDmg)} ${jaxDmgType === 'magic' ? '마법' : '물리'} 피해`,
+              };
+              logs.push(jaxLog);
+              tickLogs.push(jaxLog);
+
+              // 별돌보미 뱀(Serpent) — JaxCarry cast 도 동일 적용 (cast loop ability damage 일관)
+              triggerSerpentPoison(unit, target, jaxEffectiveDmg);
+            }
+
             // === 아군 전체 버프 ===
             if (config.allyBuff) {
               const allyTeam = unit.team === 'player' ? playerUnits : enemies;
@@ -7131,6 +7177,57 @@ export function simulateCombat(
             totalAbilityDmg += illaoiOorResult.totalDealt;
             totalRawAbilityDmg += illaoiOorResult.totalRaw;
           }
+
+          // === PR #140 Lint #11-A 해소 (OOR cast path): JaxCarry self_buff cast 시 target damage ===
+          // main pipeline (line ~6952+) 와 동일 분기. cast path 3종 일관 (PR #129 룰 — stun 같은 OOR 누락 가드).
+          // OOR cast path 는 self_buff 패턴 + JaxCarry abilityOverride 면 진입 (line 7038 canDashCast).
+          // 사망 시 markTargetDead 직접 호출 — OOR cast 의 처치 분기는 abilityTargets loop 안 (self-hit 회귀 방지 제외).
+          if (unit.jaxCarryActive && oorCarryCfg?.abilityData?.damage && target.state !== 'dead') {
+            const oorJaxDmgArr = oorCarryCfg.abilityData.damage;
+            const oorJaxDmgBase = oorJaxDmgArr[unit.starLevel - 1] ?? oorJaxDmgArr[0];
+            const oorJaxDmgType: DamageType = oorCarryCfg.damageTypeOverride
+              ?? oorCarryCfg.abilityData.damageType
+              ?? 'magic';
+            const oorJaxRawDmg = oorJaxDmgType === 'magic'
+              ? oorJaxDmgBase * (1 + unit.stats.ap / 100)
+              : oorJaxDmgBase;
+            let oorJaxDamageAmp = unit.damageAmp;
+            if (unit.inventionTankDamageAmp > 0 && target.role === 'Tank') oorJaxDamageAmp += unit.inventionTankDamageAmp;
+            if (unit.madredsTankDamageAmp > 0 && target.role === 'Tank') oorJaxDamageAmp += unit.madredsTankDamageAmp;
+            if (unit.gravesTankDamageAmp > 0 && target.role === 'Tank') oorJaxDamageAmp += unit.gravesTankDamageAmp;
+            oorJaxDamageAmp += computeSniperDamageAmp(unit, target);
+            if (unit.mfReplicatorEffectiveness > 0) oorJaxDamageAmp += unit.mfReplicatorEffectiveness;
+            let oorJaxAmplified = oorJaxRawDmg * (1 + oorJaxDamageAmp);
+            if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
+              oorJaxAmplified *= unit.stats.critMultiplier;
+            }
+            totalRawAbilityDmg += oorJaxAmplified;
+            const oorJaxEffectiveDmg = applyAbilityMitigation(unit, target, oorJaxAmplified, oorJaxDmgType, eventBus, tick);
+            target.currentHp -= oorJaxEffectiveDmg;
+            target.totalDamageTaken += oorJaxEffectiveDmg;
+            unit.totalDamageDealt += oorJaxEffectiveDmg;
+            totalAbilityDmg += oorJaxEffectiveDmg;
+
+            const oorJaxLog: CombatLog = {
+              tick, time, type: 'ability',
+              sourceId: unit.id, targetId: target.id,
+              value: Math.round(oorJaxEffectiveDmg),
+              message: `${unit.champion.name} carry cast (OOR)! ${target.champion.name}에게 ${Math.round(oorJaxEffectiveDmg)} ${oorJaxDmgType === 'magic' ? '마법' : '물리'} 피해`,
+            };
+            logs.push(oorJaxLog);
+            tickLogs.push(oorJaxLog);
+
+            // 별돌보미 뱀(Serpent) — OOR cast 도 동일 적용
+            triggerSerpentPoison(unit, target, oorJaxEffectiveDmg);
+
+            // 사망 시 markTargetDead (OOR 의 일반 처치 path 는 self_buff abilityTargets self 만이라 진입 안 함).
+            // target.state 검사는 위 가드로 narrowed 라 currentHp 만 검사. markTargetDead 내부 idempotent.
+            if (target.currentHp <= 0) {
+              const ownArbiterStateOORJax = unit.team === 'player' ? playerArbiterState : enemyArbiterState;
+              markTargetDead(unit, target, ownArbiterStateOORJax, eventBus, tick);
+            }
+          }
+
           const oorAlive = abilityTargets.filter(t => t.state !== 'dead');
           const abilityDmg = oorIsSplit && oorAlive.length > 0
             ? oorHitTotal / oorAlive.length

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6854,6 +6854,54 @@ export function simulateCombat(
               applyCarryPostCastEffects(unit, abilityTargets, carryCfg);
             }
 
+            // === PR #140 Lint #11-A 해소: JaxCarry self_buff cast 시 target magic damage ===
+            // desc: "사용: 대상 magic damage". self_buff 패턴이 rawAbilityDmgBase=0 강제 (line 6266,
+            // self-hit 회귀 방지) 라 carry abilityData.damage 미반영. jaxCarryActive 가드
+            // (selected single-carry semantics — PR #135 Layer 1 패턴) + abilityData.damage 존재 가드.
+            // damageAmp / Tank 보너스 (invention/madreds/graves) / sniper / mfReplicator / crit
+            // 모두 main cast loop (line ~6435+) 와 일관 적용. mitigation pipeline 표준 helper 사용.
+            // cast path 3종 룰 (PR #129): OOR cast path 에도 동일 분기 추가 (아래 line ~7140+).
+            // **위치**: 일반 cast damage / applyCarryPostCastEffects 직후 + omnivamp/Fountain hook
+            // 직전 (codex P2 PR #140: Jax damage 가 omnivamp/Fountain heal 정합 반영되도록).
+            if (unit.jaxCarryActive && carryCfg?.abilityData?.damage && target.state !== 'dead') {
+              const jaxDmgArr = carryCfg.abilityData.damage;
+              const jaxDmgBase = jaxDmgArr[unit.starLevel - 1] ?? jaxDmgArr[0];
+              const jaxDmgType: DamageType = carryCfg.damageTypeOverride
+                ?? carryCfg.abilityData.damageType
+                ?? 'magic';
+              const jaxRawDmg = jaxDmgType === 'magic'
+                ? jaxDmgBase * (1 + unit.stats.ap / 100)
+                : jaxDmgBase;
+              let jaxDamageAmp = unit.damageAmp;
+              if (unit.inventionTankDamageAmp > 0 && target.role === 'Tank') jaxDamageAmp += unit.inventionTankDamageAmp;
+              if (unit.madredsTankDamageAmp > 0 && target.role === 'Tank') jaxDamageAmp += unit.madredsTankDamageAmp;
+              if (unit.gravesTankDamageAmp > 0 && target.role === 'Tank') jaxDamageAmp += unit.gravesTankDamageAmp;
+              jaxDamageAmp += computeSniperDamageAmp(unit, target);
+              if (unit.mfReplicatorEffectiveness > 0) jaxDamageAmp += unit.mfReplicatorEffectiveness;
+              let jaxAmplified = jaxRawDmg * (1 + jaxDamageAmp);
+              if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
+                jaxAmplified *= unit.stats.critMultiplier;
+              }
+              totalRawAbilityDmg += jaxAmplified;
+              const jaxEffectiveDmg = applyAbilityMitigation(unit, target, jaxAmplified, jaxDmgType, eventBus, tick);
+              target.currentHp -= jaxEffectiveDmg;
+              target.totalDamageTaken += jaxEffectiveDmg;
+              unit.totalDamageDealt += jaxEffectiveDmg;
+              totalAbilityDmg += jaxEffectiveDmg;
+
+              const jaxLog: CombatLog = {
+                tick, time, type: 'ability',
+                sourceId: unit.id, targetId: target.id,
+                value: Math.round(jaxEffectiveDmg),
+                message: `${unit.champion.name} carry cast! ${target.champion.name}에게 ${Math.round(jaxEffectiveDmg)} ${jaxDmgType === 'magic' ? '마법' : '물리'} 피해`,
+              };
+              logs.push(jaxLog);
+              tickLogs.push(jaxLog);
+
+              // 별돌보미 뱀(Serpent) — JaxCarry cast 도 동일 적용 (cast loop ability damage 일관)
+              triggerSerpentPoison(unit, target, jaxEffectiveDmg);
+            }
+
             // 전체 피해량 기반 흡혈 — healAmp 곱셈 적용.
             if (unit.omnivamp > 0 && totalAbilityDmg > 0) {
               const grievousReduction = target.augmentGrievousWounds > 0 ? (1 - target.augmentGrievousWounds) : 1;
@@ -6948,52 +6996,6 @@ export function simulateCombat(
               if (config.selfBuff.ad) unit.stats.damage += config.selfBuff.ad;
               if (config.selfBuff.ap) unit.stats.ap += config.selfBuff.ap;
               if (config.selfBuff.durability) unit.damageReduction += config.selfBuff.durability;
-            }
-
-            // === PR #140 Lint #11-A 해소: JaxCarry self_buff cast 시 target magic damage ===
-            // desc: "사용: 대상 magic damage". self_buff 패턴이 rawAbilityDmgBase=0 강제 (line 6266,
-            // self-hit 회귀 방지) 라 carry abilityData.damage 미반영. jaxCarryActive 가드
-            // (selected single-carry semantics — PR #135 Layer 1 패턴) + abilityData.damage 존재 가드.
-            // damageAmp / Tank 보너스 (invention/madreds/graves) / sniper / mfReplicator / crit
-            // 모두 main cast loop (line ~6435+) 와 일관 적용. mitigation pipeline 표준 helper 사용.
-            // cast path 3종 룰 (PR #129): OOR cast path 에도 동일 분기 추가 (아래 line 7133+).
-            if (unit.jaxCarryActive && carryCfg?.abilityData?.damage && target.state !== 'dead') {
-              const jaxDmgArr = carryCfg.abilityData.damage;
-              const jaxDmgBase = jaxDmgArr[unit.starLevel - 1] ?? jaxDmgArr[0];
-              const jaxDmgType: DamageType = carryCfg.damageTypeOverride
-                ?? carryCfg.abilityData.damageType
-                ?? 'magic';
-              const jaxRawDmg = jaxDmgType === 'magic'
-                ? jaxDmgBase * (1 + unit.stats.ap / 100)
-                : jaxDmgBase;
-              let jaxDamageAmp = unit.damageAmp;
-              if (unit.inventionTankDamageAmp > 0 && target.role === 'Tank') jaxDamageAmp += unit.inventionTankDamageAmp;
-              if (unit.madredsTankDamageAmp > 0 && target.role === 'Tank') jaxDamageAmp += unit.madredsTankDamageAmp;
-              if (unit.gravesTankDamageAmp > 0 && target.role === 'Tank') jaxDamageAmp += unit.gravesTankDamageAmp;
-              jaxDamageAmp += computeSniperDamageAmp(unit, target);
-              if (unit.mfReplicatorEffectiveness > 0) jaxDamageAmp += unit.mfReplicatorEffectiveness;
-              let jaxAmplified = jaxRawDmg * (1 + jaxDamageAmp);
-              if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
-                jaxAmplified *= unit.stats.critMultiplier;
-              }
-              totalRawAbilityDmg += jaxAmplified;
-              const jaxEffectiveDmg = applyAbilityMitigation(unit, target, jaxAmplified, jaxDmgType, eventBus, tick);
-              target.currentHp -= jaxEffectiveDmg;
-              target.totalDamageTaken += jaxEffectiveDmg;
-              unit.totalDamageDealt += jaxEffectiveDmg;
-              totalAbilityDmg += jaxEffectiveDmg;
-
-              const jaxLog: CombatLog = {
-                tick, time, type: 'ability',
-                sourceId: unit.id, targetId: target.id,
-                value: Math.round(jaxEffectiveDmg),
-                message: `${unit.champion.name} carry cast! ${target.champion.name}에게 ${Math.round(jaxEffectiveDmg)} ${jaxDmgType === 'magic' ? '마법' : '물리'} 피해`,
-              };
-              logs.push(jaxLog);
-              tickLogs.push(jaxLog);
-
-              // 별돌보미 뱀(Serpent) — JaxCarry cast 도 동일 적용 (cast loop ability damage 일관)
-              triggerSerpentPoison(unit, target, jaxEffectiveDmg);
             }
 
             // === 아군 전체 버프 ===

--- a/tests/unit/simulator/hero-carry-augments.test.ts
+++ b/tests/unit/simulator/hero-carry-augments.test.ts
@@ -254,6 +254,28 @@ describe('저 별을 향해 (JaxCarry) — asGain starLevel별 정합 (Lint #11-
     expect(star2.jaxCarryActive).toBe(false);
   });
 
+  it('cast 시 target 에 magic damage 적용 (Lint #11-A 해소, PR #140)', () => {
+    // JaxCarry desc: "사용: 대상 magic damage". self_buff 패턴이라도 carry abilityData.damage
+    // 가 target 에 magic damage 로 적용되어야 함. self_buff 분기 직후 신규 분기.
+    const team: PlacedChampion[] = [placed(apJax, 0, 0, 3)];
+    const enemy: PlacedChampion[] = [placed(dummyEnemy, 6, 3, 3)]; // 3성 enemy — Jax cast 발동 보장
+    const result = simulateCombat(team, enemy, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+      playerAugments: [augJaxCarry] as RawAugment[],
+    });
+    const jax = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Jax')!;
+    // cast 발동 시 (castCount > 0) totalDamageDealt > 0 보장 (carry damage 적용됨).
+    // 이전 (PR #140 전) 에는 self_buff 패턴 rawAbilityDmgBase=0 강제로 cast 자체는 damage 0.
+    // basic attack damage 도 있지만 onAttackBonus passive (line 5618-) 와 raw AD 합산이라
+    // 어느 path 든 totalDamageDealt > 0.
+    expect(jax.totalDamageDealt).toBeGreaterThan(0);
+    // carry cast log message 가 발생 (cast count > 0 이면 minimum 1번)
+    if (jax.castCount > 0) {
+      const carryCastLog = result.logs.find(l => l.message?.includes('carry cast'));
+      expect(carryCastLog).toBeDefined();
+    }
+  });
+
   it('non-selected Jax 는 carry self_buff abilityOverride 무시 (PR #136 codex P2 amend)', () => {
     // 다중 Jax + JaxCarry → non-selected (2성) 은 getAbilityConfigForUnit 에서 raw Jax config
     // (aoe_circle stun) fallback 받아야 함. carry self_buff override 가 모든 카피에 전파되면


### PR DESCRIPTION
## Summary

위키 [[lint #11-A]] (PR #132 검출) 해소 — JaxCarry \`abilityData.damage[170,250,450]\` 가 self_buff 패턴이라 미반영 (line 6266 \`rawAbilityDmgBase = 0\` 강제, self-hit 회귀 방지). desc \"사용: 대상 magic damage\" 의도 sim 도달 안 함.

**설계 결정 (Option A 채택)** — self_buff 패턴 + abilityData.damage 양립 분기 신규.

| Option | 평가 |
|--------|------|
| **A. self_buff + damage 양립 분기 신규** ⭐ 채택 | desc 정합 + lint 종결 |
| B. damage 필드 dead 명시 | desc 와 sim 미스매치 유지 (거부) |
| C. abilityOverride pattern 변경 | selfBuff + onAttackBonus 의도 깨짐 (거부) |

## 변경

| 위치 | 변경 |
|------|------|
| \`combatLoop.ts:6953+\` (main pipeline) | self_buff 분기 직후 — \`unit.jaxCarryActive\` + \`carryCfg.abilityData.damage\` 가드 시 target magic damage |
| \`combatLoop.ts:7134+\` (OOR cast path) | Illaoi result 직후 — 동일 패턴. 처치 시 \`markTargetDead\` 직접 호출 |
| \`.gitignore\` | \`docs/wiki/\` unignore 추가 (PR #137 relocate 시 누락 보정) |

## 표준 적용 (main cast loop 와 일관)

- damageAmp + Tank 보너스 (invention/madreds/graves) + sniper + mfReplicator
- spellCanCrit + critMultiplier
- \`applyAbilityMitigation\` pipeline (resistance + DR + non-target reduction + shield + invul)
- \`triggerSerpentPoison\` (별돌보미 뱀 강화 칸 ability 명중 시 중독)
- \`totalAbilityDmg\` / \`totalRawAbilityDmg\` 누적 → omnivamp / Fountain heal / on_cast emit 일관

## cast path 3종 (PR #129 룰)

| Cast path | Jax 진입 | sim 정합 |
|-----------|:--------:|:--------:|
| Main | ✅ self_buff cast + damage | ✓ |
| Recast | ❌ (Pyke 전용) | — |
| OOR | ✅ self_buff + damage | ✓ (markTargetDead 직접 호출) |

## selected single-carry semantics (PR #135 Layer 1 패턴)

\`unit.jaxCarryActive\` 가드 — 다중 Jax 카피 시 selected (가장 강한 1명) 만 cast damage 적용. non-selected 는 raw fallback (이미 PR #136 의 \`getAbilityConfigForUnit\` Layer 2 가드로 self_buff 패턴 자체 진입 안 함).

## 테스트

\`tests/unit/simulator/hero-carry-augments.test.ts\` 1 case 추가 — 전체 **16/16 pass**:

- JaxCarry cast 시 target magic damage 적용 (\`totalDamageDealt > 0\` + \"carry cast\" log 검출)

## 위키 cleanup

- \`augments/jax-carry.md\` — \`sim_active partial → active\`. \`damage\` ❌ → ✅. Lint #11-A ✅ resolved 기록
- \`index.md\` / \`log.md\` PR #140 변경 기록

## 잔존

- **MS (이동속도) gain** — abilityData \`movementSpeed\` 필드 없음. desc \"AS/MS\" 중 MS 부분 sim 미반영 (낮은 우선순위)
- **statOverrides** 인게임 측정 (HP/AS base/range 변화 여부)

## Test plan

- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm vitest run tests/unit/simulator/hero-carry-augments.test.ts\` ✅ 16/16 pass
- [ ] Codex review 대기