### PR TITLE
fix(sim): main pipeline omnivamp grievousReduction abilityTarget — Lint #16 ✅ resolved

### DIFF
--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -8,6 +8,18 @@ format: newest first
 
 ## 2026-05-19
 
+### Sim fix: main pipeline omnivamp grievousReduction abilityTarget 사용 — Lint #16 ✅ resolved (PR #142)
+
+- **Source**: PR #141 codex P2 amend 시 발견 (OOR fix 일관성 점검 중 main 의 동일 패턴 검출)
+- **문제**: main pipeline (`combatLoop.ts:6907`) 의 omnivamp grievousReduction 도 `target.augmentGrievousWounds` 사용 — Aatrox/Pyke/IvernMinion carry 가 main pipeline dash 진입 시 retarget (to_target/to_lowest_hp/to_largest_cluster 등) 가능 → `target` (pre-dash) vs `abilityTarget` (dash 결과) 불일치 → 잘못된 unit 의 healing-reduction state 참조
+- **변경**: `target.augmentGrievousWounds` → `abilityTarget.augmentGrievousWounds` (PR #141 OOR fix 와 동일 패턴)
+- **검증**:
+  - `pnpm typecheck` pass
+  - `hero-carry-augments.test.ts` 16/16 pass (no regression)
+  - 전체 test suite: 883 pass / 9 fail — **9 fail 은 pre-existing** (Mordekaiser proc test, 변경 전 dev 도 동일 fail 확인됨). 본 PR 변경과 무관
+- **dash retarget abilityTarget 룰 main+OOR 양쪽 정합 완료**
+- **메모리 룰 후보**: dash retarget 분기에서 grievousReduction / shield / debuff 등 target-specific state 참조 시 `target` (pre-dash) 가 아닌 `abilityTarget` (dash 결과) 사용 필수. main+OOR 양쪽 비대칭 점검 필요 (PR #129 cast path 3종 룰의 응용).
+
 ### Sim fix: OOR cast path omnivamp hook 추가 — Lint #15 ✅ resolved (PR #141 + codex P2 amend)
 
 - **Source**: PR #140 Codex P2 amend 시 발견 (Jax damage omnivamp 정합 점검 중 OOR cast path 의 omnivamp hook 부재 검출)

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6903,8 +6903,12 @@ export function simulateCombat(
             }
 
             // 전체 피해량 기반 흡혈 — healAmp 곱셈 적용.
+            // PR #142 Lint #16: grievousReduction 은 abilityTarget (dash 후 실제 primary hit target)
+            // 기준 — Aatrox/Pyke/IvernMinion carry 가 main pipeline dash 진입 시 retarget
+            // (to_target/to_lowest_hp/to_largest_cluster 등) → target 은 pre-dash, abilityTarget
+            // 은 dash 결과. PR #141 amend (OOR 동일 fix) 와 일관. main+OOR 양쪽 abilityTarget 사용.
             if (unit.omnivamp > 0 && totalAbilityDmg > 0) {
-              const grievousReduction = target.augmentGrievousWounds > 0 ? (1 - target.augmentGrievousWounds) : 1;
+              const grievousReduction = abilityTarget.augmentGrievousWounds > 0 ? (1 - abilityTarget.augmentGrievousWounds) : 1;
               const heal = totalAbilityDmg * unit.omnivamp * grievousReduction * (1 + (unit.healAmp ?? 0));
               applyOmnivampHealWithMeleeShield(unit, heal);
             }


### PR DESCRIPTION
## Summary

PR #141 codex P2 amend 시 발견된 **Lint #16** sim 해소 — main pipeline 의 동일 패턴.

main pipeline (\`combatLoop.ts:6907\`) 의 omnivamp grievousReduction 이 \`target.augmentGrievousWounds\` 사용 — Aatrox/Pyke/IvernMinion carry 가 main pipeline dash 진입 시 retarget (to_target / to_lowest_hp / to_largest_cluster 등) 가능 → \`target\` (pre-dash) vs \`abilityTarget\` (dash 결과) 불일치.

## 변경 (단일 라인)

\`\`\`diff
- const grievousReduction = target.augmentGrievousWounds > 0 ? (1 - target.augmentGrievousWounds) : 1;
+ const grievousReduction = abilityTarget.augmentGrievousWounds > 0 ? (1 - abilityTarget.augmentGrievousWounds) : 1;
\`\`\`

PR #141 OOR fix 와 **동일 패턴** — main+OOR 양쪽 abilityTarget 사용 일관 완료.

## 영향 챔프 (main pipeline dash 진입 가능 carry)

| 챔프 | dash type | retarget 영향 |
|------|-----------|----------------|
| Aatrox carry (cycle) | to_target | dash 후 target 변경 가능 |
| Pyke carry (X-shape) | to_lowest_hp | pre-dash target 과 lowest HP target 다를 수 있음 |
| IvernMinion carry (Big Bang) | to_largest_cluster | cluster center vs pre-dash target 다름 |

이전: 위 carry 들 + omnivamp 아이템 보유 시 잘못된 unit 의 grievousWounds 참조 → over/under heal.

## 검증

- ✅ \`pnpm typecheck\` pass
- ✅ \`hero-carry-augments.test.ts\` 16/16 pass (no regression)
- ⚠️ 전체 suite: 883 pass / **9 fail (pre-existing)** — Mordekaiser proc cast/tick test. 변경 전 dev 에서도 동일 fail 확인 (stash test). 본 PR 변경과 **무관**

## Lint 누적 현황

| Lint | 상태 |
|------|------|
| 1~12 | resolved / documented (이전 PR) |
| 13 (Zed) | spec 대기 |
| 14 (광범위 abilityOverride pollution audit) | 별도 PR |
| 15 (OOR omnivamp 부재) | ✅ PR #141 |
| **16 (main pipeline grievousReduction)** | **✅ 본 PR #142** |

dash retarget abilityTarget 룰 main+OOR 양쪽 정합 완료.

## 메모리 룰 (정착)

> **dash retarget abilityTarget 룰**: cast loop 의 dash 분기에서 grievousReduction / shield / debuff 등 target-specific state 참조 시 \`target\` (pre-dash) 가 아닌 \`abilityTarget\` (dash 결과) 사용 필수. main+OOR 양쪽 비대칭 점검 필요 (PR #129 cast path 3종 룰의 응용).

## Test plan

- [x] typecheck pass
- [x] 16/16 carry-augments test pass
- [x] pre-existing 9 fail 확인 (변경 무관)
- [ ] Codex review 대기