### PR TITLE
docs(wiki): champions/mordekaiser.md ingest — 4번째 champion 페이지 (helper 통합 sim 가장 정합)

### DIFF
--- a/docs/wiki/champions/mordekaiser.md
+++ b/docs/wiki/champions/mordekaiser.md
@@ -1,0 +1,184 @@
+---
+id: mordekaiser
+type: champion
+display_name_kr: 모데카이저
+api_name: TFT17_Mordekaiser
+cost: 2
+traits:
+  - 암흑의 별
+  - 전달자
+  - 선봉대
+role: Tank   # raw "APTank" → mapGameRole() → sim Tank. ⚠️ MordekaiserCarry augment 활성 시 Fighter 로 변환 (applyHeroCarryTransforms) — base 의 helper 메커니즘은 carry 활성 여부와 무관 동작 (mordekaiserCarryShield 만 InitialShield override)
+raw_role: APTank
+current_patch_status: active
+sim_active: active   # base raw 메커니즘 거의 완성 (helper 2개 + 별도 shield pool + healRefund + main/OOR cast parity)
+last_verified: 2026-05-21
+sources:
+  - "public/data/tft_set17_champions.json (TFT17_Mordekaiser entry)"
+  - "src/lib/simulator/systems/ability.ts:210 (abilityOverride pattern 'self_buff' + comment helper 참조)"
+  - "src/lib/simulator/engine/combatLoop.ts:230-233 (mordekaiser proc state field 3개 + mordekaiserShieldRemaining default)"
+  - "src/lib/simulator/engine/combatLoop.ts:292 (mordekaiserCarryShield: null default — carry data 보유 필드)"
+  - "src/lib/simulator/engine/combatLoop.ts:953-975 (applyMordekaiserProcCast — InitialShield × AP → shield pool + proc state 등록)"
+  - "src/lib/simulator/engine/combatLoop.ts:990-1067 (tickMordekaiserProc — 매초 펄스 + 만료 healRefund)"
+  - "src/lib/simulator/engine/combatLoop.ts:1213-1218 (mordekaiserShieldRemaining 별도 pool 우선 흡수)"
+  - "src/lib/simulator/engine/combatLoop.ts:2041 (암흑의 별 6 챔프 — Kaisa/Karma/Jhin/Chogath/Lissandra/Mordekaiser)"
+  - "src/lib/simulator/engine/combatLoop.ts:5533 (tickMordekaiserProc — combat loop per-tick 호출)"
+  - "src/lib/simulator/engine/combatLoop.ts:7037 / :7185 (applyMordekaiserProcCast — main + OOR cast path 양쪽 호출, cast path parity)"
+  - "src/lib/simulator/engine/combatLoop.ts:2305-2312 (applyHeroCarryTransforms — MordekaiserCarry 활성 시 mordekaiserCarryShield carry data 저장)"
+  - "tests/unit/mordekaiser-proc.test.ts (applyMordekaiserProcCast + tickMordekaiserProc 전용 test)"
+  - "tests/unit/simulator/darkstar-execute-supermassive.test.ts:27+ (apMordekaiser 암흑의 별 fixture)"
+related:
+  - "[[role-passive]]"
+  - "[[ability-targeting]]"
+  - "[[hero-augment-carry]]"
+  - "[[mordekaiser-carry]]"
+  - "[[shen]]"
+  - "[[jax]]"
+  - "[[nasus]]"
+---
+
+# 모데카이저 (Mordekaiser)
+
+## 요약
+
+2코스트 **Tank** (raw `APTank` → `mapGameRole()` → sim Tank, [[role-passive]]), 암흑의 별(Dark Star) + 전달자 + 선봉대(Vanguard) 시너지. raw 어빌리티 "불멸" — InitialShield 부여 + 4초 동안 매초 (본인 shield +N + 인접 적 magic damage) 펄스 + 종료 시 잔여 shield × 40% healRefund.
+
+[[mordekaiser-carry]] (뜨거운 죽음 / Heat Death) augment 활성 시 가장 강한 Mordekaiser 1명이 **Fighter 로 변환** + `mordekaiserCarryShield` carry data 저장 + statOverrides `mana 10/40`. 본 페이지는 **base raw Mordekaiser** 의 sim 동작을 다루며, carry 변환 사항은 [[mordekaiser-carry]] 참조.
+
+> ⚠️ Role 주의 — base vs carry: raw role `APTank` → sim **Tank** (weight 3, 공격당 마나 5, 피격 시 마나 ✅). **MordekaiserCarry augment 활성 시** `applyHeroCarryTransforms` 가 `target.role = 'Fighter'` overwrite → Fighter 룰 ([[jax]] / [[nasus]] 와 동일 패턴). 단 **proc helper 자체는 carry 활성 여부와 무관 동작** — base sim 이 helper 통합 (cast 진입 시점 + tick 처리) 라 carry 활성 시 `mordekaiserCarryShield` 만 InitialShield override 로 작용 (PR #124 lint #7 해소).
+
+## 메커니즘 (base raw, helper 통합 sim)
+
+### Stats (raw, 17.3 LIVE)
+
+| Stat | 값 |
+|------|---|
+| hp | 950 |
+| armor / magicResist | 45 / 45 |
+| damage | 40 |
+| attackSpeed | 0.6 |
+| range | 1 (melee) |
+| critChance / critMultiplier | 0.25 / 1.4 |
+| initialMana / mana | 40 / 100 |
+
+### Active — 불멸 (Immortal)
+
+raw 명세: "`@ModifiedInitialShield@(scaleAP)`의 보호막을 얻습니다. 다음 `@Duration@`초 (`@AugmentedDuration@` if Concentration) 동안 매초 `@ModifiedShieldPerProc@(scaleAP)`의 보호막을 더 얻고 인접한 적에게 `@ModifiedDamagePerProc@(scaleAP)`의 마법 피해를 입힙니다. 이 스킬이 끝나면 남은 보호막을 소모하고 보호막 수치의 `@HealRefund*100@%`만큼 체력을 회복합니다."
+
+→ **4단계 효과** (모두 sim 적용 ✅): (1) 즉시 InitialShield × (1+AP/100) 부여, (2) Duration (기본 4s) 동안 매초 펄스 = 본인 ShieldPerProc + 1칸 적 DamagePerProc magic, (3) Duration 만료 시 잔여 shield × HealRefund (40%) × (1+healAmp) currentHp 회복, (4) `mordekaiserShieldRemaining` 별도 pool 로 unit.shield 와 분리 (HealRefund 정확 계산).
+
+**sim 적용** (`ability.ts:210` + 헬퍼 2개):
+```ts
+TFT17_Mordekaiser: { pattern: 'self_buff' },  // 헬퍼가 메인 처리
+```
+
+| 단계 | 코드 위치 | 동작 |
+|------|----------|------|
+| cast 시점 (main pipeline) | `combatLoop.ts:7037` `applyMordekaiserProcCast(unit, tick)` | InitialShield × AP → `mordekaiserShieldRemaining` 누적. `mordekaiserProcEndTick = tick + Duration × TICKS_PER_SECOND`. `mordekaiserNextProcTick = tick + TICKS_PER_SECOND` (첫 펄스 t=1) |
+| cast 시점 (OOR cast path) | `combatLoop.ts:7185` 동일 helper 호출 | **main + OOR parity** (cast path 3종 룰 일관 — [[ability-targeting]]) |
+| 매 tick 처리 | `combatLoop.ts:5533` `tickMordekaiserProc(unit, ...)` | 펄스 발동 + 만료 처리 (사망 시 cancel + cleanup) |
+| 펄스 발동 (`t = mordekaiserNextProcTick ~ ProcEndTick`) | `combatLoop.ts:1016-1052` | 1칸 적 → DamagePerProc × AP magic (`applyAbilityMitigation` 표준 통과 + per-target damageAmp + tank amp 3종 + sniper). 본인 → ShieldPerProc × AP shield pool 누적. nextProcTick += TICKS_PER_SECOND |
+| 만료 (`t >= ProcEndTick`) | `combatLoop.ts:1055-1066` | `heal = mordekaiserShieldRemaining × HealRefund (0.4) × (1+healAmp)` → `currentHp` 회복. shield pool reset 0 |
+| 별도 shield pool 흡수 | `combatLoop.ts:1213-1218` | damage 가 mitigation 통과 후 `mordekaiserShieldRemaining > 0` 시 우선 흡수 (general `unit.shield` 와 분리 — HealRefund 잔여 정확 계산) |
+
+### raw ability variables (★1~★5 — 첫 값 sentinel filler)
+
+| 변수 | raw 값 | sim 적용 | 비고 |
+|------|--------|---------|------|
+| `InitialShield` | `[0, 300, 375, 500, 650, 200, 240]` ★1=300, ★2=375, ★3=500, ★4=650 | ✅ `applyMordekaiserProcCast` line 962-966 `readVarByStar` (sentinel 0 처리) | MordekaiserCarry 활성 시 `mordekaiserCarryShield` 우선 read (PR #124 lint #7 해소) |
+| `Duration` | `[4,4,4,4,4,4,4]` (전부 4초) | ✅ `applyMordekaiserProcCast` line 967-969 | base 동작 — `AugmentedDuration` (Concentration augment 활성 시 6초) 는 별도 미반영 |
+| `ShieldPerProc` | `[0, 75, 90, 105, 120, 0, 0]` ★1=75, ★2=90, ★3=105, ★4=120 | ✅ `tickMordekaiserProc` line 1020-1022 매 펄스 read | shield × (1+AP/100) 누적 |
+| `DamagePerProc` | `[0, 45, 70, 100, 170, 0, 0]` ★1=45, ★2=70, ★3=100, ★4=170 | ✅ `tickMordekaiserProc` line 1017-1019 매 펄스 read | 1칸 내 적 magic damage (per-target amp + sniper + mitigation 표준) |
+| `HealRefund` | `[0.4,...]` 전부 40% | ✅ `tickMordekaiserProc` line 1056-1058 만료 시 read | `mordekaiserShieldRemaining × 0.4 × (1+healAmp)` → currentHp |
+| `AugmentedDuration` | `[6,6,6,6,6,6,6]` Concentration augment 활성 시 | ❌ **미반영** | `TFT17_Augment_Concentration` augment (집중) 활성 시 Duration 4→6초로 확장. sim 분기 없음 |
+
+### 펄스 카운트 = 4 (`tick <= ProcEndTick` 포함)
+
+`tickMordekaiserProc` line 1016 의 `tick <= ProcEndTick` (≤) 조건으로 t=4 펄스 발동 + 만료 동시 처리. 4 펄스 정확 (`mordekaiser-proc.test.ts` 검증).
+
+### Trait — 암흑의 별(Dark Star) + 전달자 + 선봉대(Vanguard)
+
+- **암흑의 별 (Dark Star)** — `combatLoop.ts:2041` 6 챔프 그룹: Kaisa / Karma / Jhin / Chogath / Lissandra / **Mordekaiser**. Set 17 신규 시너지 — execute / supermassive 메커니즘 (`darkstar-execute-supermassive.test.ts` 27+ apMordekaiser fixture)
+- **전달자** — 시너지 stat 보강 분기 (Tank 보조)
+- **선봉대 (Vanguard)** — `applyVanguardEffects` (`combatLoop.ts:4664`) 전투 시작 시 보호막 (tick=0). Tank role 보강
+
+## MordekaiserCarry 변환 시 (참조)
+
+MordekaiserCarry augment 활성 시:
+- `applyHeroCarryTransforms` (`combatLoop.ts:2258-2312`): `target.role = 'Fighter'` + `target.selectedCarryAugment = 'TFT17_Augment_MordekaiserCarry'`
+- **statOverrides 적용** (`mana 10/40`) — `applyHeroCarryTransforms` 가 item delta 보존하며 적용 (Tear/Blue Buff 등 mana item bonus 위에 누적, PR #124 codex P2 정합)
+- **`mordekaiserCarryShield` carry data 저장** (`combatLoop.ts:2306-2311`) — `cfg.abilityData?.shield` (17.3 `[175, 200, 400]`) → `applyMordekaiserProcCast` 가 raw `InitialShield` 대신 우선 read (PR #124 lint #7 해소)
+- **helper 자체는 동일 동작** — proc system (cast 진입 + tick 처리 + shield pool + healRefund) 그대로 작동 (base raw 구현이 carry 와 통합)
+
+상세 cast path / 패치 변경 / lint history 는 [[mordekaiser-carry]] 참조.
+
+⚠️ **메모리 cleanup 후보**: `mordekaiserCarryShield` 필드는 `selectedCarryAugment === 'TFT17_Augment_MordekaiserCarry'` + `carryCfg.abilityData?.shield` 로 derive 가능 (불필요한 unit field). PR #144 selected-single-carry 일반화 후속으로 deprecate 검토 가능 — 단 현재 필드는 `null | number[]` 데이터 보유라 단순 boolean flag deprecate (PR #147 xxxCarryActive) 와 다른 work 필요.
+
+## 패치 히스토리 (base raw)
+
+| 패치 | 변경 |
+|------|------|
+| 17.2~17.3 base | raw stats / InitialShield / Duration / ShieldPerProc / DamagePerProc / HealRefund 별도 변경 검출 없음 (patch wiki 의 Mordekaiser 항목은 모두 MordekaiserCarry 한정) |
+
+## sim 적용 상태 — `active`
+
+✅ **활성** (base raw helper 통합):
+- stats 17.3 정합 (hp 950, armor/MR 45, AS 0.6, mana 40/100, range 1)
+- ability override `pattern: 'self_buff'` + helper 통합 (applyMordekaiserProcCast + tickMordekaiserProc)
+- InitialShield × AP → 별도 shield pool (`mordekaiserShieldRemaining`)
+- 4초 동안 매초 펄스 (4 펄스): ShieldPerProc 본인 + DamagePerProc 1칸 적 magic
+- 매 펄스 per-target damageAmp + tank amp 3종 (invention/madreds/graves) + sniper + mitigation pipeline 표준
+- 만료 시 HealRefund 40% × (1+healAmp) → currentHp 회복
+- 사망 시 proc cancel + state cleanup (잔여 shield 무효)
+- **cast path parity**: main + OOR 양쪽 `applyMordekaiserProcCast` 호출 ([[ability-targeting]] cast path 3종 룰 일관)
+- 별도 shield pool 우선 흡수 (general `unit.shield` 와 분리 — HealRefund 정확 계산)
+- 암흑의 별 (Dark Star) 6 챔프 그룹 멤버 (`combatLoop.ts:2041`)
+- 선봉대 (Vanguard) `applyVanguardEffects` 보호막 (tick=0)
+- 전용 test 2 file 회귀 가드 (`mordekaiser-proc.test.ts` + `darkstar-execute-supermassive.test.ts`)
+- MordekaiserCarry 활성 시 `mordekaiserCarryShield` carry data 우선 read (PR #124 lint #7 해소)
+
+❌ **미반영**:
+- **`AugmentedDuration` (Concentration augment 활성 시 Duration 4→6초)** — `TFT17_Augment_Concentration` augment 활성 시 펄스 +2회 (6 펄스). sim 분기 없음
+- 전달자 (Transmitter?) trait 효과 — sim 별도 분기 verify 필요
+
+🔍 **검증 필요**:
+- 전달자 trait 의 정확한 효과 (Tank 보조 / stat 보강 등) — sim 통합 위치 verify 필요
+- `mordekaiserCarryShield` 의 cleanup 가능성 — `selectedCarryAugment + carryCfg.abilityData.shield` 로 derive 가능 여부 (PR #147 후속 후보)
+
+## Lint 신규 등록 후보 (champion ingest 발견)
+
+본 페이지 작성 중 **base Mordekaiser** sim 미반영 1건 검출:
+
+| # | 항목 | 의미 |
+|---|------|------|
+| M1 | `AugmentedDuration` 6초 (Concentration augment 활성 시) | 펄스 +2회 = ShieldPerProc + DamagePerProc 50% 추가 손실 |
+
+⚠️ **우선순위 평가**: Concentration augment 자체가 set17 active 여부 별도 verify 필요. inactive 시 본 lint 자동 무효. 활성 augment 면 +50% 펄스 손실 큼.
+
+**Jax L1~L5 + Nasus N1~N4 + Mordekaiser M1 = base champion 미반영 lint 10건 누적** — Mordekaiser 는 가장 정합 (1건만 검출) → helper 통합 sim 의 효율성 입증.
+
+## Lint 체크리스트
+
+- [x] **set17 entity 소속 0단계** — `public/data/tft_set17_champions.json` `TFT17_Mordekaiser` apiName grep 확인 (한글 매칭 금지)
+- [x] entity-wide grep `Mordekaiser` + `mordekaiser` — sim 23+ site + test 2 file 전수 식별 (helper 2개 + state 3 field + shield pool + carry data field + dark star group + per-tick 호출)
+- [x] raw stats 17.3 정합
+- [x] **raw role `APTank` → mapGameRole → sim Tank** ([[jax]] / [[nasus]] 와 동일 매핑 — 3번째 base APTank champion)
+- [x] MordekaiserCarry 변환 시 role overwrite `Fighter` + `mordekaiserCarryShield` carry data 저장 (lint #7 해소)
+- [x] **cast path 3종** — main (`combatLoop.ts:7037`) + OOR (`:7185`) 양쪽 `applyMordekaiserProcCast` 호출 parity verify. recast 무관 (self_buff 패턴 + onKillRecast 없음)
+- [x] 별도 shield pool (`mordekaiserShieldRemaining`) general unit.shield 와 분리 — HealRefund 정확 계산 verify
+- [x] 사망 시 proc cleanup verify (`tickMordekaiserProc` line 1004-1009)
+- [ ] (사용자 verify) Concentration augment 활성 set17 여부 + `AugmentedDuration` sim 통합 결정
+- [ ] (사용자 verify) 전달자 trait 효과 + sim 통합 위치
+- [ ] (선택) `mordekaiserCarryShield` cleanup 가능성 평가 (selectedCarryAugment + carryCfg derive)
+- [ ] (선택) Lint M1 정식 등록 — Jax L1~L5 + Nasus N1~N4 와 묶음 평가
+
+## 관련
+
+- [[role-passive]] — Tank role 마나/타게팅 규칙 (base raw 적용)
+- [[ability-targeting]] — `self_buff` 패턴 + cast path 3종
+- [[hero-augment-carry]] — MordekaiserCarry 변환 시 role/stat/ability override 시스템
+- [[mordekaiser-carry]] — MordekaiserCarry augment 페이지 (Heat Death + lint #7 history)
+- [[jax]] / [[nasus]] — 동일 raw `APTank` → Tank 매핑 + augment 시 Fighter overwrite 패턴 (3 챔프 누적)
+- [[shen]] — 다른 raw role 변형 사례 (APFighter → Fighter, augment 무관)
+- 코드: `src/lib/simulator/systems/ability.ts:210`, `src/lib/simulator/engine/combatLoop.ts:953/990/1213/2306/5533/7037/7185`
+- 테스트: `tests/unit/mordekaiser-proc.test.ts` (전용) / `tests/unit/simulator/darkstar-execute-supermassive.test.ts:27+`

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,7 +1,7 @@
 ---
 name: TFT Domain Wiki — Index
 purpose: 위키 전체 페이지 카탈로그 (content-oriented)
-updated: 2026-05-21 (PR #150 nasus.md)
+updated: 2026-05-21 (PR #151 mordekaiser.md)
 ---
 
 # TFT Domain Wiki — Index
@@ -31,6 +31,7 @@ updated: 2026-05-21 (PR #150 nasus.md)
 - [[shen]] (쉔) — 5코스트 Fighter (raw `APFighter`, sim mapGameRole → Fighter), 보루 + 요새 trait. cast 마다 `shenPassiveStack++` 누적 + 평타 시 stack × BonusDamage 추가 (3+ true damage). 17.3 nerf (45/75 → 20/30) + maxHp/ShieldHP buff 정합
 - [[jax]] (잭스) — 2코스트 Tank (raw `APTank` → sim Tank), 별돌보미 + 요새. base raw "별의 반격" 3초 방어 태세 + AOE+stun. ⚠️ JaxCarry augment 활성 시 role=Fighter 로 변환 (augment 가 role 자체 변경, [[shen]] 과 다른 패턴). base 의 ShieldAP/FlatDR/StunDuration starLevel별 미반영 5건 lint 후보 검출
 - [[nasus]] (나서스) — 1코스트 Tank (raw `APTank` → sim Tank, [[jax]] 와 동일 매핑), 우주 그루브 + 선봉대. base raw "두둠칫 수잔" 6초 변신 + 인접 매초 magic DOT. ⚠️ NasusCarry augment 활성 시 role=Fighter + `nasusBonkStack × bonusPerKill[★]` cast kill 누적 (PR #135 Layer 1 selected 가드). base 의 MaxHealth/DamageHealth/Space Groove `TheGroove` 상태 미반영 4건 lint 후보 검출. Lint #5 잔존 (Bonk! Resists 40→45 base vs augment grant 미verify)
+- [[mordekaiser]] (모데카이저) — 2코스트 Tank (raw `APTank` → sim Tank), 암흑의 별 + 전달자 + 선봉대. base raw "불멸" InitialShield + 4초 매초 펄스 (본인 shield + 1칸 적 magic) + 만료 시 잔여 × 40% healRefund. ⭐ **가장 정합 base sim** — helper 통합 (`applyMordekaiserProcCast` + `tickMordekaiserProc`) + 별도 shield pool (`mordekaiserShieldRemaining`) + main/OOR cast parity + 전용 test. ⚠️ MordekaiserCarry 시 `mordekaiserCarryShield` carry data 우선 read (PR #124 lint #7 해소). 미반영 1건 (M1 `AugmentedDuration` Concentration augment 6초 확장)
 
 ## Items
 
@@ -68,7 +69,7 @@ selected-carry-augment 일반화 foundation + 광범위 selected 가드 적용 �
 2. **Lint #11-A/B (Jax) + #12 (Nasus) + #13 (Zed) sim 해소** — sim fix PR (필드 read 추가 vs 필드 dead 정리)
 3. **flag 자체 dead 정리** (`gragasCarryActive` / `leonaCarryActive`) — sim 코드 사용처 0, 테스트 assertion 만 (Lint #6/#8 후속)
 4. **Lint #10 cleanup** — `hero-augment-carry.md` 의 "Pyke onKill 미구현" stale 정정 (PR #131 에서 부분 정정, 후속 PR 로 더 깊이)
-5. **챔피언별** (set17 한정 — `public/data/tft_set17_champions.json` `TFT17_` prefix entries 로 ground truth 확인 필수, **한글 이름이 아닌 apiName 으로**) — Shen ✅ / Jax ✅ / Nasus ✅ / 다음: Zed (Lint #13 spec 대기), Poppy (Lint #5 측정 대기), Mordekaiser (mordekaiserCarryShield deprecate 연계), Galio (4코 메카 거대 메크 로봇 — 신규 plan 필요). ⚠️ Annie/Yasuo plan 파일은 이전 set 작업물 — set17 챔피언 아님 (2026-05-21 정정). ✅ **TFT17_Galio = 거대 메크 로봇 (4코 메카+여행자)** 으로 set17 챔피언 맞음 (codex PR #149 P2 정정) — 단 `galio-hero.plan.md` (5코 hero) 는 이전 set 작업물이라 직접 매핑 불가, 신규 plan 또는 raw 기반 ingest 필요
+5. **챔피언별** (set17 한정 — `public/data/tft_set17_champions.json` `TFT17_` prefix entries 로 ground truth 확인 필수, **한글 이름이 아닌 apiName 으로**) — Shen ✅ / Jax ✅ / Nasus ✅ / Mordekaiser ✅ / 다음: Zed (Lint #13 spec 대기), Poppy (Lint #5 측정 대기), Galio (4코 메카 거대 메크 로봇 — 신규 plan 필요), 블리츠크랭크 (5코 우주 그루브 carry). ⚠️ Annie/Yasuo plan 파일은 이전 set 작업물 — set17 챔피언 아님 (2026-05-21 정정). ✅ **TFT17_Galio = 거대 메크 로봇 (4코 메카+여행자)** 으로 set17 챔피언 맞음 (codex PR #149 P2 정정) — 단 `galio-hero.plan.md` (5코 hero) 는 이전 set 작업물이라 직접 매핑 불가, 신규 plan 또는 raw 기반 ingest 필요
 6. **Poppy/Nasus 인게임 verify 후 statOverrides 적용** (Lint #5 잔존 TODO — 사용자 측정 필요)
 7. **integration test** — LeonaCarry / GragasCarry / AatroxCarry sim 통합 (cycle counter / 적군 AOE / starLevel별 stun 등)
 8. **OOR cast path 의 cycle/x_shape 일관성 verify** — Aatrox/Pyke 페이지의 follow-up verify 항목 (PR #129 stun 같은 패턴 가능성)

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -8,6 +8,44 @@ format: newest first
 
 ## 2026-05-21
 
+### Ingest: champions/mordekaiser.md — 4번째 champion 페이지 (helper 통합 sim 가장 정합)
+
+- **Source** (0+5단계 워크플로우):
+  - `public/data/tft_set17_champions.json` (TFT17_Mordekaiser entry — 2코 암흑의 별+전달자+선봉대)
+  - `src/lib/simulator/systems/ability.ts:210` (abilityOverride `pattern: 'self_buff'` + helper 참조 comment)
+  - `src/lib/simulator/engine/combatLoop.ts:230-233/292` (state field 4개: mordekaiserProcEndTick / NextProcTick / ShieldRemaining + mordekaiserCarryShield)
+  - `src/lib/simulator/engine/combatLoop.ts:953-975` (`applyMordekaiserProcCast` — cast 진입 helper)
+  - `src/lib/simulator/engine/combatLoop.ts:990-1067` (`tickMordekaiserProc` — per-tick helper, 4 펄스 + 만료 healRefund)
+  - `src/lib/simulator/engine/combatLoop.ts:1213-1218` (별도 shield pool 우선 흡수 — HealRefund 정확 계산)
+  - `src/lib/simulator/engine/combatLoop.ts:7037 / :7185` (cast path parity — main + OOR 양쪽 helper 호출)
+  - `src/lib/simulator/engine/combatLoop.ts:5533` (per-tick 호출 site)
+  - `src/lib/simulator/engine/combatLoop.ts:2305-2312` (applyHeroCarryTransforms — MordekaiserCarry 활성 시 `mordekaiserCarryShield` carry data 저장, PR #124 lint #7 해소)
+  - 테스트: `tests/unit/mordekaiser-proc.test.ts` (전용) + `tests/unit/simulator/darkstar-execute-supermassive.test.ts:27+` (apMordekaiser 암흑의 별 fixture)
+
+- **Frontmatter 표준 (Jax/Nasus 따름)**:
+  - `role: Tank   # raw "APTank" → mapGameRole() → sim Tank` (3번째 base APTank champion — Jax/Nasus/Mordekaiser 모두 동일 매핑)
+  - `raw_role: APTank`
+  - `sim_active: active` ⭐ — base raw 메커니즘 가장 정합 (이전 Jax/Nasus 는 partial)
+
+- **신규 발견 — helper 통합 sim 의 효율성**:
+  - Mordekaiser 는 **가장 정합 base sim** (champion 페이지 4개 중 sim_active: active 첫 사례)
+  - 이유: cast 진입 helper + per-tick helper + 별도 shield pool + main/OOR cast parity + 전용 test 5 case
+  - Jax/Nasus 는 raw ability variables 의 starLevel별 / scaling 다수 미반영 → helper 부재 (단순 selfBuff/dot 매핑)
+  - Mordekaiser 는 raw vars `InitialShield/ShieldPerProc/DamagePerProc/HealRefund/Duration` 모두 `readVarByStar` 로 ★별 정확 read
+  - **인사이트**: base champion sim 정합도는 helper 존재 여부와 강한 상관관계 — champion ingest 가 helper 필요성 신호 (Jax/Nasus 도 helper 작성하면 sim 정합도 ↑)
+
+- **신규 lint 후보 1건만 등록** (champion ingest 발견):
+  - M1: `AugmentedDuration` (Concentration augment 활성 시 Duration 4→6초 펄스 +2회) 미반영
+  - 비교: Jax 5건, Nasus 4건 vs Mordekaiser 1건 — helper 통합 효과 입증
+  - Jax L1~L5 + Nasus N1~N4 + Mordekaiser M1 = 누적 10건 (champion ingest trigger)
+
+- **cleanup 후보 식별**:
+  - `mordekaiserCarryShield` 필드 deprecate 검토 — `selectedCarryAugment + carryCfg.abilityData?.shield` 로 derive 가능 (PR #147 xxxCarryActive deprecate 후속). 단 데이터 보유 (`null | number[]`) 라 단순 boolean flag 와 다른 work 필요
+
+- **wiki index.md 업데이트**:
+  - Champions 섹션에 Mordekaiser entry 추가 (Shen / Jax / Nasus / Mordekaiser 4개 완료)
+  - "작성 우선순위" 섹션 정렬 (Mordekaiser 완료 → Zed/Poppy/Galio/블리츠크랭크 후보)
+
 ### Ingest: champions/nasus.md — 3번째 champion 페이지 (Jax 표준 + carry semantics 강조)
 
 - **Source** (0+5단계 워크플로우):


### PR DESCRIPTION
## Summary
- **champions/mordekaiser.md** 신규 작성 — Jax/Nasus 표준 + helper 통합 sim 가장 정합 사례 강조
- raw role `APTank` → sim Tank ([[jax]] / [[nasus]] 와 동일 매핑, 3번째 base APTank champion)
- **⭐ sim_active: `active`** — champion 4개 중 첫 사례 (이전 Jax/Nasus 는 partial). base raw 메커니즘 가장 정합
- helper 통합 sim trace:
  - `applyMordekaiserProcCast` (`combatLoop.ts:953-975`) — cast 진입: InitialShield × AP → 별도 shield pool + proc state 3 field
  - `tickMordekaiserProc` (`combatLoop.ts:990-1067`) — per-tick: 4 펄스 (본인 shield + 1칸 적 magic) + 만료 시 HealRefund 40% currentHp 회복
  - 별도 shield pool 우선 흡수 (`combatLoop.ts:1213-1218`) — general unit.shield 분리 (HealRefund 정확 계산)
- **cast path parity**: main (`:7037`) + OOR (`:7185`) 양쪽 helper 호출 ([[ability-targeting]] cast path 3종 룰 일관)
- MordekaiserCarry 활성 시 `mordekaiserCarryShield` carry data 우선 read (PR #124 lint #7 해소)

## 0+5단계 워크플로우 적용
- **0단계 (apiName grep)** — `TFT17_Mordekaiser` 2코 ground truth 확인 (한글 매칭 금지, codex PR #149 P2 sub-rule)
- **1~3단계** — sim 23+ site + test 2 file 전수 식별 (helper 2개 + state 4 field + shield pool + carry data + dark star group + per-tick 호출)
- **4단계 cast path 3종** — main + OOR helper 호출 parity verify (self_buff + onKillRecast 없음 → recast 무관)
- **5단계** — shield pool 분리 / 사망 시 cleanup / 만료 처리 모두 sim 정합 verify

## Test plan
- [x] `pnpm lint` 통과
- [x] `pnpm typecheck` 통과
- [x] `pnpm build` 통과
- [x] entity-wide grep `Mordekaiser` + `mordekaiser` — 모든 sim site verify
- [x] cast path parity main + OOR 양쪽 verify
- [x] 별도 shield pool 우선 흡수 verify
- [x] 전용 test 회귀 가드 (`mordekaiser-proc.test.ts` + `darkstar-execute-supermassive.test.ts`)

## 신규 lint 후보 (champion ingest 가 발견)
| # | 항목 | 의미 |
|---|------|------|
| M1 | `AugmentedDuration` (Concentration augment 활성 시 Duration 4→6초) | 펄스 +2회 = ShieldPerProc + DamagePerProc 50% 추가 손실 |

**Jax L1~L5 + Nasus N1~N4 + Mordekaiser M1 = 누적 10건**. Mordekaiser 가 helper 통합으로 가장 적은 lint (1건) — **base champion sim 정합도는 helper 존재 여부와 강한 상관관계** 입증.

## cleanup 후보 식별
- `mordekaiserCarryShield` 필드 deprecate 검토 — `selectedCarryAugment === 'TFT17_Augment_MordekaiserCarry'` + `carryCfg.abilityData?.shield` 로 derive 가능 (PR #147 xxxCarryActive 후속). 단 데이터 보유 (`null | number[]`) 라 단순 boolean flag 와 다른 work 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)