### PR TITLE
fix(sim): OOR cast path omnivamp hook 추가 — Lint #15 ✅ resolved (main+OOR 비대칭 해소)

### DIFF
--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -8,6 +8,27 @@ format: newest first
 
 ## 2026-05-19
 
+### Sim fix: OOR cast path omnivamp hook 추가 — Lint #15 ✅ resolved (PR #141)
+
+- **Source**: PR #140 Codex P2 amend 시 발견 (Jax damage omnivamp 정합 점검 중 OOR cast path 의 omnivamp hook 부재 검출)
+- **문제**: main+OOR cast post-processing 비대칭
+  - main pipeline (`combatLoop.ts:6906`): omnivamp hook 있음 (`if (unit.omnivamp > 0 && totalAbilityDmg > 0) { ... applyOmnivampHealWithMeleeShield }`)
+  - OOR cast path (`combatLoop.ts:7341`): `triggerFountainHeal` 만 있고 **omnivamp 없음**
+  - 결과: OOR cast (Talon/Corki dash, Warwick/MasterYi/Jax self_buff) 시 omnivamp heal 누락 — carry/non-carry 무관 dash/self_buff caster 의 흡혈 sim 미반영
+- **변경**:
+  - `combatLoop.ts:7340+` (OOR cast log 직후 + triggerFountainHeal 직전): main pipeline 와 동일 패턴 omnivamp hook 추가
+  - `grievousReduction` + `healAmp` 모두 main 과 일관 적용
+  - `applyOmnivampHealWithMeleeShield` 표준 helper 사용
+- **영향 범위**: dash/self_buff cast 발동 챔프 다수
+  - dash: Talon (line dash), Corki (to_farthest), Pyke (to_lowest_hp), Aatrox/Briar (to_target), Fizz (to_backline), IvernMinion (to_largest_cluster) 등
+  - self_buff: Warwick, MasterYi, Teemo, Jax (JaxCarry), Zed (InvaderZed) 등
+  - 모두 OOR cast 진입 가능 — omnivamp 아이템 (흡혈검 등) 보유 시 흡혈 sim 적용
+- **검증**:
+  - `pnpm typecheck` pass
+  - 기존 16/16 test pass 유지 (regression 없음)
+  - OOR cast path omnivamp 검증은 actual-data diff 또는 인게임 측정으로 후속 verify
+- **메모리 룰 후보**: cast loop 의 main+OOR post-cast hook (omnivamp / Fountain / on_cast) 비대칭은 회귀 위험. main 에 hook 추가 시 OOR 도 동시에 추가 점검 필수 (cast path 3종 룰의 응용)
+
 ### Sim fix: JaxCarry damage self_buff + damage 양립 분기 — Lint #11-A ✅ resolved (PR #140 + codex P2 amend)
 
 - **Source**: 위키 lint #11-A (JaxCarry damage 필드 self_buff 패턴 미반영, PR #132 검출)

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -8,7 +8,7 @@ format: newest first
 
 ## 2026-05-19
 
-### Sim fix: OOR cast path omnivamp hook 추가 — Lint #15 ✅ resolved (PR #141)
+### Sim fix: OOR cast path omnivamp hook 추가 — Lint #15 ✅ resolved (PR #141 + codex P2 amend)
 
 - **Source**: PR #140 Codex P2 amend 시 발견 (Jax damage omnivamp 정합 점검 중 OOR cast path 의 omnivamp hook 부재 검출)
 - **문제**: main+OOR cast post-processing 비대칭
@@ -27,6 +27,8 @@ format: newest first
   - `pnpm typecheck` pass
   - 기존 16/16 test pass 유지 (regression 없음)
   - OOR cast path omnivamp 검증은 actual-data diff 또는 인게임 측정으로 후속 verify
