### PR TITLE
fix(test): Mordekaiser pre-existing 9 fail 해소 — 892/892 ✅

### DIFF
--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -8,6 +8,20 @@ format: newest first
 
 ## 2026-05-19
 
+### Test fix: Mordekaiser pre-existing 9 fail 해소 — 전체 suite 892/892 ✅ (PR #143)
+
+- **Source**: PR #141/#142 작업 중 발견된 pre-existing 9 fail (Mordekaiser proc test). 변경 전 dev 도 동일 fail 확인 — 본 PR 들과 무관 누적 fail
+- **원인 분석**:
+  - `applyMordekaiserProcCast` line 951: `unit.mordekaiserCarryShield !== null` (strict !==) 가드 — `undefined !== null = true` 로 인해 array access TypeError
+  - 원인: PR #124 (Mordekaiser shield/mana 17.3 정합) 시 `mordekaiserCarryShield: null` 필드 추가 했으나 **test fixture (`tests/unit/mordekaiser-proc.test.ts`) 갱신 누락**
+- **해소 (2-layer)**:
+  - **sim 코드 defensive 가드**: `!== null` (strict) → `!= null` (loose) — undefined 도 safe (`combatLoop.ts:951`)
+  - **test fixture 갱신**: `tests/unit/mordekaiser-proc.test.ts` makeMordekaiserUnit fixture 에 `mordekaiserCarryShield: null` 추가 (raw 챔프 명시)
+- **follow-up test 갱신** (sim 코드 변경의 후속 follow-up):
+  - `tests/unit/simulator/heal-amp-integration.test.ts`: healAmp 곱셈 사이트 카운트 `14 → 15` (PR #141 OOR omnivamp heal 추가 반영)
+  - `tests/unit/simulator/hero-augment-stat-system.test.ts`: Mordekaiser grep test regex `!== null` → `!= null`
+- **검증**: 전체 suite **892/892 pass** ✅ (이전 883 pass / 9 fail → 892 pass / 0 fail)
+
 ### Sim fix: main pipeline omnivamp grievousReduction abilityTarget 사용 — Lint #16 ✅ resolved (PR #142)
 
 - **Source**: PR #141 codex P2 amend 시 발견 (OOR fix 일관성 점검 중 main 의 동일 패턴 검출)

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -948,7 +948,9 @@ export function applyMordekaiserProcCast(unit: CombatUnit, tick: number): void {
   // 위키 lint #7 (PR #123 검출, fix #124): MordekaiserCarry (Heat Death) 활성 시 carry
   // abilityData.shield override 우선 read. 비활성 시 raw InitialShield var 사용 (base
   // Mordekaiser cast). 17.3 patch note Heat Death shield 175/200/400 정합 적용.
-  const baseInitialShield = unit.mordekaiserCarryShield !== null
+  // PR #143: != null (loose) 가드 — undefined (test fixture / 외부 호출자) 도 safe.
+  // 기존 !== null (strict) 는 undefined !== null = true 라 array access TypeError 회귀.
+  const baseInitialShield = unit.mordekaiserCarryShield != null
     ? (unit.mordekaiserCarryShield[unit.starLevel - 1] ?? 0)
     : readVarByStar(
       vars.find(v => v.name === 'InitialShield')?.value, unit.starLevel, 0

--- a/tests/unit/mordekaiser-proc.test.ts
+++ b/tests/unit/mordekaiser-proc.test.ts
@@ -101,6 +101,9 @@ function makeMordekaiser(opts: {
     mordekaiserProcEndTick: 0,
     mordekaiserNextProcTick: 0,
     mordekaiserShieldRemaining: 0,
+    // PR #124 추가 필드 — raw Mordekaiser test 라 null (MordekaiserCarry 비활성).
+    // applyMordekaiserProcCast 가 carry override 검사 시 raw InitialShield fallback 진입.
+    mordekaiserCarryShield: null,
     // codex P2 PR #103: pulse 의 per-target amp 계산에 사용되는 필드 (0 default).
     inventionTankDamageAmp: 0,
     madredsTankDamageAmp: 0,

--- a/tests/unit/simulator/heal-amp-integration.test.ts
+++ b/tests/unit/simulator/heal-amp-integration.test.ts
@@ -105,8 +105,10 @@ describe('healAmp 적용 사이트 코드 grep — 회귀 안전성', () => {
     //   (`mordekaiserShieldRemaining * healRefund * (1 + (unit.healAmp ?? 0))`) 추가 → 13 매치.
     // Illaoi NumEnemies drain heal (audit P3): total drain × (1 + healAmp)
     //   (`totalDrain * (1 + (unit.healAmp ?? 0))`) 추가 → 14 매치.
+    // PR #141 Lint #15: OOR cast path omnivamp heal (`totalAbilityDmg * unit.omnivamp *
+    //   grievousReductionOOR * (1 + (unit.healAmp ?? 0))`) 추가 — main+OOR 비대칭 해소 → 15 매치.
     // 새 heal 사이트 추가 시 본 카운트도 갱신 필수.
-    expect(matches!.length).toBe(14);
+    expect(matches!.length).toBe(15);
   });
 
   it('각 heal 사이트별 fingerprint — 의미 단위 회귀 가드', async () => {

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -1353,7 +1353,8 @@ describe('CarryAugmentConfig.statOverrides — 슬롯 추후 채움 가드', () 
       'utf8',
     );
     expect(combatLoopSrc).toMatch(/applyMordekaiserProcCast[\s\S]+?unit\.mordekaiserCarryShield/);
-    expect(combatLoopSrc).toMatch(/mordekaiserCarryShield\s*!==\s*null/);
+    // PR #143: !== null → != null (undefined 도 safe, test fixture 회귀 가드)
+    expect(combatLoopSrc).toMatch(/mordekaiserCarryShield\s*!=\s*null/);
   });
 
   it('applyHeroCarryTransforms mana override 는 item delta 보존 (PR #124 Codex P2 회귀 가드)', async () => {


### PR DESCRIPTION
## Summary

PR #141/#142 작업 중 발견된 **pre-existing 9 fail** (Mordekaiser proc test) 해소. 변경 전 dev 도 동일 fail 확인 — 본 PR 들과 무관 누적 fail.

## 원인 분석

\`applyMordekaiserProcCast\` (\`combatLoop.ts:951\`):

\`\`\`ts
const baseInitialShield = unit.mordekaiserCarryShield !== null  // ← strict !==
  ? (unit.mordekaiserCarryShield[unit.starLevel - 1] ?? 0)
  : readVarByStar(...);
\`\`\`

\`undefined !== null = true\` → \`unit.mordekaiserCarryShield[0]\` array access → **TypeError: Cannot read properties of undefined**.

원인: **PR #124** (Mordekaiser shield/mana 17.3 정합) 시 \`mordekaiserCarryShield: null\` 필드 추가 했으나 **test fixture (\`tests/unit/mordekaiser-proc.test.ts\` makeMordekaiserUnit) 갱신 누락**.

## 해소 (2-layer)

| Layer | 변경 |
|-------|------|
| **sim 코드 defensive** | \`!== null\` (strict) → \`!= null\` (loose). undefined 도 safe |
| **test fixture 갱신** | \`makeMordekaiserUnit\` 에 \`mordekaiserCarryShield: null\` 추가 (raw 챔프 명시) |

## follow-up test 갱신 (PR #141/#142 sim 변경 반영)

| 파일 | 변경 |
|------|------|
| \`heal-amp-integration.test.ts\` | healAmp 곱셈 사이트 카운트 \`14 → 15\` (PR #141 OOR omnivamp heal 추가 반영) |
| \`hero-augment-stat-system.test.ts\` | Mordekaiser grep regex \`!== null\` → \`!= null\` |

## 검증

- ✅ \`pnpm typecheck\` pass
- ✅ \`pnpm vitest run\` 전체 suite **892/892 pass** (이전 883 pass / 9 fail → 892 pass / 0 fail)

## Test plan

- [x] typecheck pass
- [x] 전체 suite 0 fail
- [ ] Codex review 대기