### PR TITLE
docs(wiki): ingest verify 워크플로우 재설계 + mordekaiser P1-1 retro fix

### DIFF
--- a/.claude/agents/wiki-ingest-verifier.md
+++ b/.claude/agents/wiki-ingest-verifier.md
@@ -1,0 +1,147 @@
+---
+name: wiki-ingest-verifier
+description: TFT Domain Wiki ingest 직후 자동 dispatch 되는 lint subagent. champion / mechanic / carry-augment 페이지의 모든 fact·코드 참조·sim 효과 주장을 코드 ground truth (grep + 함수 read) 로 검증해 Tiered P0/P1/P2 finding 반환. 9건 누적 lint case 의 self-catch 0% 문제 해결 목적. **반드시 trigger**, champion ingest, mechanic page write, carry-augment edit, 위키 ingest 검증, wiki lint, champion 페이지 작성, mechanic 페이지 작성, carry augment 페이지 작성, set17 챔피언 위키, 카리 증강 페이지, TFT 위키 검증, 챔피언 위키 lint, ability cast path verify, starLevel verify, sim integration verify, wikipage check, ウィキ検証, チャンピオン検証, 维基检查, 冠军检查.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+# Wiki Ingest Verifier
+
+당신은 `docs/wiki/` 의 champion / mechanic / carry-augment 페이지에 대한 lint subagent 입니다. **read-only**. fix 는 main agent 책임 — 당신은 finding 만 보고하고 종료합니다.
+
+## Mission
+
+위키 ingest 9건 누적 lint case 가 **모두 Codex review 가 catch** (self-catch 0%). 본 subagent 는 사전 verify forcing function 으로 도입되어 다음 6 PR 내 self-catch rate ≥ 50% (P0 기준) 달성을 목표로 합니다.
+
+## 입력
+
+main agent 가 dispatch 시 다음 중 하나 또는 복수의 페이지 경로를 받습니다:
+
+- `docs/wiki/champions/<id>.md`
+- `docs/wiki/mechanics/<id>.md`
+- `docs/wiki/augments/<id>-carry.md` (carry augment 만 lint 대상, `*-carry.md` suffix 또는 본문에 carry semantic 명시 시)
+
+페이지 경로가 명시되지 않으면 main agent 에게 명확화 요청 후 종료.
+
+## 절대 룰셋: `docs/wiki/lint-rules.md`
+
+**dispatch 첫 단계로 반드시 `docs/wiki/lint-rules.md` 를 Read** 하여 최신 5단계 verify rule + entity-type checklist + 9건 사례 + Severity Tier 정의를 로드합니다. 본 prompt 와 룰셋이 충돌하면 **룰셋이 우선** (single source of truth).
+
+## 실행 절차
+
+1. **lint-rules.md Read** — single source of truth 로드
+2. **대상 페이지 Read** — frontmatter + 본문 전체
+3. **Entity type 판별**:
+   - path `champions/` → champion checklist 적용
+   - path `mechanics/` → mechanic checklist 적용
+   - path `augments/` + 본문 carry semantic → carry-augment checklist 적용
+4. **5단계 + 0단계 verify 수행**:
+   - 0 set 소속 / 1 좁은 grep / 2 함수 컨텍스트 / 3 entity-wide grep / 4 호출 순서 (+ cast path 3종 sub-rule) / 5 actual integration verify
+   - 각 단계마다 코드 grep / 함수 read 결과를 finding 의 근거로 인용
+5. **Entity-type 별 추가 checklist 적용** — lint-rules.md 의 entity-type 표 참조
+6. **Tiered finding 분류** — P0 / P1 / P2 (Severity Tier 정의는 lint-rules.md)
+7. **Output 보고** — 아래 형식 준수
+
+## 출력 형식 (반드시 준수)
+
+```markdown
+## Lint Result: <page-path>
+
+**Entity type**: <champion | mechanic | carry-augment>
+**Verify 수행 단계**: 0 ✅ / 1 ✅ / 2 ✅ / 3 ✅ / 4 ✅ / 4-sub cast path ✅ / 5 ✅
+**총 finding**: P0 <N> / P1 <M> / P2 <K>
+
+### P0 (commit 전 fix 필수)
+
+#### P0-1. <Finding name>
+- **위치**: 본문 line ~XX 또는 섹션 헤딩
+- **주장**: "<인용>"
+- **검증**:
+  - `grep -n "<pattern>" <path>` → <결과>
+  - `<src/...:functionName>` 함수 read → <발견 사실>
+- **회귀 위험**: <sim 영향. cast path / range / starLevel / item 손실 등 명시>
+- **권장 fix**: <action>
+
+#### P0-2. ...
+
+### P1 (follow-up 허용, 본 PR 가능하면 fix)
+
+(동일 형식)
+
+### P2 (다음 사이클)
+
+(동일 형식)
+
+### Self-verify check
+
+- 9건 lint history 의 어떤 패턴과 유사한가? (해당 시 #번호 인용)
+- 본 lint 가 놓쳤을 가능성이 있는 영역: <명시>
+```
+
+## 핵심 패턴 (lint-rules.md 보강)
+
+dispatch 시 다음 grep 패턴을 entity type 별로 우선 수행:
+
+### Champion
+
+```bash
+# 0단계 — set17 소속
+grep -n "TFT17_<id>" public/data/tft_set17_champions.json
+
+# 3단계 — entity-wide multi-source helper
+grep -rn "<ChampionName>" src/lib/simulator/
+
+# 1단계 — carry augment entry
+grep -rn "<ChampionName>Carry" src/lib/simulator/
+
+# 5단계 — starLevel별 main pipeline read
+grep -n "abilityData\.<field>\|carryCfg\?\.abilityData\?\.<field>" src/lib/simulator/engine/combatLoop.ts
+
+# 4-sub — cast path 3종
+grep -n "config\.<field>\|outOfRangeConfig\.<field>\|recastConfig\.<field>" src/lib/simulator/engine/combatLoop.ts
+```
+
+### Mechanic
+
+```bash
+# 1단계 — 트리거 식별자
+grep -rn "<trigger-identifier>" src/lib/simulator/
+
+# 2단계 — 함수 컨텍스트
+# grep hit line ± 50 line read 또는 함수 전체 read
+```
+
+### Carry augment
+
+```bash
+# 3단계 — entity-wide grep (entry 외 helper)
+grep -rn "<EntityName>" src/lib/simulator/
+
+# 1단계 — entry
+grep -n "<EntityName>Carry" src/lib/simulator/carryAugments.ts
+```
+
+## 금지 사항
+
+- ❌ **Edit / Write tool 사용 금지** — fix 는 main agent 책임. 당신은 read-only lint
+- ❌ **lint-rules.md 룰을 우회한 자체 판단** — 룰셋이 single source. 룰 갱신이 필요하다면 P2 finding 으로 "룰 추가 권장" 보고
+- ❌ **CLAUDE.md / 다른 wiki 페이지 / docs/meta/ 의 plan·audit 인용으로 fact 검증** — 반드시 코드 ground truth (`src/...:identifier`) 또는 raw json
+- ❌ **한글 이름 list 만으로 set 소속 검증** — apiName grep 필수
+- ❌ **좁은 식별자 grep 한 줄만 보고 fact 단정** — 함수 컨텍스트 read 또는 entity-wide grep 으로 multi-source 확인
+- ❌ **"abilityData 에 정의됨" → "sim 적용됨" 결론** — main pipeline read site 까지 trace 필수
+- ❌ **Cast 관련 finding 시 cast path 1개 (main) 만 확인** — main / OOR / recast 3종 전수
+- ❌ **Pass/fail 단순 판정** — 모든 finding 은 P0/P1/P2 tier + 근거 (grep 결과) + 권장 fix 동반
+
+## False-positive 방지
+
+- 본문에 이미 "🔍 sim 효과 검증 필요" / "Lint #X (pending)" / "측정 대기" 등 명시적 보류 표기 있는 항목은 **P0 → P2** 로 downgrade
+- 본문에 PR 번호 (`#XYZ`) 와 함께 "resolved" / "applied" 표기된 항목은 grep 으로 실제 적용 verify. 적용됐으면 finding 아님
+
+## 종료 조건
+
+- 모든 finding 보고 + Self-verify check 작성 → main agent 에게 result 반환 후 종료
+- 결정 보류 / 추가 정보 필요 시 → main agent 에게 명확화 요청 (P2 finding 로 노트)
+
+---
+
+**Reminder**: 당신의 가치는 *Codex review 가 잡기 전에* 같은 패턴을 catch 하는 것입니다. 9건 사례 중 자신과 유사한 패턴이 있으면 반드시 명시적으로 self-verify 섹션에 인용하세요.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bkit
-.claude
+.claude/*
+!.claude/agents/
 .worktrees
 .next
 .superpowers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,3 +204,35 @@ MVP에서 제외하는 것:
 - 시뮬레이션 엔진은 UI 레이어와 완전히 분리되어야 한다
 - Replay 정확성을 위해 엔진에 `Math.random()` 직접 사용 금지 — seed 기반 난수 생성기를 통해서만 사용
 - `console.log` 커밋 금지
+
+---
+
+## TFT Domain Wiki Ingest 검증
+
+`docs/wiki/` 에 champion / mechanic / carry-augment 페이지를 작성·수정할 때 누적된 9건 lint case 가 모두 Codex review 가 catch 했다 (self-catch 0%). 사전 verify forcing function 으로 `wiki-ingest-verifier` subagent 를 도입한다.
+
+### Dispatch 규칙 (필수)
+
+다음 경로의 파일을 **write 또는 edit 직후 commit 전** 에 반드시 `wiki-ingest-verifier` subagent 를 dispatch 한다.
+
+- `docs/wiki/champions/*.md` (모든 champion 페이지)
+- `docs/wiki/mechanics/*.md` (모든 mechanic 페이지)
+- `docs/wiki/augments/*-carry.md` (carry augment 만, 일반 augment 제외)
+
+### Dispatch 호출 예시
+
+```
+Agent (subagent_type=wiki-ingest-verifier) — dispatch with page paths
+```
+
+Subagent 는 read-only. P0/P1/P2 finding 을 tiered 로 반환하며, **P0 finding 은 commit 전 반드시 fix**. P1 은 본 PR 내 가능하면 fix, P2 는 다음 사이클 허용.
+
+### Single source of truth
+
+- 룰셋: `docs/wiki/lint-rules.md` — 5단계 verify rule + entity-type checklist + 9건 lint history + Severity Tier 정의. 룰 진화 시 본 파일만 수정 (git diff 추적).
+- Subagent: `.claude/agents/wiki-ingest-verifier.md` — lint-rules.md 를 dispatch 첫 단계에서 Read 하여 룰 로드.
+- 메모리 `feedback_wiki_ingest_verify` (user-local) — main agent 작성 워크플로우 (positive verify). lint subagent (negative verify) 와 책임 분리.
+
+### 평가
+
+다음 6 PR 후 `docs/wiki/lint-rules.md` 의 Self-catch Metric 표 업데이트. Target: **self-catch / (self-catch + Codex) ≥ 50%** (P0 기준). 미달 시 subagent prompt 강화 / 룰 추가.

--- a/docs/wiki/champions/mordekaiser.md
+++ b/docs/wiki/champions/mordekaiser.md
@@ -12,7 +12,7 @@ role: Tank   # raw "APTank" → mapGameRole() → sim Tank. ⚠️ MordekaiserCa
 raw_role: APTank
 current_patch_status: active
 sim_active: active   # base raw 메커니즘 거의 완성 (helper 2개 + 별도 shield pool + healRefund + main/OOR cast parity)
-last_verified: 2026-05-21
+last_verified: 2026-05-26
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Mordekaiser entry)"
   - "src/lib/simulator/systems/ability.ts:210 (abilityOverride pattern 'self_buff' + comment helper 참조)"
@@ -25,6 +25,9 @@ sources:
   - "src/lib/simulator/engine/combatLoop.ts:5533 (tickMordekaiserProc — combat loop per-tick 호출)"
   - "src/lib/simulator/engine/combatLoop.ts:7037 / :7185 (applyMordekaiserProcCast — main + OOR cast path 양쪽 호출, cast path parity)"
   - "src/lib/simulator/engine/combatLoop.ts:2305-2312 (applyHeroCarryTransforms — MordekaiserCarry 활성 시 mordekaiserCarryShield carry data 저장)"
+  - "src/lib/simulator/engine/combatLoop.ts:524-529 (전달자/Channeler TFT17_ManaTrait InnateManaGain → unit.channelerInnateManaGain 설정)"
+  - "src/lib/simulator/engine/combatLoop.ts:5549 (channelerMult — 매 tick mana gain × (1 + channelerInnateManaGain))"
+  - "src/lib/simulator/systems/mana.ts:36-41 (channelerInnateManaGain 곱셈자 helper)"
   - "tests/unit/mordekaiser-proc.test.ts (applyMordekaiserProcCast + tickMordekaiserProc 전용 test)"
   - "tests/unit/simulator/darkstar-execute-supermassive.test.ts:27+ (apMordekaiser 암흑의 별 fixture)"
 related:
@@ -99,7 +102,7 @@ TFT17_Mordekaiser: { pattern: 'self_buff' },  // 헬퍼가 메인 처리
 ### Trait — 암흑의 별(Dark Star) + 전달자 + 선봉대(Vanguard)
 
 - **암흑의 별 (Dark Star)** — `combatLoop.ts:2041` 6 챔프 그룹: Kaisa / Karma / Jhin / Chogath / Lissandra / **Mordekaiser**. Set 17 신규 시너지 — execute / supermassive 메커니즘 (`darkstar-execute-supermassive.test.ts` 27+ apMordekaiser fixture)
-- **전달자** — 시너지 stat 보강 분기 (Tank 보조)
+- **전달자 (Channeler, `TFT17_ManaTrait`)** — 활성 시 전달자 unit 의 mana gain 곱셈자. `combatLoop.ts:524-529` `InnateManaGain` (raw 0.20) → `unit.channelerInnateManaGain`. 매 tick mana 가산 시 `combatLoop.ts:5549` `channelerMult = 1 + channelerInnateManaGain` 적용 (`augmentManaRegen` 도 곱셈 적용, codex P1 PR #64). Tank stat 보강 아님 — **mana regen 곱셈** (`mana.ts:36-41` helper)
 - **선봉대 (Vanguard)** — `applyVanguardEffects` (`combatLoop.ts:4664`) 전투 시작 시 보호막 (tick=0). Tank role 보강
 
 ## MordekaiserCarry 변환 시 (참조)
@@ -138,24 +141,20 @@ MordekaiserCarry augment 활성 시:
 - MordekaiserCarry 활성 시 `mordekaiserCarryShield` carry data 우선 read (PR #124 lint #7 해소)
 
 ❌ **미반영**:
-- **`AugmentedDuration` (Concentration augment 활성 시 Duration 4→6초)** — `TFT17_Augment_Concentration` augment 활성 시 펄스 +2회 (6 펄스). sim 분기 없음
-- 전달자 (Transmitter?) trait 효과 — sim 별도 분기 verify 필요
+- **`AugmentedDuration` (Concentration augment 활성 시 Duration 4→6초)** — `TFT17_Augment_Concentration` augment 활성 시 펄스 +2회 (6 펄스). sim 분기 없음. ⚠️ `public/data/tft_set17_augments.json:83-102` 에서 해당 augment `"disable": true` (set17 inactive) — 본 미반영의 실제 sim 영향 0, M1 lint 자동 무효 (retro lint pilot 2026-05-26)
 
 🔍 **검증 필요**:
-- 전달자 trait 의 정확한 효과 (Tank 보조 / stat 보강 등) — sim 통합 위치 verify 필요
 - `mordekaiserCarryShield` 의 cleanup 가능성 — `selectedCarryAugment + carryCfg.abilityData.shield` 로 derive 가능 여부 (PR #147 후속 후보)
 
 ## Lint 신규 등록 후보 (champion ingest 발견)
 
 본 페이지 작성 중 **base Mordekaiser** sim 미반영 1건 검출:
 
-| # | 항목 | 의미 |
-|---|------|------|
-| M1 | `AugmentedDuration` 6초 (Concentration augment 활성 시) | 펄스 +2회 = ShieldPerProc + DamagePerProc 50% 추가 손실 |
+| # | 항목 | 의미 | 상태 |
+|---|------|------|------|
+| M1 | `AugmentedDuration` 6초 (Concentration augment 활성 시) | 펄스 +2회 = ShieldPerProc + DamagePerProc 50% 추가 손실 | ✅ 자동 무효 — Concentration augment `disable: true` set17 inactive (retro lint pilot 2026-05-26 verify) |
 
-⚠️ **우선순위 평가**: Concentration augment 자체가 set17 active 여부 별도 verify 필요. inactive 시 본 lint 자동 무효. 활성 augment 면 +50% 펄스 손실 큼.
-
-**Jax L1~L5 + Nasus N1~N4 + Mordekaiser M1 = base champion 미반영 lint 10건 누적** — Mordekaiser 는 가장 정합 (1건만 검출) → helper 통합 sim 의 효율성 입증.
+**Jax L1~L5 + Nasus N1~N4 + Mordekaiser M1 (자동 무효) = base champion 미반영 lint 9건 활성 + 1건 무효** — Mordekaiser 는 가장 정합 (검출 1건도 augment inactive 로 자동 무효) → helper 통합 sim 의 효율성 입증.
 
 ## Lint 체크리스트
 
@@ -167,10 +166,10 @@ MordekaiserCarry augment 활성 시:
 - [x] **cast path 3종** — main (`combatLoop.ts:7037`) + OOR (`:7185`) 양쪽 `applyMordekaiserProcCast` 호출 parity verify. recast 무관 (self_buff 패턴 + onKillRecast 없음)
 - [x] 별도 shield pool (`mordekaiserShieldRemaining`) general unit.shield 와 분리 — HealRefund 정확 계산 verify
 - [x] 사망 시 proc cleanup verify (`tickMordekaiserProc` line 1004-1009)
-- [ ] (사용자 verify) Concentration augment 활성 set17 여부 + `AugmentedDuration` sim 통합 결정
-- [ ] (사용자 verify) 전달자 trait 효과 + sim 통합 위치
+- [x] **전달자 (Channeler, `TFT17_ManaTrait`) trait 효과 verify** — `combatLoop.ts:524-529` + `:5549` + `mana.ts:36-41` mana gain 곱셈자 (`InnateManaGain=0.20` raw) integration 완료. Tank stat 보강 아님 (retro lint pilot 2026-05-26 catch)
+- [x] **Concentration augment `disable: true` verify** — `tft_set17_augments.json:83-102` `"disable": true` set17 inactive. M1 lint 자동 무효
 - [ ] (선택) `mordekaiserCarryShield` cleanup 가능성 평가 (selectedCarryAugment + carryCfg derive)
-- [ ] (선택) Lint M1 정식 등록 — Jax L1~L5 + Nasus N1~N4 와 묶음 평가
+- [ ] (선택) Lint M1 정식 등록 보류 — Concentration disable 으로 자동 무효, 추후 augment 재활성 시만 의미
 
 ## 관련
 

--- a/docs/wiki/champions/mordekaiser.md
+++ b/docs/wiki/champions/mordekaiser.md
@@ -1,0 +1,184 @@
+---
+id: mordekaiser
+type: champion
+display_name_kr: 모데카이저
+api_name: TFT17_Mordekaiser
+cost: 2
+traits:
+  - 암흑의 별
+  - 전달자
+  - 선봉대
+role: Tank   # raw "APTank" → mapGameRole() → sim Tank. ⚠️ MordekaiserCarry augment 활성 시 Fighter 로 변환 (applyHeroCarryTransforms) — base 의 helper 메커니즘은 carry 활성 여부와 무관 동작 (mordekaiserCarryShield 만 InitialShield override)
+raw_role: APTank
+current_patch_status: active
+sim_active: active   # base raw 메커니즘 거의 완성 (helper 2개 + 별도 shield pool + healRefund + main/OOR cast parity)
+last_verified: 2026-05-21
+sources:
+  - "public/data/tft_set17_champions.json (TFT17_Mordekaiser entry)"
+  - "src/lib/simulator/systems/ability.ts:210 (abilityOverride pattern 'self_buff' + comment helper 참조)"
+  - "src/lib/simulator/engine/combatLoop.ts:230-233 (mordekaiser proc state field 3개 + mordekaiserShieldRemaining default)"
+  - "src/lib/simulator/engine/combatLoop.ts:292 (mordekaiserCarryShield: null default — carry data 보유 필드)"
+  - "src/lib/simulator/engine/combatLoop.ts:953-975 (applyMordekaiserProcCast — InitialShield × AP → shield pool + proc state 등록)"
+  - "src/lib/simulator/engine/combatLoop.ts:990-1067 (tickMordekaiserProc — 매초 펄스 + 만료 healRefund)"
+  - "src/lib/simulator/engine/combatLoop.ts:1213-1218 (mordekaiserShieldRemaining 별도 pool 우선 흡수)"
+  - "src/lib/simulator/engine/combatLoop.ts:2041 (암흑의 별 6 챔프 — Kaisa/Karma/Jhin/Chogath/Lissandra/Mordekaiser)"
+  - "src/lib/simulator/engine/combatLoop.ts:5533 (tickMordekaiserProc — combat loop per-tick 호출)"
+  - "src/lib/simulator/engine/combatLoop.ts:7037 / :7185 (applyMordekaiserProcCast — main + OOR cast path 양쪽 호출, cast path parity)"
+  - "src/lib/simulator/engine/combatLoop.ts:2305-2312 (applyHeroCarryTransforms — MordekaiserCarry 활성 시 mordekaiserCarryShield carry data 저장)"
+  - "tests/unit/mordekaiser-proc.test.ts (applyMordekaiserProcCast + tickMordekaiserProc 전용 test)"
+  - "tests/unit/simulator/darkstar-execute-supermassive.test.ts:27+ (apMordekaiser 암흑의 별 fixture)"
+related:
+  - "[[role-passive]]"
+  - "[[ability-targeting]]"
+  - "[[hero-augment-carry]]"
+  - "[[mordekaiser-carry]]"
+  - "[[shen]]"
+  - "[[jax]]"
+  - "[[nasus]]"
+---
+
+# 모데카이저 (Mordekaiser)
+
+## 요약
+
+2코스트 **Tank** (raw `APTank` → `mapGameRole()` → sim Tank, [[role-passive]]), 암흑의 별(Dark Star) + 전달자 + 선봉대(Vanguard) 시너지. raw 어빌리티 "불멸" — InitialShield 부여 + 4초 동안 매초 (본인 shield +N + 인접 적 magic damage) 펄스 + 종료 시 잔여 shield × 40% healRefund.
+
+[[mordekaiser-carry]] (뜨거운 죽음 / Heat Death) augment 활성 시 가장 강한 Mordekaiser 1명이 **Fighter 로 변환** + `mordekaiserCarryShield` carry data 저장 + statOverrides `mana 10/40`. 본 페이지는 **base raw Mordekaiser** 의 sim 동작을 다루며, carry 변환 사항은 [[mordekaiser-carry]] 참조.
+
+> ⚠️ Role 주의 — base vs carry: raw role `APTank` → sim **Tank** (weight 3, 공격당 마나 5, 피격 시 마나 ✅). **MordekaiserCarry augment 활성 시** `applyHeroCarryTransforms` 가 `target.role = 'Fighter'` overwrite → Fighter 룰 ([[jax]] / [[nasus]] 와 동일 패턴). 단 **proc helper 자체는 carry 활성 여부와 무관 동작** — base sim 이 helper 통합 (cast 진입 시점 + tick 처리) 라 carry 활성 시 `mordekaiserCarryShield` 만 InitialShield override 로 작용 (PR #124 lint #7 해소).
+
+## 메커니즘 (base raw, helper 통합 sim)
+
+### Stats (raw, 17.3 LIVE)
+
+| Stat | 값 |
+|------|---|
+| hp | 950 |
+| armor / magicResist | 45 / 45 |
+| damage | 40 |
+| attackSpeed | 0.6 |
+| range | 1 (melee) |
+| critChance / critMultiplier | 0.25 / 1.4 |
+| initialMana / mana | 40 / 100 |
+
+### Active — 불멸 (Immortal)
+
+raw 명세: "`@ModifiedInitialShield@(scaleAP)`의 보호막을 얻습니다. 다음 `@Duration@`초 (`@AugmentedDuration@` if Concentration) 동안 매초 `@ModifiedShieldPerProc@(scaleAP)`의 보호막을 더 얻고 인접한 적에게 `@ModifiedDamagePerProc@(scaleAP)`의 마법 피해를 입힙니다. 이 스킬이 끝나면 남은 보호막을 소모하고 보호막 수치의 `@HealRefund*100@%`만큼 체력을 회복합니다."
+
+→ **4단계 효과** (모두 sim 적용 ✅): (1) 즉시 InitialShield × (1+AP/100) 부여, (2) Duration (기본 4s) 동안 매초 펄스 = 본인 ShieldPerProc + 1칸 적 DamagePerProc magic, (3) Duration 만료 시 잔여 shield × HealRefund (40%) × (1+healAmp) currentHp 회복, (4) `mordekaiserShieldRemaining` 별도 pool 로 unit.shield 와 분리 (HealRefund 정확 계산).
+
+**sim 적용** (`ability.ts:210` + 헬퍼 2개):
+```ts
+TFT17_Mordekaiser: { pattern: 'self_buff' },  // 헬퍼가 메인 처리
+```
+
+| 단계 | 코드 위치 | 동작 |
+|------|----------|------|
+| cast 시점 (main pipeline) | `combatLoop.ts:7037` `applyMordekaiserProcCast(unit, tick)` | InitialShield × AP → `mordekaiserShieldRemaining` 누적. `mordekaiserProcEndTick = tick + Duration × TICKS_PER_SECOND`. `mordekaiserNextProcTick = tick + TICKS_PER_SECOND` (첫 펄스 t=1) |
+| cast 시점 (OOR cast path) | `combatLoop.ts:7185` 동일 helper 호출 | **main + OOR parity** (cast path 3종 룰 일관 — [[ability-targeting]]) |
+| 매 tick 처리 | `combatLoop.ts:5533` `tickMordekaiserProc(unit, ...)` | 펄스 발동 + 만료 처리 (사망 시 cancel + cleanup) |
+| 펄스 발동 (`t = mordekaiserNextProcTick ~ ProcEndTick`) | `combatLoop.ts:1016-1052` | 1칸 적 → DamagePerProc × AP magic (`applyAbilityMitigation` 표준 통과 + per-target damageAmp + tank amp 3종 + sniper). 본인 → ShieldPerProc × AP shield pool 누적. nextProcTick += TICKS_PER_SECOND |
+| 만료 (`t >= ProcEndTick`) | `combatLoop.ts:1055-1066` | `heal = mordekaiserShieldRemaining × HealRefund (0.4) × (1+healAmp)` → `currentHp` 회복. shield pool reset 0 |
+| 별도 shield pool 흡수 | `combatLoop.ts:1213-1218` | damage 가 mitigation 통과 후 `mordekaiserShieldRemaining > 0` 시 우선 흡수 (general `unit.shield` 와 분리 — HealRefund 잔여 정확 계산) |
+
+### raw ability variables (★1~★5 — 첫 값 sentinel filler)
+
+| 변수 | raw 값 | sim 적용 | 비고 |
+|------|--------|---------|------|
+| `InitialShield` | `[0, 300, 375, 500, 650, 200, 240]` ★1=300, ★2=375, ★3=500, ★4=650 | ✅ `applyMordekaiserProcCast` line 962-966 `readVarByStar` (sentinel 0 처리) | MordekaiserCarry 활성 시 `mordekaiserCarryShield` 우선 read (PR #124 lint #7 해소) |
+| `Duration` | `[4,4,4,4,4,4,4]` (전부 4초) | ✅ `applyMordekaiserProcCast` line 967-969 | base 동작 — `AugmentedDuration` (Concentration augment 활성 시 6초) 는 별도 미반영 |
+| `ShieldPerProc` | `[0, 75, 90, 105, 120, 0, 0]` ★1=75, ★2=90, ★3=105, ★4=120 | ✅ `tickMordekaiserProc` line 1020-1022 매 펄스 read | shield × (1+AP/100) 누적 |
+| `DamagePerProc` | `[0, 45, 70, 100, 170, 0, 0]` ★1=45, ★2=70, ★3=100, ★4=170 | ✅ `tickMordekaiserProc` line 1017-1019 매 펄스 read | 1칸 내 적 magic damage (per-target amp + sniper + mitigation 표준) |
+| `HealRefund` | `[0.4,...]` 전부 40% | ✅ `tickMordekaiserProc` line 1056-1058 만료 시 read | `mordekaiserShieldRemaining × 0.4 × (1+healAmp)` → currentHp |
+| `AugmentedDuration` | `[6,6,6,6,6,6,6]` Concentration augment 활성 시 | ❌ **미반영** | `TFT17_Augment_Concentration` augment (집중) 활성 시 Duration 4→6초로 확장. sim 분기 없음 |
+
+### 펄스 카운트 = 4 (`tick <= ProcEndTick` 포함)
+
+`tickMordekaiserProc` line 1016 의 `tick <= ProcEndTick` (≤) 조건으로 t=4 펄스 발동 + 만료 동시 처리. 4 펄스 정확 (`mordekaiser-proc.test.ts` 검증).
+
+### Trait — 암흑의 별(Dark Star) + 전달자 + 선봉대(Vanguard)
+
+- **암흑의 별 (Dark Star)** — `combatLoop.ts:2041` 6 챔프 그룹: Kaisa / Karma / Jhin / Chogath / Lissandra / **Mordekaiser**. Set 17 신규 시너지 — execute / supermassive 메커니즘 (`darkstar-execute-supermassive.test.ts` 27+ apMordekaiser fixture)
+- **전달자** — 시너지 stat 보강 분기 (Tank 보조)
+- **선봉대 (Vanguard)** — `applyVanguardEffects` (`combatLoop.ts:4664`) 전투 시작 시 보호막 (tick=0). Tank role 보강
+
+## MordekaiserCarry 변환 시 (참조)
+
+MordekaiserCarry augment 활성 시:
+- `applyHeroCarryTransforms` (`combatLoop.ts:2258-2312`): `target.role = 'Fighter'` + `target.selectedCarryAugment = 'TFT17_Augment_MordekaiserCarry'`
+- **statOverrides 적용** (`mana 10/40`) — `applyHeroCarryTransforms` 가 item delta 보존하며 적용 (Tear/Blue Buff 등 mana item bonus 위에 누적, PR #124 codex P2 정합)
+- **`mordekaiserCarryShield` carry data 저장** (`combatLoop.ts:2306-2311`) — `cfg.abilityData?.shield` (17.3 `[175, 200, 400]`) → `applyMordekaiserProcCast` 가 raw `InitialShield` 대신 우선 read (PR #124 lint #7 해소)
+- **helper 자체는 동일 동작** — proc system (cast 진입 + tick 처리 + shield pool + healRefund) 그대로 작동 (base raw 구현이 carry 와 통합)
+
+상세 cast path / 패치 변경 / lint history 는 [[mordekaiser-carry]] 참조.
+
+⚠️ **메모리 cleanup 후보**: `mordekaiserCarryShield` 필드는 `selectedCarryAugment === 'TFT17_Augment_MordekaiserCarry'` + `carryCfg.abilityData?.shield` 로 derive 가능 (불필요한 unit field). PR #144 selected-single-carry 일반화 후속으로 deprecate 검토 가능 — 단 현재 필드는 `null | number[]` 데이터 보유라 단순 boolean flag deprecate (PR #147 xxxCarryActive) 와 다른 work 필요.
+
+## 패치 히스토리 (base raw)
+
+| 패치 | 변경 |
+|------|------|
+| 17.2~17.3 base | raw stats / InitialShield / Duration / ShieldPerProc / DamagePerProc / HealRefund 별도 변경 검출 없음 (patch wiki 의 Mordekaiser 항목은 모두 MordekaiserCarry 한정) |
+
+## sim 적용 상태 — `active`
+
+✅ **활성** (base raw helper 통합):
+- stats 17.3 정합 (hp 950, armor/MR 45, AS 0.6, mana 40/100, range 1)
+- ability override `pattern: 'self_buff'` + helper 통합 (applyMordekaiserProcCast + tickMordekaiserProc)
+- InitialShield × AP → 별도 shield pool (`mordekaiserShieldRemaining`)
+- 4초 동안 매초 펄스 (4 펄스): ShieldPerProc 본인 + DamagePerProc 1칸 적 magic
+- 매 펄스 per-target damageAmp + tank amp 3종 (invention/madreds/graves) + sniper + mitigation pipeline 표준
+- 만료 시 HealRefund 40% × (1+healAmp) → currentHp 회복
+- 사망 시 proc cancel + state cleanup (잔여 shield 무효)
+- **cast path parity**: main + OOR 양쪽 `applyMordekaiserProcCast` 호출 ([[ability-targeting]] cast path 3종 룰 일관)
+- 별도 shield pool 우선 흡수 (general `unit.shield` 와 분리 — HealRefund 정확 계산)
+- 암흑의 별 (Dark Star) 6 챔프 그룹 멤버 (`combatLoop.ts:2041`)
+- 선봉대 (Vanguard) `applyVanguardEffects` 보호막 (tick=0)
+- 전용 test 2 file 회귀 가드 (`mordekaiser-proc.test.ts` + `darkstar-execute-supermassive.test.ts`)
+- MordekaiserCarry 활성 시 `mordekaiserCarryShield` carry data 우선 read (PR #124 lint #7 해소)
+
+❌ **미반영**:
+- **`AugmentedDuration` (Concentration augment 활성 시 Duration 4→6초)** — `TFT17_Augment_Concentration` augment 활성 시 펄스 +2회 (6 펄스). sim 분기 없음
+- 전달자 (Transmitter?) trait 효과 — sim 별도 분기 verify 필요
+
+🔍 **검증 필요**:
+- 전달자 trait 의 정확한 효과 (Tank 보조 / stat 보강 등) — sim 통합 위치 verify 필요
+- `mordekaiserCarryShield` 의 cleanup 가능성 — `selectedCarryAugment + carryCfg.abilityData.shield` 로 derive 가능 여부 (PR #147 후속 후보)
+
+## Lint 신규 등록 후보 (champion ingest 발견)
+
+본 페이지 작성 중 **base Mordekaiser** sim 미반영 1건 검출:
+
+| # | 항목 | 의미 |
+|---|------|------|
+| M1 | `AugmentedDuration` 6초 (Concentration augment 활성 시) | 펄스 +2회 = ShieldPerProc + DamagePerProc 50% 추가 손실 |
+
+⚠️ **우선순위 평가**: Concentration augment 자체가 set17 active 여부 별도 verify 필요. inactive 시 본 lint 자동 무효. 활성 augment 면 +50% 펄스 손실 큼.
+
+**Jax L1~L5 + Nasus N1~N4 + Mordekaiser M1 = base champion 미반영 lint 10건 누적** — Mordekaiser 는 가장 정합 (1건만 검출) → helper 통합 sim 의 효율성 입증.
+
+## Lint 체크리스트
+
+- [x] **set17 entity 소속 0단계** — `public/data/tft_set17_champions.json` `TFT17_Mordekaiser` apiName grep 확인 (한글 매칭 금지)
+- [x] entity-wide grep `Mordekaiser` + `mordekaiser` — sim 23+ site + test 2 file 전수 식별 (helper 2개 + state 3 field + shield pool + carry data field + dark star group + per-tick 호출)
+- [x] raw stats 17.3 정합
+- [x] **raw role `APTank` → mapGameRole → sim Tank** ([[jax]] / [[nasus]] 와 동일 매핑 — 3번째 base APTank champion)
+- [x] MordekaiserCarry 변환 시 role overwrite `Fighter` + `mordekaiserCarryShield` carry data 저장 (lint #7 해소)
+- [x] **cast path 3종** — main (`combatLoop.ts:7037`) + OOR (`:7185`) 양쪽 `applyMordekaiserProcCast` 호출 parity verify. recast 무관 (self_buff 패턴 + onKillRecast 없음)
+- [x] 별도 shield pool (`mordekaiserShieldRemaining`) general unit.shield 와 분리 — HealRefund 정확 계산 verify
+- [x] 사망 시 proc cleanup verify (`tickMordekaiserProc` line 1004-1009)
+- [ ] (사용자 verify) Concentration augment 활성 set17 여부 + `AugmentedDuration` sim 통합 결정
+- [ ] (사용자 verify) 전달자 trait 효과 + sim 통합 위치
+- [ ] (선택) `mordekaiserCarryShield` cleanup 가능성 평가 (selectedCarryAugment + carryCfg derive)
+- [ ] (선택) Lint M1 정식 등록 — Jax L1~L5 + Nasus N1~N4 와 묶음 평가
+
+## 관련
+
+- [[role-passive]] — Tank role 마나/타게팅 규칙 (base raw 적용)
+- [[ability-targeting]] — `self_buff` 패턴 + cast path 3종
+- [[hero-augment-carry]] — MordekaiserCarry 변환 시 role/stat/ability override 시스템
+- [[mordekaiser-carry]] — MordekaiserCarry augment 페이지 (Heat Death + lint #7 history)
+- [[jax]] / [[nasus]] — 동일 raw `APTank` → Tank 매핑 + augment 시 Fighter overwrite 패턴 (3 챔프 누적)
+- [[shen]] — 다른 raw role 변형 사례 (APFighter → Fighter, augment 무관)
+- 코드: `src/lib/simulator/systems/ability.ts:210`, `src/lib/simulator/engine/combatLoop.ts:953/990/1213/2306/5533/7037/7185`
+- 테스트: `tests/unit/mordekaiser-proc.test.ts` (전용) / `tests/unit/simulator/darkstar-execute-supermassive.test.ts:27+`

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,7 +1,7 @@
 ---
 name: TFT Domain Wiki — Index
 purpose: 위키 전체 페이지 카탈로그 (content-oriented)
-updated: 2026-05-21 (PR #150 nasus.md)
+updated: 2026-05-21 (PR #151 mordekaiser.md)
 ---
 
 # TFT Domain Wiki — Index
@@ -31,6 +31,7 @@ updated: 2026-05-21 (PR #150 nasus.md)
 - [[shen]] (쉔) — 5코스트 Fighter (raw `APFighter`, sim mapGameRole → Fighter), 보루 + 요새 trait. cast 마다 `shenPassiveStack++` 누적 + 평타 시 stack × BonusDamage 추가 (3+ true damage). 17.3 nerf (45/75 → 20/30) + maxHp/ShieldHP buff 정합
 - [[jax]] (잭스) — 2코스트 Tank (raw `APTank` → sim Tank), 별돌보미 + 요새. base raw "별의 반격" 3초 방어 태세 + AOE+stun. ⚠️ JaxCarry augment 활성 시 role=Fighter 로 변환 (augment 가 role 자체 변경, [[shen]] 과 다른 패턴). base 의 ShieldAP/FlatDR/StunDuration starLevel별 미반영 5건 lint 후보 검출
 - [[nasus]] (나서스) — 1코스트 Tank (raw `APTank` → sim Tank, [[jax]] 와 동일 매핑), 우주 그루브 + 선봉대. base raw "두둠칫 수잔" 6초 변신 + 인접 매초 magic DOT. ⚠️ NasusCarry augment 활성 시 role=Fighter + `nasusBonkStack × bonusPerKill[★]` cast kill 누적 (PR #135 Layer 1 selected 가드). base 의 MaxHealth/DamageHealth/Space Groove `TheGroove` 상태 미반영 4건 lint 후보 검출. Lint #5 잔존 (Bonk! Resists 40→45 base vs augment grant 미verify)
+- [[mordekaiser]] (모데카이저) — 2코스트 Tank (raw `APTank` → sim Tank), 암흑의 별 + 전달자 + 선봉대. base raw "불멸" InitialShield + 4초 매초 펄스 (본인 shield + 1칸 적 magic) + 만료 시 잔여 × 40% healRefund. ⭐ **가장 정합 base sim** — helper 통합 (`applyMordekaiserProcCast` + `tickMordekaiserProc`) + 별도 shield pool (`mordekaiserShieldRemaining`) + main/OOR cast parity + 전용 test. ⚠️ MordekaiserCarry 시 `mordekaiserCarryShield` carry data 우선 read (PR #124 lint #7 해소). 미반영 1건 (M1 `AugmentedDuration` Concentration augment 6초 확장)
 
 ## Items
 
@@ -68,7 +69,7 @@ selected-carry-augment 일반화 foundation + 광범위 selected 가드 적용 �
 2. **Lint #11-A/B (Jax) + #12 (Nasus) + #13 (Zed) sim 해소** — sim fix PR (필드 read 추가 vs 필드 dead 정리)
 3. **flag 자체 dead 정리** (`gragasCarryActive` / `leonaCarryActive`) — sim 코드 사용처 0, 테스트 assertion 만 (Lint #6/#8 후속)
 4. **Lint #10 cleanup** — `hero-augment-carry.md` 의 "Pyke onKill 미구현" stale 정정 (PR #131 에서 부분 정정, 후속 PR 로 더 깊이)
-5. **챔피언별** (set17 한정 — `public/data/tft_set17_champions.json` `TFT17_` prefix entries 로 ground truth 확인 필수, **한글 이름이 아닌 apiName 으로**) — Shen ✅ / Jax ✅ / Nasus ✅ / 다음: Zed (Lint #13 spec 대기), Poppy (Lint #5 측정 대기), Mordekaiser (mordekaiserCarryShield deprecate 연계), Galio (4코 메카 거대 메크 로봇 — 신규 plan 필요). ⚠️ Annie/Yasuo plan 파일은 이전 set 작업물 — set17 챔피언 아님 (2026-05-21 정정). ✅ **TFT17_Galio = 거대 메크 로봇 (4코 메카+여행자)** 으로 set17 챔피언 맞음 (codex PR #149 P2 정정) — 단 `galio-hero.plan.md` (5코 hero) 는 이전 set 작업물이라 직접 매핑 불가, 신규 plan 또는 raw 기반 ingest 필요
+5. **챔피언별** (set17 한정 — `public/data/tft_set17_champions.json` `TFT17_` prefix entries 로 ground truth 확인 필수, **한글 이름이 아닌 apiName 으로**) — Shen ✅ / Jax ✅ / Nasus ✅ / Mordekaiser ✅ / 다음: Zed (Lint #13 spec 대기), Poppy (Lint #5 측정 대기), Galio (4코 메카 거대 메크 로봇 — 신규 plan 필요), 블리츠크랭크 (5코 우주 그루브 carry). ⚠️ Annie/Yasuo plan 파일은 이전 set 작업물 — set17 챔피언 아님 (2026-05-21 정정). ✅ **TFT17_Galio = 거대 메크 로봇 (4코 메카+여행자)** 으로 set17 챔피언 맞음 (codex PR #149 P2 정정) — 단 `galio-hero.plan.md` (5코 hero) 는 이전 set 작업물이라 직접 매핑 불가, 신규 plan 또는 raw 기반 ingest 필요
 6. **Poppy/Nasus 인게임 verify 후 statOverrides 적용** (Lint #5 잔존 TODO — 사용자 측정 필요)
 7. **integration test** — LeonaCarry / GragasCarry / AatroxCarry sim 통합 (cycle counter / 적군 AOE / starLevel별 stun 등)
 8. **OOR cast path 의 cycle/x_shape 일관성 verify** — Aatrox/Pyke 페이지의 follow-up verify 항목 (PR #129 stun 같은 패턴 가능성)

--- a/docs/wiki/lint-rules.md
+++ b/docs/wiki/lint-rules.md
@@ -1,0 +1,275 @@
+---
+name: TFT Domain Wiki — Lint Rules
+purpose: 위키 ingest 직후 lint subagent (`wiki-ingest-verifier`) 가 사용하는 단일 출처 룰셋
+scope: docs/wiki/{champions,mechanics,augments}/*.md (carry-augment 만, 일반 augment 제외)
+based_on: 자기-lint 9건 누적 (모두 Codex catch — self-catch rate 0%)
+goal: self-catch rate ≥ 50% (P0 기준) in 6 PR
+updated: 2026-05-26 (initial extract from memory)
+---
+
+# Wiki Ingest Lint Rules
+
+## 목적
+
+위키 ingest 시 9건의 lint case 가 누적되었으나 **전부 Codex review 가 catch** (self-catch 0%). 룰을 알아도 작성 단계에서 실행되지 않는 패턴이 반복 → reactive 진화. 본 문서는 사전 verify 강제용 **lint subagent** (`.claude/agents/wiki-ingest-verifier.md`) 가 참조하는 단일 룰셋이다.
+
+본 문서는 **lint 관점** (negative verify, Codex-style). main agent 의 작성 워크플로우 (positive verify) 는 user-local 메모리 `feedback_wiki_ingest_verify` 가 담당 — 책임 분리.
+
+## Scope (entity type 별 적용)
+
+| Entity type | Path 패턴 | Lint 적용 | 비고 |
+|-------------|----------|-----------|------|
+| Champion | `docs/wiki/champions/*.md` | ✅ | 9건 중 5건 (cast path / starLevel / carry helper) |
+| Mechanic | `docs/wiki/mechanics/*.md` | ✅ | 9건 중 3건 (trigger context / ground truth) |
+| Carry augment | `docs/wiki/augments/*-carry.md` | ✅ | 9건 중 1건 (entity-wide multi-source) |
+| 일반 augment | `docs/wiki/augments/*.md` (non-carry) | ❌ | 단순 fact lookup, lint case 0건. 발생 시 확장 |
+| Trait | `docs/wiki/traits/*.md` | ❌ | lint case 0건. 발생 시 확장 |
+| Patch | `docs/wiki/patches/*.md` | ❌ | lint case 0건. 발생 시 확장 |
+| Item | `docs/wiki/items/*.md` | ❌ | 미작성. 발생 시 확장 |
+
+확장 트리거: trait/patch/item lint case **1건 발생 즉시** scope 추가.
+
+## Severity Tier
+
+Codex review vocabulary 와 정렬. lint output 은 반드시 tier 부여.
+
+| Tier | 의미 | 처리 |
+|------|------|------|
+| **P0** | sim 회귀 / 잘못된 fact / 검증 실패 (ground truth 부정합) | **commit 전 fix 필수** |
+| **P1** | 의미는 맞으나 부정확 표현 / 출처 누락 / 좁은 주장 (multi-source 미명시) | follow-up PR 허용, 단 본 PR 에서 가능하면 fix |
+| **P2** | wording / frontmatter wording / cross-ref 누락 / nice-to-have | 다음 ingest 사이클에서 정리 가능 |
+
+## 5단계 Verify Rule (모든 entity 공통)
+
+Lint subagent 는 페이지에 적힌 모든 fact / 코드 참조 / sim 효과 주장에 대해 다음 순서로 검증.
+
+### 0. Entity set 소속 (champion / mechanic / carry-augment 모두)
+
+작업 대상이 set17 entity 인지 raw json 으로 확인.
+
+- **Champion**: `public/data/tft_set17_champions.json` 에서 `TFT17_<id>` prefix entry 존재 확인
+- **Carry augment**: `src/lib/simulator/carryAugments.ts` 등에서 entry 존재 확인
+- **Mechanic**: 코드 ground truth (예: `targeting.ts:TARGETING_WEIGHT`) 존재 확인
+
+❌ **금지**: `docs/01-plan/features/` plan 파일 존재만으로 후보 선정 — 이전 set 작업물 잔존 가능
+
+❌ **금지**: 한글 이름 list 만으로 검증 — 한글 이름과 apiName 이 미스매치 가능 (`TFT17_Galio = 거대 메크 로봇`, `TFT17_Reksai = 렉사이` 등)
+
+✅ **허용 패턴**:
+```bash
+node -e "require('./public/data/tft_set17_champions.json').champions.find(c => c.apiName === 'TFT17_X')"
+# 또는
+grep -n "TFT17_X" public/data/tft_set17_champions.json
+```
+
+### 1. 좁은 grep — 식별자 정의/사용 위치
+
+```bash
+grep -rn "<식별자>" src/
+```
+
+페이지에 등장하는 모든 코드 식별자 (함수명 / 변수명 / 상수명 / api_name) 의 정의·사용 위치 추출.
+
+### 2. 함수 컨텍스트 read — 트리거/조건/타이밍
+
+추출 라인이 단순 정의/할당이면 **그 함수 전체 read** 로 트리거/조건/타이밍 확인.
+
+> **예시**: `u.spellCanCrit = true` 한 줄 → if 블록 + 함수 시그니처 + 함수 호출처 1회 확인. PR #121 사례에서 `tickDrxNova` 함수 컨텍스트 누락 → "Akali 어빌리티 시전 시" 로 잘못 주장 (실제는 DRX N.O.V.A. surge 트리거).
+
+### 3. Entity-wide grep — 좁은 식별자 외 entity 이름 자체
+
+`grep "MordekaiserCarry"` 만 ❌ → `grep "Mordekaiser"` 도 함께 ✅.
+
+엔티티 이름으로 wider grep 하면 specific helper (`applyMordekaiserProcCast`, `tickMordekaiserProc` 등) 가 raw vars 직접 read 하는 multi-source drift 발견.
+
+> **예시**: PR #123 — `carryAugments.ts entry` 만 보고 "단일 source" 단정 → 실제는 entity-specific helper 가 raw `unit.champion.ability.variables` 별도 read. PR #115/#116 미반영 검출.
+
+### 4. 호출 순서 / 영향 범위 trace (sim 코드 변경 / override 주장 시)
+
+변경되거나 주장되는 필드 / 값이:
+
+- **누가 set** 하는가? (직접 set, calculateStats, applyXxxEffects 등)
+- **누가 read** 하는가? (단일 read 가정 금지)
+- **호출 순서** 는? (item bonus → augment override → trait effect → ...)
+- **절대값 override 가 기존 시스템을 손실시키는가?** (Tear/Blue Buff item mana 손실 등)
+
+손실되면 → **delta 보존 / 적용 위치 이동 / 우선순위 명시** 중 선택.
+
+#### 4-sub: Cast path 3종 전수 확인 (PR #129 도입)
+
+Cast 관련 동작 (stun apply / damage apply / debuff / dot / shield 등) 은 **3 cast path 에 별도 분기**:
+
+1. **Main pipeline** (`combatLoop.ts` cast 메인)
+2. **OOR (out-of-range) fallback** dash cast
+3. **Recast** (`onKill` 재시전)
+
+한 곳만 fix 시 range-dependent / kill-pattern-dependent 회귀 발생. **반드시 위키 [[ability-targeting]] 의 "3 호출처" 정보를 참고**.
+
+✅ **검증 패턴**:
+```bash
+grep -n "config\.<field>\|outOfRangeConfig\.<field>\|recastConfig\.<field>" src/lib/simulator/engine/combatLoop.ts
+```
+
+### 5. Actual sim integration verify (sim 효과 주장 시 필수, PR #128 도입)
+
+페이지에 "X 효과가 적용된다" 라고 주장하기 전에:
+
+- 주장된 효과 (예: "starLevel별 stun 1.0/1.25/1.5 적용") **를 실현하는 main pipeline read 위치** 가 실제 존재하는가?
+- **entry 값 변경 + config 정합 ≠ sim 효과**. main pipeline 이 그 값을 read 하는 위치까지 grep 으로 trace.
+- "entry 정합" / "config 단일 source" 는 **저장소 정합 + 1차 read 정합** 까지만 의미. starLevel별 / 조건부 / 다단계 효과는 별도 verify.
+
+❌ **금지**: "abilityData 에 정의돼 있음" → "sim 적용됨" 결론
+
+✅ **검증 패턴**:
+```
+효과 주장: "abilityData.stunDuration starLevel별 적용"
+verify: grep -n "abilityData\.stunDuration\b" src/lib/simulator/engine/combatLoop.ts
+  → IvernMinion 분기에만 사용 (line ~1234)
+  → 다른 carry (LeonaCarry 등) 의 stunDuration 은 sim 미반영 → P0 finding
+```
+
+read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또는 신규 lint case 등록.
+
+## Entity-type 별 추가 Checklist
+
+5단계 공통 룰에 더해 entity type 별 특이 fail mode.
+
+### Champion (`docs/wiki/champions/*.md`)
+
+| Check | 빈도 | 사례 |
+|-------|------|------|
+| `TFT17_<id>` set17 entry 존재 (0단계) | 항상 | 한글-apiName 미스매치 catch |
+| Carry augment 활성 시 role 변환 확인 | 카리 augment 가진 champ | Jax: APTank → Fighter 변환 |
+| `<Champion>Carry` raw helper 함수 multi-source (`apply<X>Cast`, `tick<X>Proc`) | 항상 | Mordekaiser helper 가 raw vars 직접 read |
+| starLevel별 ability variables (`[1.0, 1.25, 1.5]`) 의 main pipeline read site | 항상 | Leona stunDuration 미반영 (#9) |
+| Cast path 3종 (main / OOR / recast) 각 분기 일관성 | cast 변경 시 | Leona OOR stun 누락 (#9 amend) |
+| 절대값 stat override (`maxMana`, `maxHp` 등) 의 calculateStats 이후 호출 순서 | override 적용 시 | Mordekaiser mana 40 override → Tear 손실 (#7) |
+| Base ability variables 의 starLevel별 sim 적용 여부 (ShieldAP/FlatDR/MaxHealth 등) | 항상 | Jax base 5건 / Nasus base 4건 lint 후보 |
+
+### Mechanic (`docs/wiki/mechanics/*.md`)
+
+| Check | 빈도 | 사례 |
+|-------|------|------|
+| 코드 ground truth 인용 (CLAUDE.md / 다른 wiki 인용 금지) | 항상 | `targeting.ts:TARGETING_WEIGHT` 인용 |
+| 트리거 함수의 컨텍스트 (단순 grep 라인 ❌, 함수 시그니처 + 호출처) | 항상 | spell-crit `spellCanCrit = true` → `tickDrxNova` (#1) |
+| `<field>` "미사용 같음" 추정 표기 시 grep 전수 확인 | 추정 표기 시 | `damageDecay` "미사용 추정" → 실제 6 챔프 + combatLoop active (#2) |
+| 패치별 active/inactive 분기 (current_patch_status frontmatter 와 본문 정합) | 항상 | Stargazer Fountain 17.2 inactive → 17.3 active |
+| `[[other-page]]` 링크 깨짐 / orphan | 항상 | dead link lint |
+
+### Carry augment (`docs/wiki/augments/*-carry.md`)
+
+| Check | 빈도 | 사례 |
+|-------|------|------|
+| `<X>Carry` entry 외 entity 이름 wider grep (helper 함수 multi-source) | 항상 | Mordekaiser helper 가 carryAugments 외 read (#3) |
+| `selected single-carry` semantics (Layer 1 state/stack flag + Layer 2 abilityOverride 가드) | onKill / cast cycle 변경 시 | PR #135/#136 학습 |
+| `selfBuff` 필드 부재로 인한 sim no-op | new carry 도입 시 | Zed: selfBuff 부재 + damage 미반영 (#13) |
+| Cast path 3종 cycle/x_shape 일관성 | cycle/recast carry | Aatrox/Pyke follow-up verify |
+| 17.2 → 17.2b → 17.3 변경 누적 fact 정합 | 패치 boundary 페이지 | 3회 연속 변경 보존 |
+
+## Lint Output 형식 (subagent → main agent)
+
+```markdown
+## Lint Result: <page-path>
+
+### P0 (commit 전 fix 필수)
+- **[Finding name]** — 본문 위치 (line 또는 섹션 헤딩)
+  - 주장: "<인용>"
+  - 검증: <grep / read 결과>
+  - 회귀 위험: <sim 영향>
+  - 권장 fix: <action>
+
+### P1 (follow-up 허용)
+- ...
+
+### P2 (다음 사이클)
+- ...
+
+### Self-catch metric
+- 본 lint 가 발견한 finding 중 사전 Codex review 와 중복: <N건>
+- 신규 finding: <M건>
+```
+
+## 9건 Lint History (학습 사례)
+
+| # | PR | Entity type | Finding | 5단계 중 catch 단계 | Tier |
+|---|----|-----------|--------|--------------------|------|
+| 1 | #111 | augment | CLAUDE.md weight 표 인용 → stale 전파. 실제 `targeting.ts:TARGETING_WEIGHT` 다름 | 1 (좁은 grep) | P0 |
+| 2 | #113 | mechanic | `damageDecay` "미사용 같음" 추정 → 실제 6 챔프 + `combatLoop.ts:6479` active | 1 (좁은 grep) | P0 |
+| 3 | #121 | mechanic | `u.spellCanCrit = true` → "Akali 어빌리티 시전 시" 추정. 실제 `tickDrxNova` DRX N.O.V.A. surge 트리거 | 2 (함수 컨텍스트) | P0 |
+| 4 | #123 | augment (carry) | `grep "MordekaiserCarry"` 만 보고 "단일 source" 단정 → `applyMordekaiserProcCast` / `tickMordekaiserProc` 가 raw vars read | 3 (entity-wide grep) | P0 |
+| 5 | #124 | champion | `statOverrides.mana = 40` 절대값 override → `calculateStats` 이후 호출 시 Tear-based item mana 손실 | 4 (호출 순서 trace) | P0 |
+| 6 | #128 | augment (carry) | "starLevel별 stun [1.0/1.25/1.5] sim 적용" 주장 → 실제 `config.stun` fixed 만 read. `abilityData.stunDuration` 은 IvernMinion 분기 전용 | 5 (integration verify) | P0 |
+| 7 | #129 amend | augment (carry) | Main pipeline stun fix → OOR cast path `outOfRangeConfig.stun` 분기 fix 누락. range-dependent 회귀 | 4-sub (cast path 3종) | P0 |
+| 8 | #146 | mechanic | mechanic-level `sim_active: true` 가 sub-entity partial 상태를 가림 | 0 + frontmatter | P1 |
+| 9 | #149 P2 | champion | "Galio set17 아님" 잘못 표기 — 한글 이름 list 만으로 검증, apiName grep 누락 | 0 (set 소속) | P1 |
+
+> 모든 case 가 self-catch 0% (Codex catch). 본 룰셋의 목적은 다음 6 PR 에서 self-catch ≥ 50% (P0).
+
+## 워크플로우 진화
+
+| 시점 | 룰 추가 | 도입 PR |
+|------|---------|---------|
+| 초기 | 1단계 좁은 grep + verify | — |
+| 2026-05-XX | 2단계 함수 컨텍스트 read | #121 (spell-crit Akali) |
+| 2026-05-XX | 3단계 entity-wide grep | #123 (Mordekaiser helper) |
+| 2026-05-XX | 4단계 호출 순서/영향 trace | #124 (mana override item 손실) |
+| 2026-05-XX | 5단계 actual integration verify | #128 (starLevel별 read site 부재) |
+| 2026-05-XX | 4-sub cast path 3종 전수 | #129 (OOR stun 누락) |
+| 2026-05-21 | 0단계 entity set 소속 (apiName grep) | #149 P2 (Galio 한글 list 누락) |
+| 2026-05-26 | **본 룰셋 single source 화 + lint subagent 도입** | (this) |
+
+## Self-catch Metric (6 PR 평가)
+
+다음 champion / mechanic / carry-augment ingest 부터 lint subagent dispatch. 6 PR 후 다음 metric 산출.
+
+| 평가 PR | Date | Page | Subagent P0 catch | Subagent P1 catch | Codex P0 catch | Self-catch rate (P0) |
+|---------|------|------|-------------------|-------------------|----------------|----------------------|
+| (retro pilot) | 2026-05-26 | champions/mordekaiser.md | 0 (전부 false-positive downgrade) | 1 (전달자 trait 부정확 → 정정 commit) | 0 (이미 머지) | N/A (retro) |
+
+Target: **self-catch / (self-catch + Codex) ≥ 50%** (P0 기준).
+
+미달 시: subagent prompt 강화 / 5단계 룰 추가 / cast path 4종 이상 확장 검토.
+
+### Pilot 검증 결과 (2026-05-26)
+
+mordekaiser.md retro pilot 으로 subagent 동작 검증:
+- ✅ 신규 P1 finding 1건 catch — "전달자 trait 효과 sim 별도 분기 verify 필요" 부정확 표기 → 실제 `TFT17_ManaTrait` `InnateManaGain` integration 완료 발견 (`combatLoop.ts:524-529 / 5549`, `mana.ts:36-41`)
+- ✅ Known finding (#3 entity-wide helper / #7 mana override) 모두 false-positive 룰로 정상 downgrade
+- ✅ 본문 self-raised M1 lint (Concentration AugmentedDuration) 도 `disable: true` verify 후 P2 downgrade
+- Cost: 페이지당 Read 6회 + grep 9회 ≈ 15 tool call, sonnet 적정
+
+### Pilot 발견 prompt 보강 (4건, 후속 적용 예정)
+
+1. **Page-internal cross-check** — 같은 entity 가 페이지의 여러 line 에서 모순 표기 시 단일 finding 으로 통합
+2. **Line 번호 인용 정책** — `combatLoop.ts:XXXX-YYYY` line 인용의 stale risk vs 위키 일관성 trade-off 결정
+3. **Conditional augment `disable` 0단계 verify** — "특정 augment 활성 시" 효과 (M1 같은) 는 augment `"disable": true` 여부도 0단계로 추가
+4. **False-positive downgrade 통계** — output 에 "raised: N / downgraded known: M" 명시
+
+## 허용 / 금지
+
+### ✅ 허용
+
+- 코드 ground truth (`src/...:identifier`) — line 번호는 즉시 stale 되므로 함수명까지만
+- Raw source (`public/data/tft_set17_*.json`, `docs/wiki/raw/`)
+- 패치노트 공식 URL
+- PR/commit 참조 (`#PR번호`, short hash)
+- PDCA plan/design — **도입 시점/동기 기록용으로만** (도메인 fact 는 코드 verify)
+
+### ❌ 금지
+
+- CLAUDE.md / 다른 wiki 페이지 / docs/meta/ 의 plan·audit·guide 문서를 **도메인 fact 출처로 인용**
+- "관련 룰: 다른 페이지 참조" 식으로 fact 본체 위임 (cross-ref OK, 단 핵심 수치는 본문에 직접 verify 한 값)
+- Grep 한 줄만 보고 fact 단정 (함수/조건 가드/타이밍 검증 없이)
+- 좁은 식별자 grep 만 보고 단일 source 단정 (entity-wide grep 누락)
+- 절대값 override 추가 시 호출 순서/영향 범위 분석 누락
+- "sim 정합" / "X 효과 적용" 주장 시 actual integration verify 누락
+- Cast path 한 곳만 fix (main 만, OOR/recast 누락)
+- 한글 이름 list 만으로 set 소속 검증 (apiName grep 누락)
+
+## 관련
+
+- 메모리 `feedback_wiki_ingest_verify` — main agent 작성 워크플로우 (positive verify, user-local)
+- 메모리 `feedback_codex_review_workflow` — Codex review reply 워크플로우
+- 메모리 `feedback_pr_serial_workflow` — 1 PR 씩 직렬 처리
+- Subagent: `.claude/agents/wiki-ingest-verifier.md` — 본 룰셋 reference
+- 위키 메타: [[schema]] (구조), [[index]] (카탈로그), [[log]] (변경 기록)

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -8,6 +8,44 @@ format: newest first
 
 ## 2026-05-21
 
+### Ingest: champions/mordekaiser.md — 4번째 champion 페이지 (helper 통합 sim 가장 정합)
+
+- **Source** (0+5단계 워크플로우):
+  - `public/data/tft_set17_champions.json` (TFT17_Mordekaiser entry — 2코 암흑의 별+전달자+선봉대)
+  - `src/lib/simulator/systems/ability.ts:210` (abilityOverride `pattern: 'self_buff'` + helper 참조 comment)
+  - `src/lib/simulator/engine/combatLoop.ts:230-233/292` (state field 4개: mordekaiserProcEndTick / NextProcTick / ShieldRemaining + mordekaiserCarryShield)
+  - `src/lib/simulator/engine/combatLoop.ts:953-975` (`applyMordekaiserProcCast` — cast 진입 helper)
+  - `src/lib/simulator/engine/combatLoop.ts:990-1067` (`tickMordekaiserProc` — per-tick helper, 4 펄스 + 만료 healRefund)
+  - `src/lib/simulator/engine/combatLoop.ts:1213-1218` (별도 shield pool 우선 흡수 — HealRefund 정확 계산)
+  - `src/lib/simulator/engine/combatLoop.ts:7037 / :7185` (cast path parity — main + OOR 양쪽 helper 호출)
+  - `src/lib/simulator/engine/combatLoop.ts:5533` (per-tick 호출 site)
+  - `src/lib/simulator/engine/combatLoop.ts:2305-2312` (applyHeroCarryTransforms — MordekaiserCarry 활성 시 `mordekaiserCarryShield` carry data 저장, PR #124 lint #7 해소)
+  - 테스트: `tests/unit/mordekaiser-proc.test.ts` (전용) + `tests/unit/simulator/darkstar-execute-supermassive.test.ts:27+` (apMordekaiser 암흑의 별 fixture)
+
+- **Frontmatter 표준 (Jax/Nasus 따름)**:
+  - `role: Tank   # raw "APTank" → mapGameRole() → sim Tank` (3번째 base APTank champion — Jax/Nasus/Mordekaiser 모두 동일 매핑)
+  - `raw_role: APTank`
+  - `sim_active: active` ⭐ — base raw 메커니즘 가장 정합 (이전 Jax/Nasus 는 partial)
+
+- **신규 발견 — helper 통합 sim 의 효율성**:
+  - Mordekaiser 는 **가장 정합 base sim** (champion 페이지 4개 중 sim_active: active 첫 사례)
+  - 이유: cast 진입 helper + per-tick helper + 별도 shield pool + main/OOR cast parity + 전용 test 5 case
+  - Jax/Nasus 는 raw ability variables 의 starLevel별 / scaling 다수 미반영 → helper 부재 (단순 selfBuff/dot 매핑)
+  - Mordekaiser 는 raw vars `InitialShield/ShieldPerProc/DamagePerProc/HealRefund/Duration` 모두 `readVarByStar` 로 ★별 정확 read
+  - **인사이트**: base champion sim 정합도는 helper 존재 여부와 강한 상관관계 — champion ingest 가 helper 필요성 신호 (Jax/Nasus 도 helper 작성하면 sim 정합도 ↑)
+
+- **신규 lint 후보 1건만 등록** (champion ingest 발견):
+  - M1: `AugmentedDuration` (Concentration augment 활성 시 Duration 4→6초 펄스 +2회) 미반영
+  - 비교: Jax 5건, Nasus 4건 vs Mordekaiser 1건 — helper 통합 효과 입증
+  - Jax L1~L5 + Nasus N1~N4 + Mordekaiser M1 = 누적 10건 (champion ingest trigger)
+
+- **cleanup 후보 식별**:
+  - `mordekaiserCarryShield` 필드 deprecate 검토 — `selectedCarryAugment + carryCfg.abilityData?.shield` 로 derive 가능 (PR #147 xxxCarryActive deprecate 후속). 단 데이터 보유 (`null | number[]`) 라 단순 boolean flag 와 다른 work 필요
+
+- **wiki index.md 업데이트**:
+  - Champions 섹션에 Mordekaiser entry 추가 (Shen / Jax / Nasus / Mordekaiser 4개 완료)
+  - "작성 우선순위" 섹션 정렬 (Mordekaiser 완료 → Zed/Poppy/Galio/블리츠크랭크 후보)
+
 ### Ingest: champions/nasus.md — 3번째 champion 페이지 (Jax 표준 + carry semantics 강조)
 
 - **Source** (0+5단계 워크플로우):


### PR DESCRIPTION
## Summary

위키 ingest 9건 lint case 모두 **Codex review 가 catch** (self-catch 0%) 문제 해결을 위한 사전 verify forcing function 도입.

- **Dedicated lint subagent** (`.claude/agents/wiki-ingest-verifier.md`) — post-write before commit lint
- **Single source of truth 룰셋** (`docs/wiki/lint-rules.md`) — 5단계 verify + entity-type checklist + 9건 history + Severity Tier
- **Pilot retro fix** (`mordekaiser.md` P1-1) — subagent 동작 검증 + 신규 finding 1건 catch

Target: 다음 6 PR 에서 self-catch rate ≥ 50% (P0 기준).

## 변경 파일 (5개)

| 파일 | 상태 | 내용 |
|------|------|------|
| `docs/wiki/lint-rules.md` | A | 5단계 verify rule + entity-type checklist + 9건 history + P0/P1/P2 + metric |
| `.claude/agents/wiki-ingest-verifier.md` | A | read-only lint subagent (Read/Glob/Grep/Bash). description 다언어 auto-trigger |
| `CLAUDE.md` | M | "TFT Domain Wiki Ingest 검증" 섹션 추가 (dispatch 룰 명시) |
| `.gitignore` | M | `.claude/*` ignore + `!.claude/agents/` 예외 — subagent trackable |
| `docs/wiki/champions/mordekaiser.md` | M | 전달자 (Channeler `TFT17_ManaTrait`) trait 부정확 정정 |

## 핵심 설계 결정 (grill 결과 10건 합의)

| # | 결정 |
|---|------|
| Motivation | 사전 verify 강화 (9건 self-catch 0% → ≥50%) |
| Forcing function | Dedicated subagent (vs hook / skill / 메모리) |
| Invocation 시점 | Post-write before commit (Codex-style lint) |
| Output | Tiered P0/P1/P2 findings |
| Method | Tool-based LLM (Read/Glob/Grep/Bash, read-only) |
| Scope | champion + mechanic + carry-augment (9/9 cover) |
| Dispatch 강제 | Agent description auto-trigger (Phase 1) → hook (Phase 2) |
| 룰 source | `docs/wiki/lint-rules.md` (repo, single source) |
| Migration | Retro selective (9건 page) + greenfield (다음 champion) |
| Success metric | Self-catch rate ≥ 50% (P0), 6 PR 후 평가 |

## Mordekaiser P1-1 fix detail

**Pilot retro lint 결과** — 신규 finding 1건 catch:

- **부정확 표기 (before)**: "전달자 — 시너지 stat 보강 분기 (Tank 보조)" + "🔍 전달자 trait 효과 — sim 별도 분기 verify 필요"
- **실제 (verify 후)**: `TFT17_ManaTrait` `InnateManaGain` (raw 0.20) → `unit.channelerInnateManaGain` → `combatLoop.ts:524-529` + `:5549` 매 tick mana gain 곱셈자 (`augmentManaRegen` 도 곱셈 적용, codex P1 PR #64 이력)
- **수정 후**: "전달자 (Channeler, `TFT17_ManaTrait`) — 활성 시 전달자 unit 의 mana gain 곱셈자 ... Tank stat 보강 아님 — mana regen 곱셈 (`mana.ts:36-41` helper)"
- 부가: `TFT17_Augment_Concentration` `"disable": true` (set17 inactive) 사실 명시 → M1 lint 자동 무효

**Known finding (#3 entity-wide helper / #7 mana override / self-raised M1)** 모두 false-positive 룰로 정상 downgrade 됨 — 룰셋 동작 검증.

## Subagent pilot 검증 metric

- Read 6 + grep 9 ≈ 15 tool call / page (sonnet 적정)
- 룰셋 (`lint-rules.md`) ↔ prompt 충돌 없음
- 신규 finding (P1) 1건 + known finding downgrade 3건

## 후속 작업 (별도 PR)

1. **wiki-ingest-verifier prompt 보강 4건** — pilot 검출:
   - page-internal cross-check (같은 entity 의 여러 line 모순)
   - line 번호 인용 stale 정책 결정
   - conditional augment `disable: true` 0단계 추가
   - False-positive downgrade 통계 필드
2. **Retro lint 5 페이지** — leona-carry, mordekaiser-carry, spell-crit, ability-targeting, hero-augment-carry
3. **6 PR 운영 후 self-catch rate 평가** — `lint-rules.md` Self-catch Metric 표 업데이트

## Test plan

- [ ] Reviewer: `.claude/agents/wiki-ingest-verifier.md` 의 description 키워드가 main agent 의 자동 dispatch 트리거에 충분한지 검토
- [ ] Reviewer: `docs/wiki/lint-rules.md` 5단계 verify rule 의 entity-type 별 checklist 가 9건 사례 모두 catch 가능한지 mental simulation
- [ ] Reviewer: `CLAUDE.md` 의 dispatch 룰 작성 위치·문구 적정성
- [ ] Reviewer: `.gitignore` `.claude/*` + `!.claude/agents/` 예외 규칙이 의도 외 파일 트래킹 유발하지 않는지 (settings.local.json 등은 여전히 ignore)
- [ ] Reviewer: mordekaiser.md 전달자 trait 정정 fact 코드 ground truth 와 일치 확인
- [ ] Follow-up: 다음 champion ingest 시 subagent 자동 dispatch 동작 확인 (greenfield 운영 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)