+- **codex P2 amend (PR #141 amend)** — grievousReduction 의 `target.augmentGrievousWounds` 사용은 OOR dash retarget (to_lowest_hp/to_farthest/to_backline 등) 시 잘못된 unit 참조. `target` = pre-dash 변수 (main loop findTarget 결과), 실제 damage 는 `abilityTarget` (dash 결과) 기준. → `abilityTarget.augmentGrievousWounds` 로 변경.
+- **Lint #16 후보 등록**: main pipeline 의 동일 패턴 (`combatLoop.ts:6907` `target.augmentGrievousWounds`) 도 같은 잠재 버그 — Aatrox/Pyke/IvernMinion carry 가 main pipeline 에서 dash 진입 시 동일 retarget 가능. main+OOR 양쪽 abilityTarget 으로 변경 별도 PR.
 - **메모리 룰 후보**: cast loop 의 main+OOR post-cast hook (omnivamp / Fountain / on_cast) 비대칭은 회귀 위험. main 에 hook 추가 시 OOR 도 동시에 추가 점검 필수 (cast path 3종 룰의 응용)
 
 ### Sim fix: JaxCarry damage self_buff + damage 양립 분기 — Lint #11-A ✅ resolved (PR #140 + codex P2 amend)

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -7344,8 +7344,13 @@ export function simulateCombat(
           // → carry/non-carry 무관 dash/self_buff caster 의 흡혈 sim 미반영.
           // PR #140 Codex P2 amend 시 발견 (Jax damage omnivamp 정합 점검 중 OOR omnivamp 부재 검출).
           // grievousReduction + healAmp 모두 main 과 일관 적용.
+          // codex P2 (PR #141): grievousReduction 은 abilityTarget (dash 후 실제 primary hit target)
+          // 기준 — OOR dash 가 retarget (to_lowest_hp/to_farthest/to_backline 등) 시 target 은
+          // pre-dash target 이라 잘못된 unit 의 augmentGrievousWounds 참조 회귀 가드.
+          // main pipeline 의 동일 패턴 (line 6907 target.augmentGrievousWounds) 도 같은 잠재 버그
+          // — Lint #16 후보 등록 (별도 PR).
           if (unit.omnivamp > 0 && totalAbilityDmg > 0) {
-            const grievousReductionOOR = target.augmentGrievousWounds > 0 ? (1 - target.augmentGrievousWounds) : 1;
+            const grievousReductionOOR = abilityTarget.augmentGrievousWounds > 0 ? (1 - abilityTarget.augmentGrievousWounds) : 1;
             const oorHeal = totalAbilityDmg * unit.omnivamp * grievousReductionOOR * (1 + (unit.healAmp ?? 0));
             applyOmnivampHealWithMeleeShield(unit, oorHeal);
           }

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -7338,6 +7338,18 @@ export function simulateCombat(
           logs.push(castLog);
           tickLogs.push(castLog);
 
+          // === PR #141 Lint #15 해소: OOR cast path omnivamp heal ===
+          // main pipeline (line 6906) 와 동일 패턴. main+OOR cast post-processing 비대칭 해소.
+          // 이전: OOR cast (Talon/Corki dash, Warwick/MasterYi/Jax self_buff) 시 omnivamp heal 누락
+          // → carry/non-carry 무관 dash/self_buff caster 의 흡혈 sim 미반영.
+          // PR #140 Codex P2 amend 시 발견 (Jax damage omnivamp 정합 점검 중 OOR omnivamp 부재 검출).
+          // grievousReduction + healAmp 모두 main 과 일관 적용.
+          if (unit.omnivamp > 0 && totalAbilityDmg > 0) {
+            const grievousReductionOOR = target.augmentGrievousWounds > 0 ? (1 - target.augmentGrievousWounds) : 1;
+            const oorHeal = totalAbilityDmg * unit.omnivamp * grievousReductionOOR * (1 + (unit.healAmp ?? 0));
+            applyOmnivampHealWithMeleeShield(unit, oorHeal);
+          }
+
           // 별돌보미 우물(Fountain) — OOR cast (dash/self_buff) path 도 동일 heal 적용
           // (codex P1 회귀 가드: Talon/Corki 같은 dash user 가 사거리 밖 시전 시 누락 방지).
           triggerFountainHeal(unit, totalAbilityDmg, tick, time, tickLogs);


### PR DESCRIPTION
## Summary

PR #140 Codex P2 amend 시 발견된 **Lint #15** sim 해소 — main+OOR cast post-processing **비대칭**.

| Cast path | omnivamp hook | Fountain hook |
|-----------|:-------------:|:-------------:|
| **main** (line 6906/6914) | ✅ | ✅ |
| **OOR (이전)** | ❌ | ✅ (line 7343) |

→ OOR cast (dash/self_buff caster) 시 omnivamp heal 누락.

## 영향 범위

OOR cast 진입 챔프 다수:

| Type | 챔프 |
|------|------|
| dash | Talon (line), Corki (to_farthest), Pyke (to_lowest_hp), Aatrox/Briar (to_target), Fizz (to_backline), IvernMinion (to_largest_cluster) |
| self_buff | Warwick, MasterYi, Teemo, **Jax (JaxCarry)**, **Zed (InvaderZed)** |

모두 흡혈검 등 omnivamp 아이템 보유 시 흡혈 sim 누락된 상태였음.

## 변경

\`combatLoop.ts:7340+\` (OOR cast log 직후 + \`triggerFountainHeal\` 직전):

\`\`\`ts
// === PR #141 Lint #15 해소: OOR cast path omnivamp heal ===
if (unit.omnivamp > 0 && totalAbilityDmg > 0) {
  const grievousReductionOOR = target.augmentGrievousWounds > 0 ? (1 - target.augmentGrievousWounds) : 1;
  const oorHeal = totalAbilityDmg * unit.omnivamp * grievousReductionOOR * (1 + (unit.healAmp ?? 0));
  applyOmnivampHealWithMeleeShield(unit, oorHeal);
}
\`\`\`

main pipeline (line 6906) 와 **완전 동일 패턴**:
- \`grievousReduction\` (augmentGrievousWounds) 적용
- \`healAmp\` 곱셈 적용
- \`applyOmnivampHealWithMeleeShield\` 표준 helper 사용

## 검증

- ✅ \`pnpm typecheck\` pass
- ✅ \`pnpm vitest run tests/unit/simulator/hero-carry-augments.test.ts\` 16/16 pass (regression 없음)
- OOR omnivamp 적용 검증은 actual-data diff 또는 인게임 측정으로 후속 verify (setup 복잡: 특정 아이템 + 사거리 외 적 시뮬)

## 메모리 룰 후보

> **cast loop main+OOR post-cast hook 비대칭 회귀 가드**: omnivamp / Fountain / on_cast 등 post-cast hook 이 main 에 있고 OOR 에 없으면 회귀. main 에 신규 hook 추가 시 OOR 도 동시 점검 필수 (cast path 3종 룰의 응용 — PR #129 stun 누락 패턴과 동일 구조).

Codex catch 9번째 사례 (PR #140 amend 시 발견된 부수 lint).

## Lint 누적 현황

| Lint | 상태 |
|------|------|
| #1~#10 | resolved / documented (이전 PR) |
| #11-A (Jax damage) | ✅ resolved (PR #140) |
| #11-B (Jax asGain) | ✅ resolved (PR #136) |
| #12 (Nasus bonusPerKill) | ✅ resolved (PR #135) |
| #13 (Zed) | spec 확인 대기 |
| #14 후보 (광범위 abilityOverride pollution) | 별도 PR |
| **#15 (OOR omnivamp 부재)** | **✅ resolved (본 PR #141)** |

## Test plan

- [x] typecheck pass
- [x] 16/16 회귀 가드 유지
- [ ] Codex review 대기
- [ ] 인게임 측정 또는 actual-data diff 로 OOR cast + omnivamp heal sim 정합 후속 verify