### PR TITLE
refactor(sim): legacy xxxCarryActive flag 4건 deprecate — selectedCarryAugment 단일화

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-05-19T07:01:49.645Z",
+  "computedAt": "2026-05-19T08:01:38.926Z",
   "sourceGameMtime": 1777273516360,
-  "engineSha": "1593705ea5ad66d7606755dff8c91cc36317696b",
+  "engineSha": "5f93d50a910324332a3003a163a920b38dd86ccc",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -8,6 +8,24 @@ format: newest first
 
 ## 2026-05-19
 
+### Refactor: legacy xxxCarryActive flag 4건 deprecate — selectedCarryAugment 단일화 (PR #147)
+
+- **Source**: PR #144 selectedCarryAugment 일반화 후속 cleanup. legacy flag 4건 (PR #135/#136 추가 + leona/gragas legacy) 단순 deprecate
+- **제거된 type 필드** (CombatUnit):
+  - `gragasCarryActive` (legacy, sim 코드 read 0건 dead)
+  - `leonaCarryActive` (legacy, sim 코드 read 0건 dead)
+  - `nasusCarryActive` (PR #135, bonusPerKill modifier + stack hook read site 2건)
+  - `jaxCarryActive` (PR #136, selfBuff asGain + Jax damage 분기 main+OOR 4 read site)
+- **read site 모두 selectedCarryAugment 비교로 교체** (동치 검증):
+  - `unit.xxxCarryActive` → `unit.selectedCarryAugment === 'TFT17_Augment_XxxCarry'`
+  - cast loop 6 read site + applyCarryDamageModifiers 1 read site = 7 read site 갱신
+- **createCombatUnit init 12 site 제거** (4 flag × 3 init site)
+- **`applyHeroCarryTransforms` simplify** — 4 flag set 분기 제거. `selectedCarryAugment` + Mordekaiser carry shield (carry data 보유) 만 유지
+- **test assertion 갱신** — `.xxxCarryActive).toBe(true/false)` → `.selectedCarryAugment).toBe(...) / .toBeNull()` 14건 sed 일괄 갱신
+- **mordekaiserCarryShield 유지**: carry data (shield array 보유) — 단순 boolean 아니라 별도 처리. selectedCarryAugment 와 함께 유지
+- **검증**: pnpm typecheck pass, 전체 suite **896/896 pass** ✅
+- **효과**: type 8 줄 + 12 init line + 14 test assertion 일관 → CombatUnit type 단순화, selected single-carry semantics 일원화 완료
+
 ### Docs: Lint #10 deep cleanup — hero-augment-carry.md stale 표기 전수 정정 (PR #146 + codex P2 amend)
 
 - **Source**: 위키 lint #10 (`hero-augment-carry.md` 의 "❌ 미완" 섹션 stale 표기 — PR #131 부분 정정 후 deep cleanup 후속)

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -289,8 +289,6 @@ function createCombatUnit(
     blitzBoltDamage: 0,
     blitzBoltLastFireTick: 0,
     blitzBoltSpeedMult: 1,
-    gragasCarryActive: false,
-    leonaCarryActive: false,
     mordekaiserCarryShield: null,
     aatroxCycleCounter: 0,
     aatroxPreviouslyDead: false,
@@ -308,8 +306,6 @@ function createCombatUnit(
     stargazerSerpentDurationSec: 0,
     shenPassiveStack: 0,
     nasusBonkStack: 0,
-    nasusCarryActive: false,
-    jaxCarryActive: false,
     selectedCarryAugment: null,
     stargazerShieldCashoutHpFrac: 0,
     stargazerShieldCashoutAsFrac: 0,
@@ -1361,9 +1357,12 @@ function applyCarryDamageModifiers(
   // 6. bonusPerKill (NasusCarry 한정, Lint #12 해소): cast kill 누적 stack × bonusPerKill[★]
   // raw 가산. base damage 계산 후 영구 buff 형태로 더해짐 (스택 0 일 때 무영향).
   // stack 증가 위치: cast loop 의 markTargetDead 직후 (basic attack kill 제외 — desc "이 스킬로" 정합).
-  // codex P2 (PR #135): unit.nasusCarryActive 가드 — 다중 Nasus 카피 시 selected 1명만 적용.
-  // (augmentApiName 매치 만으로는 non-selected 카피도 동일 carry config 반환 → semantics 위반).
-  if (ad.bonusPerKill && unit.nasusBonkStack > 0 && unit.nasusCarryActive) {
+  // codex P2 (PR #135): selected 가드 — 다중 Nasus 카피 시 selected 1명만 적용.
+  // PR #147 deprecate: nasusCarryActive flag → selectedCarryAugment 비교 (동치 + 일반화).
+  // 단, PR #144 findSelectedCarryAugment 가 carryCfg 를 selected 만 반환하므로 본 가드는
+  // defense-in-depth (carryCfg 통과 시 추가 검증 — bonusPerKill 정의 + stack > 0).
+  if (ad.bonusPerKill && unit.nasusBonkStack > 0
+      && unit.selectedCarryAugment === 'TFT17_Augment_NasusCarry') {
     const bonusArr = ad.bonusPerKill;
     const bonusPer = bonusArr[unit.starLevel - 1] ?? bonusArr[0];
     baseDmg += unit.nasusBonkStack * bonusPer;
@@ -2291,8 +2290,9 @@ function applyHeroCarryTransforms(augmentApiNames: string[], units: CombatUnit[]
       }
     }
     // PR #144 Lint #14 foundation: selected single-carry semantics 일반화 — 모든 carry 에
-    // selectedCarryAugment 일관 set. 기존 xxxCarryActive flag 는 legacy 호환 유지 (점진 deprecate).
-    // 신규 가드 (getAbilityConfigForUnit + 미래 carry-specific) 는 selectedCarryAugment 사용 권장.
+    // selectedCarryAugment 일관 set. PR #147 deprecate: 기존 xxxCarryActive flag (jax/nasus/
+    // leona/gragas) 제거됨 — read site 모두 selectedCarryAugment 비교로 변경. carry-specific
+    // 데이터 보유 필드 (mordekaiserCarryShield) 만 유지.
     target.selectedCarryAugment = cfg.augmentApiName;
 
     // PR #144 codex P1 amend: rangeOverride 통합 — 이전엔 applyCarryAugmentRange 가 selected
@@ -2302,27 +2302,13 @@ function applyHeroCarryTransforms(augmentApiNames: string[], units: CombatUnit[]
       target.stats.range = cfg.rangeOverride;
     }
 
-    // ability 분기용 flag (기존 호출 경로 호환 — legacy, PR #144 이후 deprecate 예정)
-    if (cfg.augmentApiName === 'TFT17_Augment_GragasCarry') {
-      target.gragasCarryActive = true;
-    } else if (cfg.augmentApiName === 'TFT17_Augment_LeonaCarry') {
-      target.leonaCarryActive = true;
-    } else if (cfg.augmentApiName === 'TFT17_Augment_MordekaiserCarry') {
+    // Mordekaiser carry shield (carry data 보유 — 단순 boolean 아님)
+    if (cfg.augmentApiName === 'TFT17_Augment_MordekaiserCarry') {
       // 위키 lint #7 (PR #123 Codex P2 검출): applyMordekaiserProcCast 가 raw
       // unit.champion.ability.variables.InitialShield 만 read 했음 (PR #115 의 17.3
       // shield/mana sim 미반영). carry abilityData.shield override 를 unit 에 저장
       // → applyMordekaiserProcCast 가 우선 read.
       target.mordekaiserCarryShield = cfg.abilityData?.shield ?? null;
-    } else if (cfg.augmentApiName === 'TFT17_Augment_NasusCarry') {
-      // PR #135 Codex P2 catch: findCarryAugment 는 모든 Nasus 카피에 NasusCarry config 반환
-      // (champion api name 매치만) 하지만 applyHeroCarryTransforms 는 가장 강한 1명만 carry
-      // transform. read site (bonusPerKill modifier + cast loop stack hook) 가 champion
-      // api 만 확인하면 non-selected 카피도 stack 누적 → 의도 위반. selected 만 flag set.
-      target.nasusCarryActive = true;
-    } else if (cfg.augmentApiName === 'TFT17_Augment_JaxCarry') {
-      // PR #136 Lint #11-B 해소: JaxCarry abilityData.asGain[★] starLevel별 read.
-      // selected single-carry semantics (PR #135 패턴) — 다중 Jax 카피 시 selected 만 적용.
-      target.jaxCarryActive = true;
     }
   }
 }
@@ -3645,8 +3631,6 @@ function spawnFreljordTurrets(
             blitzBoltDamage: 0,
             blitzBoltLastFireTick: 0,
             blitzBoltSpeedMult: 1,
-            gragasCarryActive: false,
-            leonaCarryActive: false,
             mordekaiserCarryShield: null,
             aatroxCycleCounter: 0,
             aatroxPreviouslyDead: false,
@@ -3664,8 +3648,6 @@ function spawnFreljordTurrets(
             stargazerSerpentDurationSec: 0,
             shenPassiveStack: 0,
             nasusBonkStack: 0,
-            nasusCarryActive: false,
-            jaxCarryActive: false,
             selectedCarryAugment: null,
             stargazerShieldCashoutHpFrac: 0,
             stargazerShieldCashoutAsFrac: 0,
@@ -3858,8 +3840,6 @@ function trySpawnGalio(
     blitzBoltDamage: 0,
     blitzBoltLastFireTick: 0,
     blitzBoltSpeedMult: 1,
-    gragasCarryActive: false,
-    leonaCarryActive: false,
     mordekaiserCarryShield: null,
     aatroxCycleCounter: 0,
     aatroxPreviouslyDead: false,
@@ -3877,8 +3857,6 @@ function trySpawnGalio(
     stargazerSerpentDurationSec: 0,
     shenPassiveStack: 0,
     nasusBonkStack: 0,
-    nasusCarryActive: false,
-    jaxCarryActive: false,
     selectedCarryAugment: null,
     stargazerShieldCashoutHpFrac: 0,
     stargazerShieldCashoutAsFrac: 0,
@@ -6618,7 +6596,8 @@ export function simulateCombat(
                   // codex P2 (PR #135): unit.nasusCarryActive 가드 — findCarryAugment 는 모든 Nasus
                   // 카피에 NasusCarry config 반환하나 applyHeroCarryTransforms 는 가장 강한 1명만
                   // selected. selected 만 stack 누적 (비-carry 카피 회귀 방지).
-                  if (unit.nasusCarryActive && carryCfg?.abilityData?.bonusPerKill) {
+                  // PR #147: nasusCarryActive → selectedCarryAugment 비교 (동치)
+                  if (unit.selectedCarryAugment === 'TFT17_Augment_NasusCarry' && carryCfg?.abilityData?.bonusPerKill) {
                     unit.nasusBonkStack++;
                   }
                 }
@@ -6896,7 +6875,8 @@ export function simulateCombat(
             // cast path 3종 룰 (PR #129): OOR cast path 에도 동일 분기 추가 (아래 line ~7140+).
             // **위치**: 일반 cast damage / applyCarryPostCastEffects 직후 + omnivamp/Fountain hook
             // 직전 (codex P2 PR #140: Jax damage 가 omnivamp/Fountain heal 정합 반영되도록).
-            if (unit.jaxCarryActive && carryCfg?.abilityData?.damage && target.state !== 'dead') {
+            // PR #147: jaxCarryActive → selectedCarryAugment 비교 (동치)
+            if (unit.selectedCarryAugment === 'TFT17_Augment_JaxCarry' && carryCfg?.abilityData?.damage && target.state !== 'dead') {
               const jaxDmgArr = carryCfg.abilityData.damage;
               const jaxDmgBase = jaxDmgArr[unit.starLevel - 1] ?? jaxDmgArr[0];
               const jaxDmgType: DamageType = carryCfg.damageTypeOverride
@@ -7024,7 +7004,10 @@ export function simulateCombat(
                 // selfBuff.attackSpeed 는 fixed 0.15 (carry abilityOverride) → asGain
                 // [0.15,0.15,0.20] 의 ★3 +20% 의도 미실현. jaxCarryActive 가드 (selected
                 // single-carry semantics — PR #135 패턴) 로 다중 Jax 카피 시 selected 만 정확.
-                const asGainArr = unit.jaxCarryActive ? carryCfg?.abilityData?.asGain : undefined;
+                // PR #147: jaxCarryActive → selectedCarryAugment 비교 (동치)
+                const asGainArr = unit.selectedCarryAugment === 'TFT17_Augment_JaxCarry'
+                  ? carryCfg?.abilityData?.asGain
+                  : undefined;
                 const asGainPer = asGainArr
                   ? (asGainArr[unit.starLevel - 1] ?? asGainArr[0])
                   : config.selfBuff.attackSpeed;
@@ -7178,7 +7161,10 @@ export function simulateCombat(
             if (outOfRangeConfig.selfBuff.attackSpeed) {
               // PR #136 Lint #11-B 해소: OOR cast path 도 main 과 동일하게 JaxCarry asGain[★]
               // starLevel별 우선 read. cast path 3종 일관 (PR #129 stun OOR 누락 패턴 회귀 방지).
-              const oorAsGainArr = unit.jaxCarryActive ? oorCarryCfg?.abilityData?.asGain : undefined;
+              // PR #147: jaxCarryActive → selectedCarryAugment 비교 (동치)
+              const oorAsGainArr = unit.selectedCarryAugment === 'TFT17_Augment_JaxCarry'
+                ? oorCarryCfg?.abilityData?.asGain
+                : undefined;
               const oorAsGainPer = oorAsGainArr
                 ? (oorAsGainArr[unit.starLevel - 1] ?? oorAsGainArr[0])
                 : outOfRangeConfig.selfBuff.attackSpeed;
@@ -7222,7 +7208,8 @@ export function simulateCombat(
           // main pipeline (line ~6952+) 와 동일 분기. cast path 3종 일관 (PR #129 룰 — stun 같은 OOR 누락 가드).
           // OOR cast path 는 self_buff 패턴 + JaxCarry abilityOverride 면 진입 (line 7038 canDashCast).
           // 사망 시 markTargetDead 직접 호출 — OOR cast 의 처치 분기는 abilityTargets loop 안 (self-hit 회귀 방지 제외).
-          if (unit.jaxCarryActive && oorCarryCfg?.abilityData?.damage && target.state !== 'dead') {
+          // PR #147: jaxCarryActive → selectedCarryAugment 비교 (동치)
+          if (unit.selectedCarryAugment === 'TFT17_Augment_JaxCarry' && oorCarryCfg?.abilityData?.damage && target.state !== 'dead') {
             const oorJaxDmgArr = oorCarryCfg.abilityData.damage;
             const oorJaxDmgBase = oorJaxDmgArr[unit.starLevel - 1] ?? oorJaxDmgArr[0];
             const oorJaxDmgType: DamageType = oorCarryCfg.damageTypeOverride

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -762,17 +762,9 @@ export interface CombatUnit {
   blitzBoltLastFireTick: number;
   /** 파티광 후속 효과 — 회복 완료 후 Bolt 발사 속도 multiplier. 1 default / 4 (회복 완료 후). */
   blitzBoltSpeedMult: number;
-  /**
-   * 자폭(TFT17_Augment_GragasCarry) 활성 + 가장 강한 그라가스로 선정된 unit 만 true.
-   * 그라가스 ability 가 거대한 폭발 (자기 자신 데미지, 다른 아군 X) 로 변환되며,
-   * 자폭 데미지로 hp 가 1 미만으로 떨어지지 않음 (HP floor=1).
-   */
-  gragasCarryActive: boolean;
-  /**
-   * 방패 여전사(TFT17_Augment_LeonaCarry) 활성 + 가장 강한 레오나로 선정된 unit 만 true.
-   * 레오나 ability 가 적 가로질러 dash (line 패턴) + 첫 적중 대상 기절 (CC) 로 변환.
-   */
-  leonaCarryActive: boolean;
+  // PR #147 deprecate: gragasCarryActive / leonaCarryActive 필드 제거됨.
+  // selectedCarryAugment === 'TFT17_Augment_GragasCarry' / 'TFT17_Augment_LeonaCarry'
+  // 비교로 대체. sim 코드 read 0건이었음 (test assertion 만 갱신).
   /**
    * 뜨거운 죽음(TFT17_Augment_MordekaiserCarry) 활성 시 carry abilityData.shield override.
    * null = 비활성, 배열 = augment 활성 (starLevel 별 [1성, 2성, 3성]).
@@ -858,13 +850,8 @@ export interface CombatUnit {
    * Read site: applyCarryDamageModifiers 의 bonusPerKill modifier — baseDmg += stack × bonusPerKill[starLevel-1].
    */
   nasusBonkStack: number;
-  /**
-   * NasusCarry — applyHeroCarryTransforms 의 "가장 강한 1명" selector 결과 flag.
-   * findCarryAugment 는 champion api 매치하는 모든 Nasus 에 NasusCarry config 반환 (다중 카피 시).
-   * 가장 강한 1명만 실제 carry transform 대상 → 본 flag 로 selected unit 분기.
-   * stack hook (cast loop) + bonusPerKill modifier 둘 다 본 flag 가드 (PR #135 Codex P2).
-   */
-  nasusCarryActive: boolean;
+  // PR #147 deprecate: nasusCarryActive 필드 제거됨. selectedCarryAugment 비교로 대체
+  // (cast loop bonusPerKill modifier + stack hook 두 read site 모두 갱신됨).
   /**
    * Selected single-carry semantics 일반화 helper (PR #144 foundation, Lint #14).
    * `applyHeroCarryTransforms` 가 "가장 강한 1명" selector 결과 target 에 본 필드 set
@@ -878,13 +865,8 @@ export interface CombatUnit {
    * 신규 가드는 `selectedCarryAugment === '<augment_api>'` 사용 권장. 점진 deprecate.
    */
   selectedCarryAugment: string | null;
-  /**
-   * JaxCarry — selected single-carry semantics flag (PR #136 Lint #11-B 해소).
-   * findCarryAugment 는 champion api 매치하는 모든 Jax 에 동일 config 반환.
-   * applyHeroCarryTransforms 의 "가장 강한 1명" selector 결과 unit 에만 set.
-   * asGain starLevel별 read site (selfBuff 분기 main + OOR) 둘 다 본 flag 가드.
-   */
-  jaxCarryActive: boolean;
+  // PR #147 deprecate: jaxCarryActive 필드 제거됨. selectedCarryAugment 비교로 대체
+  // (selfBuff asGain 분기 main + OOR + Jax damage 분기 main + OOR 4 read site 갱신됨).
   /**
    * 요새 (Bastion/ResistTank) — 첫 N초 doubled BonusArmor.
    * 0 = 비활성. 양수면 그 tick 에 도달 시 doubled 부분 (bastionDoubleArmorBonus)

--- a/tests/unit/simulator/hero-augment-stat-system.test.ts
+++ b/tests/unit/simulator/hero-augment-stat-system.test.ts
@@ -192,7 +192,7 @@ describe('자폭 (GragasCarry) — 17.2b healthCost 적용', () => {
     });
     const g = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Gragas');
     if (!g) return;
-    expect(g.gragasCarryActive).toBe(true);
+    expect(g.selectedCarryAugment).toBe('TFT17_Augment_GragasCarry');
     expect(g.role).toBe('Fighter');
     // 자폭이 maxHp 를 stat으로 변경하지는 않음 — base HP 보존
     expect(g.maxHp).toBeGreaterThan(0);

--- a/tests/unit/simulator/hero-carry-augments.test.ts
+++ b/tests/unit/simulator/hero-carry-augments.test.ts
@@ -47,7 +47,7 @@ describe('자폭 (GragasCarry) — 가장 강한 그라가스 self-damage + HP f
     });
     const gragas = withCarry.playerUnits.find(u => u.champion.apiName === 'TFT17_Gragas')!;
     // gragasCarryActive 플래그 + role 'Fighter' 변환
-    expect(gragas.gragasCarryActive).toBe(true);
+    expect(gragas.selectedCarryAugment).toBe('TFT17_Augment_GragasCarry');
     expect(gragas.role).toBe('Fighter');
   });
 
@@ -68,7 +68,7 @@ describe('자폭 (GragasCarry) — 가장 강한 그라가스 self-damage + HP f
     // 이 테스트는 ability 시전 후 즉시 검증이 어려우니 (loop 끝남) — gragasCarryActive 플래그
     // + log 기반 검증으로 대체.
     const gragas = withCarry.playerUnits.find(u => u.champion.apiName === 'TFT17_Gragas')!;
-    expect(gragas.gragasCarryActive).toBe(true);
+    expect(gragas.selectedCarryAugment).toBe('TFT17_Augment_GragasCarry');
     // log 에 자폭 메시지 존재
     const selfDamageLog = withCarry.logs.find(l => l.message?.includes('자폭'));
     expect(selfDamageLog).toBeDefined();
@@ -81,7 +81,7 @@ describe('자폭 (GragasCarry) — 가장 강한 그라가스 self-damage + HP f
       seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
     });
     const gragas = withoutCarry.playerUnits.find(u => u.champion.apiName === 'TFT17_Gragas')!;
-    expect(gragas.gragasCarryActive).toBe(false);
+    expect(gragas.selectedCarryAugment).toBeNull();
   });
 
   it('가장 강한 룰 — 동급 시 아이템 보유 unit 우선', () => {
@@ -100,8 +100,8 @@ describe('자폭 (GragasCarry) — 가장 강한 그라가스 self-damage + HP f
     // 아이템 보유 unit 만 carry transform
     const withItems = gragasUnits.find(u => u.items.length > 0)!;
     const noItems = gragasUnits.find(u => u.items.length === 0)!;
-    expect(withItems.gragasCarryActive).toBe(true);
-    expect(noItems.gragasCarryActive).toBe(false);
+    expect(withItems.selectedCarryAugment).toBe('TFT17_Augment_GragasCarry');
+    expect(noItems.selectedCarryAugment).toBeNull();
   });
 });
 
@@ -114,7 +114,7 @@ describe('방패 여전사 (LeonaCarry) — 가장 강한 레오나 dash + 첫 �
       playerAugments: [augLeonaCarry] as RawAugment[],
     });
     const leona = withCarry.playerUnits.find(u => u.champion.apiName === 'TFT17_Leona')!;
-    expect(leona.leonaCarryActive).toBe(true);
+    expect(leona.selectedCarryAugment).toBe('TFT17_Augment_LeonaCarry');
     expect(leona.role).toBe('Fighter');
   });
 
@@ -125,7 +125,7 @@ describe('방패 여전사 (LeonaCarry) — 가장 강한 레오나 dash + 첫 �
       seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
     });
     const leona = withoutCarry.playerUnits.find(u => u.champion.apiName === 'TFT17_Leona')!;
-    expect(leona.leonaCarryActive).toBe(false);
+    expect(leona.selectedCarryAugment).toBeNull();
   });
 
   it('가장 강한 룰 — 3성 > 2성 우선', () => {
@@ -142,8 +142,8 @@ describe('방패 여전사 (LeonaCarry) — 가장 강한 레오나 dash + 첫 �
     const leonaUnits = withCarry.playerUnits.filter(u => u.champion.apiName === 'TFT17_Leona');
     const star3 = leonaUnits.find(u => u.starLevel === 3)!;
     const star2 = leonaUnits.find(u => u.starLevel === 2)!;
-    expect(star3.leonaCarryActive).toBe(true);
-    expect(star2.leonaCarryActive).toBe(false);
+    expect(star3.selectedCarryAugment).toBe('TFT17_Augment_LeonaCarry');
+    expect(star2.selectedCarryAugment).toBeNull();
   });
 });
 
@@ -198,8 +198,8 @@ describe('꽁! (NasusCarry) — bonusPerKill cast 누적 (Lint #12 해소)', () 
     const star3 = nasusUnits.find(u => u.starLevel === 3)!;
     const star2 = nasusUnits.find(u => u.starLevel === 2)!;
     // 3성만 selected
-    expect(star3.nasusCarryActive).toBe(true);
-    expect(star2.nasusCarryActive).toBe(false);
+    expect(star3.selectedCarryAugment).toBe('TFT17_Augment_NasusCarry');
+    expect(star2.selectedCarryAugment).toBeNull();
     // 2성 non-carry 는 stack 누적 안 함 (회귀 가드)
     expect(star2.nasusBonkStack).toBe(0);
   });
@@ -229,7 +229,7 @@ describe('저 별을 향해 (JaxCarry) — asGain starLevel별 정합 (Lint #11-
       playerAugments: [augJaxCarry] as RawAugment[],
     });
     const jax = withCarry.playerUnits.find(u => u.champion.apiName === 'TFT17_Jax')!;
-    expect(jax.jaxCarryActive).toBe(true);
+    expect(jax.selectedCarryAugment).toBe('TFT17_Augment_JaxCarry');
     expect(jax.role).toBe('Fighter');
   });
 
@@ -240,7 +240,7 @@ describe('저 별을 향해 (JaxCarry) — asGain starLevel별 정합 (Lint #11-
       seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
     });
     const jax = withoutCarry.playerUnits.find(u => u.champion.apiName === 'TFT17_Jax')!;
-    expect(jax.jaxCarryActive).toBe(false);
+    expect(jax.selectedCarryAugment).toBeNull();
   });
 
   it('다중 Jax 카피 시 selected (가장 강한) 1명만 jaxCarryActive (codex P2 패턴 적용)', () => {
@@ -258,8 +258,8 @@ describe('저 별을 향해 (JaxCarry) — asGain starLevel별 정합 (Lint #11-
     const jaxUnits = result.playerUnits.filter(u => u.champion.apiName === 'TFT17_Jax');
     const star3 = jaxUnits.find(u => u.starLevel === 3)!;
     const star2 = jaxUnits.find(u => u.starLevel === 2)!;
-    expect(star3.jaxCarryActive).toBe(true);
-    expect(star2.jaxCarryActive).toBe(false);
+    expect(star3.selectedCarryAugment).toBe('TFT17_Augment_JaxCarry');
+    expect(star2.selectedCarryAugment).toBeNull();
   });
 
   it('cast 시 target 에 magic damage 적용 (Lint #11-A 해소, PR #140)', () => {
@@ -308,7 +308,7 @@ describe('저 별을 향해 (JaxCarry) — asGain starLevel별 정합 (Lint #11-
     // (item bonus / trait effect 없는 단순 setup). carry self_buff.attackSpeed 0.15 적용되면
     // final AS = rawAS × 1.15^(castCount) → cast 1회만 진입해도 rawAS 보다 큼.
     // 회귀 가드: non-selected 가 carry buff 받았다면 attackSpeed 가 raw 보다 큼.
-    expect(star2NonSelected.jaxCarryActive).toBe(false);
+    expect(star2NonSelected.selectedCarryAugment).toBeNull();
     // raw Jax attackSpeed 와 일치 (±5% 허용 — trait/buff 영향 미미)
     expect(star2NonSelected.stats.attackSpeed).toBeLessThanOrEqual(rawAS * 1.05);
   });


### PR DESCRIPTION
## Summary

PR #144 selectedCarryAugment 일반화 후속 cleanup — legacy flag 4건 deprecate + 단일화.

## 제거된 type 필드 (CombatUnit)

| Flag | 도입 | sim 코드 read site |
|------|------|-------------------|
| \`gragasCarryActive\` | legacy | 0건 (dead) |
| \`leonaCarryActive\` | legacy | 0건 (dead) |
| \`nasusCarryActive\` | PR #135 | 2건 (bonusPerKill modifier + stack hook) |
| \`jaxCarryActive\` | PR #136 | 4건 (selfBuff asGain main+OOR + Jax damage main+OOR) |

## 변경

| 위치 | 변경 |
|------|------|
| read site (7건) | \`unit.xxxCarryActive\` → \`unit.selectedCarryAugment === 'TFT17_Augment_XxxCarry'\` (동치) |
| createCombatUnit init (12 site) | 4 flag × 3 site 제거 |
| \`applyHeroCarryTransforms\` | 4 flag set 분기 제거. \`selectedCarryAugment\` + Mordekaiser carry shield (carry data 보유) 만 유지 |
| test assertion (14건) | \`.xxxCarryActive).toBe(true/false)\` → \`.selectedCarryAugment).toBe(...) / .toBeNull()\` sed 일괄 |

## 유지된 carry-specific 필드

- **`selectedCarryAugment`** — 단일 식별 필드 (PR #144 도입)
- **`mordekaiserCarryShield`** — carry data 보유 (shield array, 단순 boolean 아님). Mordekaiser proc 의 carry override 우선 read 용

## 검증

- ✅ \`pnpm typecheck\` pass
- ✅ \`pnpm vitest run\` 전체 suite **896/896 pass**

## 효과

- CombatUnit type 단순화 (8 줄 제거)
- 12 init line 제거 (createCombatUnit 일관성 향상)
- 14 test assertion 일관 — selectedCarryAugment 단일 source
- selected single-carry semantics 일원화 완료 (PR #135/#136 → #144 → #147 점진 발전)

## Test plan

- [x] typecheck pass
- [x] 896/896 pass
- [ ] Codex review 대기