### PR TITLE
docs(wiki): wiki-ingest-verifier prompt 보강 4건 (PR #152 pilot 후속)

### DIFF
--- a/.claude/agents/wiki-ingest-verifier.md
+++ b/.claude/agents/wiki-ingest-verifier.md
@@ -101,7 +101,11 @@ dispatch 시 다음 grep 패턴을 entity type 별로 우선 수행:
 grep -n "TFT17_<id>" public/data/tft_set17_champions.json
 
 # 0-sub — conditional augment disable (페이지에 "X augment 활성 시" 효과 주장이 있을 때)
+# 권장: node -e (structure-aware, robust)
 node -e "const j=require('./public/data/tft_set17_augments.json'); const a=j.augments.find(x=>x.apiName==='TFT17_Augment_<Name>'); console.log({apiName:a?.apiName, disable:a?.disable})"
+# 또는 jq: jq '.augments[] | select(.apiName == "TFT17_Augment_<Name>") | {apiName, disable}' public/data/tft_set17_augments.json
+# grep fallback 시: -A 50 (set17 max entry 31 line + 안전 마진) + grep -m1 첫 disable 만
+# grep -A 20 사용 금지 — entry size 21 line 이상 augment (예: Weightlifting) miss → PR #153 codex P2 catch
 
 # 3단계 — entity-wide multi-source helper
 grep -rn "<ChampionName>" src/lib/simulator/

--- a/.claude/agents/wiki-ingest-verifier.md
+++ b/.claude/agents/wiki-ingest-verifier.md
@@ -36,11 +36,13 @@ main agent 가 dispatch 시 다음 중 하나 또는 복수의 페이지 경로�
    - path `mechanics/` → mechanic checklist 적용
    - path `augments/` + 본문 carry semantic → carry-augment checklist 적용
 4. **5단계 + 0단계 verify 수행**:
-   - 0 set 소속 / 1 좁은 grep / 2 함수 컨텍스트 / 3 entity-wide grep / 4 호출 순서 (+ cast path 3종 sub-rule) / 5 actual integration verify
+   - 0 set 소속 (+ 0-sub conditional augment `disable: true` verify) / 1 좁은 grep / 2 함수 컨텍스트 / 3 entity-wide grep / 4 호출 순서 (+ cast path 3종 sub-rule) / 5 actual integration verify
    - 각 단계마다 코드 grep / 함수 read 결과를 finding 의 근거로 인용
 5. **Entity-type 별 추가 checklist 적용** — lint-rules.md 의 entity-type 표 참조
-6. **Tiered finding 분류** — P0 / P1 / P2 (Severity Tier 정의는 lint-rules.md)
-7. **Output 보고** — 아래 형식 준수
+6. **Page-internal cross-check** (PR #152 도입) — 같은 entity / fact 가 페이지 여러 line 에서 모순 표기 시 **단일 finding 으로 통합**. frontmatter 와 본문 모순도 동일. lint-rules.md "Page-internal Cross-check" 섹션 참조
+7. **Line 번호 인용 drift 확인** (선택) — 본문/frontmatter 의 `src/...:NNNN` line 인용에 대해 인용 line 의 함수 여전히 존재하는지 grep. drift > 10 line 시만 P2 informational ("last_verified + line 번호 갱신 권장"), 함수 자체 사라짐은 P0. drift ≤ 10 line 은 finding 불요
+8. **Tiered finding 분류** — P0 / P1 / P2 (Severity Tier 정의는 lint-rules.md). False-positive 방지 룰 적용 (본문 "PR #XYZ resolved" / "🔍 검증 필요" / "disable: true 자동 무효" 표기 + 코드 verify 결과로 downgrade)
+9. **Output 보고** — 아래 형식 준수. `Finding 통계` 라인에 `raised P0/P1/P2 N/M/K + downgraded known D` 필수 명시. `Downgraded known findings` 섹션으로 false-positive 작동 사례 별도 보고
 
 ## 출력 형식 (반드시 준수)
 
@@ -48,19 +50,19 @@ main agent 가 dispatch 시 다음 중 하나 또는 복수의 페이지 경로�
 ## Lint Result: <page-path>
 
 **Entity type**: <champion | mechanic | carry-augment>
-**Verify 수행 단계**: 0 ✅ / 1 ✅ / 2 ✅ / 3 ✅ / 4 ✅ / 4-sub cast path ✅ / 5 ✅
-**총 finding**: P0 <N> / P1 <M> / P2 <K>
+**Verify 수행 단계**: 0 ✅ / 0-sub ✅ / 1 ✅ / 2 ✅ / 3 ✅ / 4 ✅ / 4-sub cast path ✅ / 5 ✅ / page-internal cross-check ✅ / line drift check ✅
+**Finding 통계**: raised P0 <N> / P1 <M> / P2 <K> / downgraded known <D>
 
 ### P0 (commit 전 fix 필수)
 
 #### P0-1. <Finding name>
-- **위치**: 본문 line ~XX 또는 섹션 헤딩
+- **위치**: 본문 line ~XX 또는 섹션 헤딩 (다중 line 영향 시 모두 명시)
 - **주장**: "<인용>"
 - **검증**:
   - `grep -n "<pattern>" <path>` → <결과>
   - `<src/...:functionName>` 함수 read → <발견 사실>
 - **회귀 위험**: <sim 영향. cast path / range / starLevel / item 손실 등 명시>
-- **권장 fix**: <action>
+- **권장 fix**: <action; 다중 line 시 통합 patch 권장>
 
 #### P0-2. ...
 
@@ -68,14 +70,24 @@ main agent 가 dispatch 시 다음 중 하나 또는 복수의 페이지 경로�
 
 (동일 형식)
 
-### P2 (다음 사이클)
+### P2 (다음 사이클; informational 포함)
 
-(동일 형식)
+(동일 형식. line drift > 10 / 명시적 보류 표기 항목 등)
+
+### Downgraded known findings (false-positive 방지 작동 사례)
+
+#### D-1. <Finding name>
+- **위치**: 본문 line / 섹션
+- **본문 표기**: "PR #XYZ resolved" / "🔍 검증 필요" / "disable: true 자동 무효" / "Lint #N pending" 등
+- **코드 verify**: <grep / read 결과로 표기 사실 확인>
+- **결론**: raise 안 함 (downgrade 처리)
 
 ### Self-verify check
 
 - 9건 lint history 의 어떤 패턴과 유사한가? (해당 시 #번호 인용)
+- Page-internal cross-check 결과: <같은 entity 여러 line 모순 발견 / 없음>
 - 본 lint 가 놓쳤을 가능성이 있는 영역: <명시>
+- 룰 보강 권장 (있으면): <항목>
 ```
 
 ## 핵심 패턴 (lint-rules.md 보강)
@@ -88,6 +100,9 @@ dispatch 시 다음 grep 패턴을 entity type 별로 우선 수행:
 # 0단계 — set17 소속
 grep -n "TFT17_<id>" public/data/tft_set17_champions.json
 
+# 0-sub — conditional augment disable (페이지에 "X augment 활성 시" 효과 주장이 있을 때)
+node -e "const j=require('./public/data/tft_set17_augments.json'); const a=j.augments.find(x=>x.apiName==='TFT17_Augment_<Name>'); console.log({apiName:a?.apiName, disable:a?.disable})"
+
 # 3단계 — entity-wide multi-source helper
 grep -rn "<ChampionName>" src/lib/simulator/
 
@@ -99,6 +114,9 @@ grep -n "abilityData\.<field>\|carryCfg\?\.abilityData\?\.<field>" src/lib/simul
 
 # 4-sub — cast path 3종
 grep -n "config\.<field>\|outOfRangeConfig\.<field>\|recastConfig\.<field>" src/lib/simulator/engine/combatLoop.ts
+
+# Line drift check (페이지의 src/...:NNNN line 인용에 대해)
+grep -n "<expected-symbol-or-snippet>" src/lib/simulator/engine/combatLoop.ts  # 실제 line 과 비교, drift > 10 line 시 P2
 ```
 
 ### Mechanic
@@ -130,12 +148,18 @@ grep -n "<EntityName>Carry" src/lib/simulator/carryAugments.ts
 - ❌ **좁은 식별자 grep 한 줄만 보고 fact 단정** — 함수 컨텍스트 read 또는 entity-wide grep 으로 multi-source 확인
 - ❌ **"abilityData 에 정의됨" → "sim 적용됨" 결론** — main pipeline read site 까지 trace 필수
 - ❌ **Cast 관련 finding 시 cast path 1개 (main) 만 확인** — main / OOR / recast 3종 전수
+- ❌ **"특정 augment 활성 시 효과 미반영" finding raise 전 augment `disable: true` 확인 누락** — disable 이면 자동 무효 → finding 자체 raise 안 함 (downgrade only)
+- ❌ **같은 entity 의 여러 line 모순을 개별 finding 으로 raise** — page-internal cross-check 후 단일 통합 finding
+- ❌ **Line 번호 인용 자체를 finding 으로 raise** — line 인용은 허용. drift > 10 line + 함수 위치 변경 시만 P2 informational. 함수 자체 사라짐은 P0
 - ❌ **Pass/fail 단순 판정** — 모든 finding 은 P0/P1/P2 tier + 근거 (grep 결과) + 권장 fix 동반
+- ❌ **Downgraded known findings 보고 누락** — false-positive 방지 작동 사례는 별도 섹션으로 명시 (Finding 통계 D 값에 카운트)
 
 ## False-positive 방지
 
 - 본문에 이미 "🔍 sim 효과 검증 필요" / "Lint #X (pending)" / "측정 대기" 등 명시적 보류 표기 있는 항목은 **P0 → P2** 로 downgrade
 - 본문에 PR 번호 (`#XYZ`) 와 함께 "resolved" / "applied" 표기된 항목은 grep 으로 실제 적용 verify. 적용됐으면 finding 아님
+- 본문에 `"disable": true` 명시된 augment 와 연관된 미반영 finding 은 **자동 무효** — downgrade only, raise 안 함 (raised 통계에서 제외, downgraded 통계에 포함)
+- 위 모두 `Downgraded known findings` 섹션에 명시
 
 ## 종료 조건
 

--- a/docs/wiki/lint-rules.md
+++ b/docs/wiki/lint-rules.md
@@ -56,11 +56,17 @@ Lint subagent 는 페이지에 적힌 모든 fact / 코드 참조 / sim 효과 �
 페이지에 **"특정 augment 활성 시" 효과** (예: "Concentration augment 활성 시 Duration 6초") 주장이 있으면 그 augment 의 `disable` 필드를 0단계 part 로 확인:
 
 ```bash
-# augment apiName 확인 후
+# 권장 (structure-aware, robust) — node -e
 node -e "const j=require('./public/data/tft_set17_augments.json'); const a=j.augments.find(x=>x.apiName==='TFT17_Augment_<Name>'); console.log({apiName: a?.apiName, disable: a?.disable})"
-# 또는
-grep -A 20 '"apiName": "TFT17_Augment_<Name>"' public/data/tft_set17_augments.json | grep -E '"disable"|"apiName"'
+
+# 또는 jq (structure-aware)
+jq '.augments[] | select(.apiName == "TFT17_Augment_<Name>") | {apiName, disable}' public/data/tft_set17_augments.json
+
+# grep fallback — entry 크기 (set17 max 31 line) 보다 큰 window + 첫 disable 만
+grep -A 50 '"apiName": "TFT17_Augment_<Name>"' public/data/tft_set17_augments.json | grep -m1 '"disable"'
 ```
+
+⚠️ **grep window 주의** (PR #153 codex P2 catch): `-A 20` 같은 작은 window 는 entry size 가 21 line 이상인 augment (예: `TFT17_Augment_Weightlifting` apiName line 671 → disable line 692, gap 21) 를 miss → false finding 또는 downgrade 누락. set17 max augment entry size 31 line 기준 `-A 50` 안전 마진. **가능하면 node -e / jq 사용**.
 
 `"disable": true` 면 해당 augment 는 set17 inactive — **그 augment 활성 시 효과 미반영은 sim 영향 0** (자동 무효). 본문에 그 사실 명시 권장. M1 사례 (`mordekaiser.md` AugmentedDuration → Concentration `disable: true`) 가 도입 배경.
 

--- a/docs/wiki/lint-rules.md
+++ b/docs/wiki/lint-rules.md
@@ -4,7 +4,7 @@ purpose: 위키 ingest 직후 lint subagent (`wiki-ingest-verifier`) 가 사용�
 scope: docs/wiki/{champions,mechanics,augments}/*.md (carry-augment 만, 일반 augment 제외)
 based_on: 자기-lint 9건 누적 (모두 Codex catch — self-catch rate 0%)
 goal: self-catch rate ≥ 50% (P0 기준) in 6 PR
-updated: 2026-05-26 (initial extract from memory)
+updated: 2026-05-26 (initial extract + pilot prompt 보강 4건 — page-internal cross-check / line 번호 정책 / conditional augment disable / downgrade 통계)
 ---
 
 # Wiki Ingest Lint Rules
@@ -50,6 +50,19 @@ Lint subagent 는 페이지에 적힌 모든 fact / 코드 참조 / sim 효과 �
 - **Champion**: `public/data/tft_set17_champions.json` 에서 `TFT17_<id>` prefix entry 존재 확인
 - **Carry augment**: `src/lib/simulator/carryAugments.ts` 등에서 entry 존재 확인
 - **Mechanic**: 코드 ground truth (예: `targeting.ts:TARGETING_WEIGHT`) 존재 확인
+
+#### 0-sub. Conditional augment `disable: true` verify (PR #152 retro pilot 도입)
+
+페이지에 **"특정 augment 활성 시" 효과** (예: "Concentration augment 활성 시 Duration 6초") 주장이 있으면 그 augment 의 `disable` 필드를 0단계 part 로 확인:
+
+```bash
+# augment apiName 확인 후
+node -e "const j=require('./public/data/tft_set17_augments.json'); const a=j.augments.find(x=>x.apiName==='TFT17_Augment_<Name>'); console.log({apiName: a?.apiName, disable: a?.disable})"
+# 또는
+grep -A 20 '"apiName": "TFT17_Augment_<Name>"' public/data/tft_set17_augments.json | grep -E '"disable"|"apiName"'
+```
+
+`"disable": true` 면 해당 augment 는 set17 inactive — **그 augment 활성 시 효과 미반영은 sim 영향 0** (자동 무효). 본문에 그 사실 명시 권장. M1 사례 (`mordekaiser.md` AugmentedDuration → Concentration `disable: true`) 가 도입 배경.
 
 ❌ **금지**: `docs/01-plan/features/` plan 파일 존재만으로 후보 선정 — 이전 set 작업물 잔존 가능
 
@@ -166,13 +179,37 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 | Cast path 3종 cycle/x_shape 일관성 | cycle/recast carry | Aatrox/Pyke follow-up verify |
 | 17.2 → 17.2b → 17.3 변경 누적 fact 정합 | 패치 boundary 페이지 | 3회 연속 변경 보존 |
 
+## Page-internal Cross-check (PR #152 retro pilot 도입)
+
+같은 entity / 같은 fact 가 페이지의 **여러 line 에서 모순 표기** 될 때 단일 finding 으로 통합 처리.
+
+### 사례 (mordekaiser.md pilot)
+
+같은 trait "전달자" 가:
+- line 102 "전달자 — 시너지 stat 보강 분기 (Tank 보조)" (부정확)
+- line 142 "전달자 trait 효과 — sim 별도 분기 verify 필요" (부정확, 실제는 통합 완료)
+- line 145 "전달자 trait 의 정확한 효과 ... — sim 통합 위치 verify 필요" (부정확)
+- line 171 "(사용자 verify) 전달자 trait 효과 + sim 통합 위치" (부정확)
+
+→ 4 line 모두 같은 fact 의 다른 표기. 4개 finding 으로 잘게 raise 하지 말고 **단일 finding 으로 통합** ("전달자 trait 표기 부정확 — 본문 4 line 영향, 일괄 정정 필요"). 권장 fix 도 통합 patch 로.
+
+### 룰
+
+- 같은 entity (trait / champ / mechanic / augment) 의 같은 fact 가 페이지 내 다중 line 에 등장 시 → **단일 finding + 모든 영향 line 명시**
+- 모순 (line A "X 적용" + line B "X 미적용") 발견 시 → P1 이상 priority + Page-internal contradiction 명시
+- frontmatter 와 본문 모순 (예: `sim_active: true` + 본문 "🔍 검증 필요") → 단일 finding, frontmatter 정정 + 본문 정정 동시 권장
+
 ## Lint Output 형식 (subagent → main agent)
 
 ```markdown
 ## Lint Result: <page-path>
 
+**Entity type**: <champion | mechanic | carry-augment>
+**Verify 수행 단계**: 0 ✅ / 0-sub ✅ / 1 ✅ / 2 ✅ / 3 ✅ / 4 ✅ / 4-sub cast path ✅ / 5 ✅
+**Finding 통계**: raised P0 <N> / P1 <M> / P2 <K> / **downgraded known** <D>
+
 ### P0 (commit 전 fix 필수)
-- **[Finding name]** — 본문 위치 (line 또는 섹션 헤딩)
+- **[Finding name]** — 본문 위치 (line 또는 섹션 헤딩; 다중 line 영향 시 모두 명시)
   - 주장: "<인용>"
   - 검증: <grep / read 결과>
   - 회귀 위험: <sim 영향>
@@ -181,12 +218,17 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 ### P1 (follow-up 허용)
 - ...
 
-### P2 (다음 사이클)
+### P2 (다음 사이클; informational 포함)
 - ...
 
-### Self-catch metric
-- 본 lint 가 발견한 finding 중 사전 Codex review 와 중복: <N건>
-- 신규 finding: <M건>
+### Downgraded known findings (false-positive 방지 작동 사례)
+- **[#lint-history-num 또는 self-raised lint name]** — 본문 표기 ("PR #XYZ resolved" / "🔍 검증 필요" / "disable: true 자동 무효") + 코드 verify 결과로 downgrade
+- ...
+
+### Self-verify check
+- 9건 lint history 유사 패턴: #번호 인용
+- 본 lint 가 놓쳤을 가능성 영역: <명시>
+- 보강 권장 룰 (있으면): <항목>
 ```
 
 ## 9건 Lint History (학습 사례)
@@ -238,22 +280,33 @@ mordekaiser.md retro pilot 으로 subagent 동작 검증:
 - ✅ 본문 self-raised M1 lint (Concentration AugmentedDuration) 도 `disable: true` verify 후 P2 downgrade
 - Cost: 페이지당 Read 6회 + grep 9회 ≈ 15 tool call, sonnet 적정
 
-### Pilot 발견 prompt 보강 (4건, 후속 적용 예정)
+### Pilot 발견 prompt 보강 (4건, 본 룰셋 + subagent 에 적용 완료 2026-05-26)
 
-1. **Page-internal cross-check** — 같은 entity 가 페이지의 여러 line 에서 모순 표기 시 단일 finding 으로 통합
-2. **Line 번호 인용 정책** — `combatLoop.ts:XXXX-YYYY` line 인용의 stale risk vs 위키 일관성 trade-off 결정
-3. **Conditional augment `disable` 0단계 verify** — "특정 augment 활성 시" 효과 (M1 같은) 는 augment `"disable": true` 여부도 0단계로 추가
-4. **False-positive downgrade 통계** — output 에 "raised: N / downgraded known: M" 명시
+| # | 항목 | 적용 위치 |
+|---|------|-----------|
+| 1 | **Page-internal cross-check** — 같은 entity 가 페이지의 여러 line 에서 모순 표기 시 단일 finding 으로 통합 | "Page-internal Cross-check" 섹션 + Lint Output 형식 ("다중 line 영향 시 모두 명시") |
+| 2 | **Line 번호 인용 정책** — 허용 + drift > 10 line 시 P2 informational | "허용 / 금지" 섹션의 line 정책 sub-section |
+| 3 | **Conditional augment `disable` 0단계 verify** | "0. Entity set 소속" 의 0-sub section |
+| 4 | **False-positive downgrade 통계 필드** | "Lint Output 형식" 의 통계 라인 + "Downgraded known findings" 섹션 |
 
 ## 허용 / 금지
 
 ### ✅ 허용
 
-- 코드 ground truth (`src/...:identifier`) — line 번호는 즉시 stale 되므로 함수명까지만
+- 코드 ground truth (`src/...:identifier`) — **함수명 + line 번호 둘 다 허용** (이동 편의성). 단 line drift 시 P2 informational lint 가능 (아래 정책 참조)
 - Raw source (`public/data/tft_set17_*.json`, `docs/wiki/raw/`)
 - 패치노트 공식 URL
 - PR/commit 참조 (`#PR번호`, short hash)
 - PDCA plan/design — **도입 시점/동기 기록용으로만** (도메인 fact 는 코드 verify)
+
+#### Line 번호 인용 정책 (2026-05-26 결정)
+
+위키 페이지의 line 번호 인용 (`combatLoop.ts:524-529` 등) **허용**. 위키 22 페이지 (champion 4 + augment 10 + mechanic 5 + patch 3) 의 line 인용 관행 유지.
+
+- subagent 가 lint 시 인용 line 의 함수 여전히 존재하는지 grep 으로 확인 (선택적)
+- 인용 line 과 실제 함수 위치 **drift > 10 line** 인 경우만 **P2 informational** finding ("last_verified 업데이트 + line 번호 갱신 권장")
+- drift ≤ 10 line 또는 함수 자체 위치 변경 없음 → finding 불요
+- 함수 자체가 사라진 경우 (rename / 삭제) → **P0** (fact 의 ground truth 부재)
 
 ### ❌ 금지
 


### PR DESCRIPTION
## Summary

PR #152 mordekaiser.md retro pilot 에서 발견한 **prompt 보강 4건** 적용. `docs/wiki/lint-rules.md` (single source) + `.claude/agents/wiki-ingest-verifier.md` (subagent prompt) 양쪽 동시 갱신.

PR #152 가 infra (lint-rules + subagent + dispatch 룰) 도입 — 본 PR 은 그 infra 의 *첫 사용* 에서 검출된 미세 결함 보강.

## 변경 파일 (2개, +98 / -21)

| 파일 | 변경 |
|------|------|
| `docs/wiki/lint-rules.md` | Page-internal Cross-check 섹션 추가 / 0-sub conditional augment disable / line 정책 sub-section / Lint Output 형식 (통계 + Downgraded known findings) / Pilot 4건 적용 완료 표기 |
| `.claude/agents/wiki-ingest-verifier.md` | 실행 절차 7 → 9단계 (page-internal cross-check + line drift check 추가) / 출력 형식 통계·downgrade 섹션 / Champion 핵심 패턴 (0-sub augment disable + line drift grep) / 금지 사항 5건 추가 |

## 보강 4건 상세

### 1. Page-internal cross-check

같은 entity / fact 가 페이지 여러 line 에서 모순 표기 시 **단일 finding 으로 통합**.

**도입 사례** (mordekaiser.md pilot): 같은 "전달자 trait" 가 line 102 / 142 / 145 / 171 4 line 에서 다른 방식으로 부정확 표기. 4 finding 으로 잘게 raise 하지 않고 1 통합 finding 으로.

룰:
- 단일 finding + 모든 영향 line 명시
- 모순 (line A "X 적용" + line B "X 미적용") 발견 시 P1 이상 + contradiction 명시
- frontmatter ↔ 본문 모순도 동일

### 2. Line 번호 인용 stale 정책 (2026-05-26 결정 = 허용 + drift 시만 P2)

위키 22 페이지의 line 인용 관행 유지 (이동 편의성). lint subagent 는:
- drift > 10 line + 함수 위치 변경 시만 **P2 informational** ("last_verified + line 번호 갱신 권장")
- drift ≤ 10 line → finding 불요
- **함수 자체 사라짐** (rename / 삭제) → **P0** (fact ground truth 부재)

기존 룰 ("line 번호는 stale, 함수명까지만") 을 완화 — 위키 일관성 우선.

### 3. Conditional augment `disable: true` 0단계 verify

페이지에 **"특정 augment 활성 시 효과"** 주장이 있으면 그 augment 의 raw `disable` 필드 확인을 0단계 part 로 추가.

**도입 사례** (mordekaiser.md M1): "Concentration augment 활성 시 Duration 4→6초 미반영" 주장 → 실제 `TFT17_Augment_Concentration` `"disable": true` (set17 inactive) → 미반영 finding 자동 무효.

검증 패턴:
\`\`\`bash
node -e "const j=require('./public/data/tft_set17_augments.json'); const a=j.augments.find(x=>x.apiName==='TFT17_Augment_<Name>'); console.log({apiName:a?.apiName, disable:a?.disable})"
\`\`\`

\`disable: true\` 면 raise 안 함 (downgrade only).

### 4. False-positive downgrade 통계 필드

output 의 Finding 통계 라인에:
\`\`\`
Finding 통계: raised P0 N / P1 M / P2 K / downgraded known D
\`\`\`

별도 `Downgraded known findings` 섹션으로 false-positive 방지 작동 사례 명시:
- "PR #XYZ resolved" 표기 + 코드 verify
- "🔍 검증 필요" 명시적 보류 표기
- `disable: true` 자동 무효
- "Lint #N pending" 표기

→ self-catch rate metric 측정 정밀화.

## Pilot 검증 (PR #152) 의 효과 입증

mordekaiser.md pilot 결과:
- raised: P1 1 / P2 3 (신규 finding 4건 catch)
- downgraded known: 3건 (#3 entity-wide helper / #7 mana override / self-raised M1) — false-positive 룰 정상 작동

본 보강은 그 pilot 의 *부작용 시그널* (다중 line 모순 → 4 finding 으로 나뉜 것) 을 명시적으로 풀어 다음 retro 부터 더 깔끔한 output.

## 후속 작업

- **Task #7**: 5 페이지 retro lint (leona-carry / mordekaiser-carry / spell-crit / ability-targeting / hero-augment-carry) — 본 보강된 prompt 로 진행
- **Task #5**: 6 PR 운영 후 self-catch rate 평가 — Downgrade 통계 필드 덕에 측정 정밀화

## Test plan

- [ ] Reviewer: lint-rules.md 의 새 Page-internal Cross-check 섹션이 9건 history + mordekaiser pilot 사례를 정확히 반영하는지 확인
- [ ] Reviewer: 0-sub augment disable 검증 패턴 (node -e ...) 이 실제 raw json 구조와 일치하는지 확인
- [ ] Reviewer: line 번호 drift 정책 (> 10 line P2 / 함수 사라짐 P0) 의 임계값이 합리적인지 검토
- [ ] Reviewer: subagent prompt 의 실행 절차 9단계가 main agent 의 dispatch 후 후처리에 적합한 순서인지 확인
- [ ] Reviewer: 금지 사항 5건 신규 추가 항목이 false-positive 방지 룰과 정합한지 확인
- [ ] Follow-up: Task #7 retro lint 5 페이지에서 본 prompt 적용 → finding 통계 (raised / downgraded) 정확성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)