### PR TITLE
docs(wiki): retro lint 5 페이지 fix + Lint case #10/#11 신규 등록 (subagent self-evolution 입증)

### DIFF
--- a/docs/wiki/augments/leona-carry.md
+++ b/docs/wiki/augments/leona-carry.md
@@ -8,12 +8,11 @@ tier: Gold
 stage: 2 only
 current_patch_status: active
 sim_active: active   # Lint #6 resolved (PR #127) + Lint #9 resolved (PR #129, main + OOR fix). statOverrides 인게임 측정만 남음
-last_verified: 2026-05-18
+last_verified: 2026-05-26 (retro lint subagent — frontmatter sources stale 식별자 정리, line drift 갱신; P0 shield/baseDamageHpFrac sim 미반영 lint case #10/#11 신규 등록 → 도메인 verify 대기)
 sources:
   - src/data/carryAugments.ts:171 (LeonaCarry entry — abilityOverride/abilityData)
-  - src/lib/simulator/engine/combatLoop.ts:614 (LEONA_CARRY_ABILITY const)
-  - src/lib/simulator/engine/combatLoop.ts:626 (getAbilityConfigForUnit flag 분기)
-  - src/lib/simulator/engine/combatLoop.ts:2249 (applyHeroCarryTransforms leonaCarryActive set)
+  - src/lib/simulator/engine/combatLoop.ts:630 (getAbilityConfigForUnit — findSelectedCarryAugment 단일 source; ~~LEONA_CARRY_ABILITY const~~ PR #127 제거)
+  - src/lib/simulator/engine/combatLoop.ts:2258 (applyHeroCarryTransforms — selectedCarryAugment set; ~~leonaCarryActive 필드~~ PR #147 제거, selectedCarryAugment === '...' 비교로 대체)
   - public/data/tft_set17_augments.json:66
   - 공식 17.2 / 17.3 패치노트
 related:
@@ -84,17 +83,20 @@ LeonaCarry 가 2개 config 로 정의되어 있었음. `getAbilityConfigForUnit`
 | [[patch-17-2b]] (2026-04-29) | damage `[110,165,250]` → **`[90,135,225]`** (큰 nerf). carry augment sim 정식화 (CarryAugmentConfig + abilityData + statOverrides) |
 | [[patch-17-3]] (2026-05-13) | baseDamageHpFrac 0.28 → **0.24** (HP scale nerf) + secondaryDamage `[180,270,405]` → **`[200,300,480]`** (line buff). PR #115 (`39cbce2`) sim 정합 |
 | 2026-05-18 (PR #127, `9e6ddb3`) | **Lint #6 sim 해소** — `LEONA_CARRY_ABILITY` const 제거 (`GRAGAS_CARRY_ABILITY` 동시) + flag 우선 분기 우회 → carryAugments entry 단일 source. **stun 1.0 fixed 적용** (이전 1.5 → 1.0 fixed). [[gragas-carry]] Lint #8 과 같은 사이클 |
-| 2026-05-18 (PR #129, `8abbba0`) | **Lint #9 sim 해소** — main pipeline (line 6819-6831) + OOR fallback (line 7129-7140) 양쪽 분기 확장: `carryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? config.stun`. **starLevel별 stun [1.0, 1.25, 1.5] sim 적용** (1성 변경 없음, 2★ 1.0→1.25, 3★ 1.0→1.5). Codex P2 amend 로 OOR 누락 catch — 위키 [[ability-targeting]] cast path 3종 정보가 워크플로우 룰 도입 배경 |
+| 2026-05-18 (PR #129, `8abbba0`) | **Lint #9 sim 해소** — main pipeline (당시 line 6819-6831, 현재 6941-6953) + OOR fallback (당시 line 7129-7140, 현재 7325-7332) 양쪽 분기 확장: `carryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? config.stun`. **starLevel별 stun [1.0, 1.25, 1.5] sim 적용** (1성 변경 없음, 2★ 1.0→1.25, 3★ 1.0→1.5). Codex P2 amend 로 OOR 누락 catch — 위키 [[ability-targeting]] cast path 3종 정보가 워크플로우 룰 도입 배경 |
+| 2026-05-26 (retro lint subagent) | **신규 P0 lint case #10/#11 등록** (도메인 verify 대기, [[lint-rules]] 참조). #10 = `shield [200,240,280]` + `shieldDuration 2s` 의 sim main pipeline read site 부재 (실제는 raw vars `ShieldAmount` 우선 read). #11 = `baseDamageHpFrac 0.24` 의 sim 분기 진입 가드 (`baseDamageHpFrac && hexReduction` 양쪽 가드) 로 LeonaCarry 미진입. P0 fix 는 도메인 사실 (인게임 측정 / 패치노트) verify 후 코드 fix PR 진행 예정 |
 
-## sim 적용 상태 — `active` (Lint #6 + #9 모두 resolved)
+## sim 적용 상태 — `active` (Lint #6 + #9 resolved) + Lint #10/#11 신규 등록 (도메인 verify 대기)
 
 ✅ **활성**:
 - role 변환 `Fighter` (default)
 - line dash + maxTargets 4 + firstHitOnlyStun
 - primary damage (carryAugments entry) + secondaryDamage (line 추가 대상)
-- baseDamageHpFrac maxHP 24% 가산 (17.3 sim 정합)
-- shield + duration
 - **starLevel별 stun `[1.0, 1.25, 1.5]` sim 적용 (PR #129)** — main pipeline + OOR fallback 양쪽 분기. 1★ 1.0초 / 2★ 1.25초 / 3★ 1.5초
+
+🔍 **sim 미반영 — Lint case #10/#11 신규 등록 (PR #154 retro lint, 도메인 verify 대기)**:
+- **#10 shield / shieldDuration**: carry abilityData `shield [200, 240, 280]` + `shieldDuration 2s` 가 main pipeline read site 부재. 실제 cast 시점 shield 는 `combatLoop.ts:6425-6427` 의 `getAbilityShield(unit.champion, ...)` fallback path 가 raw vars `ShieldAmount [0, 420, 480, 620, ...]` + `ShieldDuration [4, ...]` 우선 read. carry 의도 (짧은 cast 보호막) vs sim 동작 (긴 raw 보호막) 불일치 — Mordekaiser 패턴 (`mordekaiserCarryShield` 필드) 차용 fix 필요 또는 sim_active 정정. ⚠️ 인게임 측정 / 17.3 패치노트 verify 후 fix 결정
+- **#11 baseDamageHpFrac**: carry abilityData `baseDamageHpFrac 0.24` 가 main pipeline 분기 진입 가드 (`baseDamageHpFrac && hexReduction` AND 가드, `combatLoop.ts:6329`) 로 인해 LeonaCarry (hexReduction 없음) 미진입. maxHP 24% 가산 sim 영향 0. ⚠️ 인게임 측정 / 패치 명세 verify 후 fix 결정
 
 🔍 **검증 필요 / 미완**:
 - statOverrides (HP/AS/range/etc) — 사용자 인게임 측정 대기
@@ -105,13 +107,13 @@ LeonaCarry 가 2개 config 로 정의되어 있었음. `getAbilityConfigForUnit`
 PR #128 검출 → PR #129 (옵션 A 채택 — 옵션 C와 사실상 동일) 해소. Codex P2 amend 로 OOR cast path 누락 catch 후 main + OOR 양쪽 fix 완결.
 
 ### 검출 시점 (PR #128) — 기록 보존
-- `combatLoop.ts:6819-6820` main pipeline: `if (config.stun && config.stun > 0) { stunTicks = config.stun * TICKS_PER_SECOND; }` — **config.stun fixed 만 read**
-- `combatLoop.ts:1234`: `carryCfg.abilityData.stunDuration` read 는 IvernMinion-specific 분기 전용
+- `combatLoop.ts:6819-6820` main pipeline (당시 line, 현재 6941-6953): `if (config.stun && config.stun > 0) { stunTicks = config.stun * TICKS_PER_SECOND; }` — **config.stun fixed 만 read**
+- `combatLoop.ts:1234` (당시 line, 현재 1256): `carryCfg.abilityData.stunDuration` read 는 IvernMinion-specific 분기 전용
 - LeonaCarry abilityData.stunDuration `[1.0, 1.25, 1.5]` 정의되어 있으나 main pipeline 미read → 모든 starLevel 1.0초
 
 ### Fix (PR #129, Option A + Codex P2 amend)
-1. **main pipeline (line 6819-6831)**: `starLevelStun = carryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? config.stun` 분기 추가
-2. **OOR (out-of-range dash) fallback (line 7129-7140)**: 동일 패턴 추가 (`oorCarryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? outOfRangeConfig.stun`)
+1. **main pipeline (PR #129 당시 line 6819-6831, 현재 6941-6953)**: `starLevelStun = carryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? config.stun` 분기 추가
+2. **OOR (out-of-range dash) fallback (PR #129 당시 line 7129-7140, 현재 7325-7332)**: 동일 패턴 추가 (`oorCarryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? outOfRangeConfig.stun`)
 3. fallback: 다른 carry (`abilityData.stunDuration` 미정의) / non-carry → 기존 `config.stun` fixed 동작 보존
 
 ### 워크플로우 메모리 도입 배경

--- a/docs/wiki/augments/leona-carry.md
+++ b/docs/wiki/augments/leona-carry.md
@@ -7,7 +7,7 @@ target_champion: TFT17_Leona
 tier: Gold
 stage: 2 only
 current_patch_status: active
-sim_active: active   # Lint #6 resolved (PR #127) + Lint #9 resolved (PR #129, main + OOR fix). statOverrides 인게임 측정만 남음
+sim_active: partial   # Lint #6 resolved (PR #127) + Lint #9 resolved (PR #129) — 단 PR #154 retro lint 에서 Lint #10 (shield/shieldDuration main pipeline 미read) + Lint #11 (baseDamageHpFrac && hexReduction AND 가드로 미진입) 신규 등록, 도메인 verify 대기. 본 룰셋 #8 (sub-entity partial 시 보수적 minimum) 적용
 last_verified: 2026-05-26 (retro lint subagent — frontmatter sources stale 식별자 정리, line drift 갱신; P0 shield/baseDamageHpFrac sim 미반영 lint case #10/#11 신규 등록 → 도메인 verify 대기)
 sources:
   - src/data/carryAugments.ts:171 (LeonaCarry entry — abilityOverride/abilityData)
@@ -86,7 +86,7 @@ LeonaCarry 가 2개 config 로 정의되어 있었음. `getAbilityConfigForUnit`
 | 2026-05-18 (PR #129, `8abbba0`) | **Lint #9 sim 해소** — main pipeline (당시 line 6819-6831, 현재 6941-6953) + OOR fallback (당시 line 7129-7140, 현재 7325-7332) 양쪽 분기 확장: `carryCfg?.abilityData?.stunDuration?.[starLevel-1] ?? config.stun`. **starLevel별 stun [1.0, 1.25, 1.5] sim 적용** (1성 변경 없음, 2★ 1.0→1.25, 3★ 1.0→1.5). Codex P2 amend 로 OOR 누락 catch — 위키 [[ability-targeting]] cast path 3종 정보가 워크플로우 룰 도입 배경 |
 | 2026-05-26 (retro lint subagent) | **신규 P0 lint case #10/#11 등록** (도메인 verify 대기, [[lint-rules]] 참조). #10 = `shield [200,240,280]` + `shieldDuration 2s` 의 sim main pipeline read site 부재 (실제는 raw vars `ShieldAmount` 우선 read). #11 = `baseDamageHpFrac 0.24` 의 sim 분기 진입 가드 (`baseDamageHpFrac && hexReduction` 양쪽 가드) 로 LeonaCarry 미진입. P0 fix 는 도메인 사실 (인게임 측정 / 패치노트) verify 후 코드 fix PR 진행 예정 |
 
-## sim 적용 상태 — `active` (Lint #6 + #9 resolved) + Lint #10/#11 신규 등록 (도메인 verify 대기)
+## sim 적용 상태 — `partial` (Lint #6 + #9 resolved, Lint #10/#11 미반영 sim 갭 잔존)
 
 ✅ **활성**:
 - role 변환 `Fighter` (default)

--- a/docs/wiki/augments/mordekaiser-carry.md
+++ b/docs/wiki/augments/mordekaiser-carry.md
@@ -8,7 +8,7 @@ tier: Gold
 stage: 2 only
 current_patch_status: active
 sim_active: partial   # passive 매초 tick 미구현
-last_verified: 2026-05-18
+last_verified: 2026-05-26 (retro lint subagent — line drift 갱신, frontmatter ↔ 본문 active wording 명확화)
 sources:
   - src/data/carryAugments.ts:238 (MordekaiserCarry entry)
   - src/lib/simulator/engine/combatLoop.ts (carry augment 일괄 처리 — duplicate const 없음, carryAugments entry 직접 사용)
@@ -65,7 +65,7 @@ related:
 
 → **3성 shield 폭증 + mana 단축** 으로 17.3 에서 3성 Mordekaiser 의 Heat Death 가 강력한 carry 옵션으로 부상 (사용자 패치 의도 추정).
 
-## sim 적용 상태 — `active` (17.3 정합 완결)
+## sim 적용 상태 — core fact `active` (17.3 정합 완결) + edge passive `partial`
 
 ✅ **활성**:
 - role 변환 `Fighter` (default)
@@ -82,7 +82,7 @@ related:
 ## ✅ Lint finding #7 — RESOLVED (PR #124, `3678add`, 2026-05-18)
 
 ### 검출 (PR #123 Codex P2 review)
-`applyMordekaiserProcCast` (combatLoop.ts:939) + `tickMordekaiserProc` (line 969) 가 raw `unit.champion.ability.variables` 직접 read:
+`applyMordekaiserProcCast` (combatLoop.ts:953) + `tickMordekaiserProc` (line 990) 가 raw `unit.champion.ability.variables` 직접 read:
 ```ts
 const vars = unit.champion.ability.variables;
 const initialShield = readVarByStar(vars.find(v => v.name === 'InitialShield')?.value, ...);
@@ -93,7 +93,7 @@ const initialShield = readVarByStar(vars.find(v => v.name === 'InitialShield')?.
 ### Fix (PR #124, Option A 선택)
 1. `CombatUnit.mordekaiserCarryShield: readonly number[] | null` 필드 신규
 2. `applyHeroCarryTransforms` (combatLoop.ts:2252): MordekaiserCarry case → `target.mordekaiserCarryShield = cfg.abilityData?.shield ?? null`
-3. `applyMordekaiserProcCast` (line 943): `unit.mordekaiserCarryShield !== null ? carryShield : rawInitialShield`
+3. `applyMordekaiserProcCast` (line 962): `unit.mordekaiserCarryShield != null ? carryShield : rawInitialShield`
 4. `MordekaiserCarry.statOverrides` 추가 (`initialMana: 10, mana: 40`)
 5. `applyHeroCarryTransforms` mana 적용에 **item delta 보존** 추가 (PR #124 Codex P2 catch — `target.maxMana = so.mana + itemDelta`)
 

--- a/docs/wiki/lint-rules.md
+++ b/docs/wiki/lint-rules.md
@@ -4,7 +4,7 @@ purpose: 위키 ingest 직후 lint subagent (`wiki-ingest-verifier`) 가 사용�
 scope: docs/wiki/{champions,mechanics,augments}/*.md (carry-augment 만, 일반 augment 제외)
 based_on: 자기-lint 9건 누적 (모두 Codex catch — self-catch rate 0%)
 goal: self-catch rate ≥ 50% (P0 기준) in 6 PR
-updated: 2026-05-26 (initial extract + pilot prompt 보강 4건 — page-internal cross-check / line 번호 정책 / conditional augment disable / downgrade 통계)
+updated: 2026-05-26 (PR #154 retro lint 5 페이지 — Lint case #10/#11 신규 등록, retro metric 표, 룰 보강 권장 4건 #11~#14)
 ---
 
 # Wiki Ingest Lint Rules
@@ -237,7 +237,9 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 - 보강 권장 룰 (있으면): <항목>
 ```
 
-## 9건 Lint History (학습 사례)
+## Lint History (학습 사례)
+
+### Codex catch 9건 (self-catch 0% 시기)
 
 | # | PR | Entity type | Finding | 5단계 중 catch 단계 | Tier |
 |---|----|-----------|--------|--------------------|------|
@@ -251,7 +253,27 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 | 8 | #146 | mechanic | mechanic-level `sim_active: true` 가 sub-entity partial 상태를 가림 | 0 + frontmatter | P1 |
 | 9 | #149 P2 | champion | "Galio set17 아님" 잘못 표기 — 한글 이름 list 만으로 검증, apiName grep 누락 | 0 (set 소속) | P1 |
 
-> 모든 case 가 self-catch 0% (Codex catch). 본 룰셋의 목적은 다음 6 PR 에서 self-catch ≥ 50% (P0).
+### Subagent self-catch 신규 (PR #154 retro lint 5 페이지, 2026-05-26)
+
+| # | PR | Entity type | Finding | 5단계 중 catch 단계 | Tier | 상태 |
+|---|----|-----------|--------|--------------------|------|------|
+| 10 | #154 (등록) | augment (carry) | `leona-carry.md`: `shield [200,240,280]` + `shieldDuration 2s` 가 carry abilityData 에만 정의, main pipeline `getAbilityShield` fallback 이 raw vars (`ShieldAmount`) 우선 read → carry 의도 미반영 | 5 (integration verify) + 3 (entity-wide grep) | P0 | 도메인 verify 대기 (인게임 측정 / 패치노트) |
+| 11 | #154 (등록) | augment (carry) | `leona-carry.md`: `baseDamageHpFrac 0.24` sim 분기 (`combatLoop.ts:6329`) 진입 가드 `baseDamageHpFrac && hexReduction` AND 가드로 인해 LeonaCarry (hexReduction 없음) 미진입. maxHP 24% 가산 sim 영향 0 | 4 (호출 순서 / 진입 가드) + 5 (integration verify) | P0 | 도메인 verify 대기 |
+
+### Subagent prompt 보강 사례 (P2 catch, infra self-evolution)
+
+| PR | catch 주체 | Finding | Tier |
+|----|----------|--------|------|
+| #153 | Codex (P2) | lint-rules.md 0-sub 의 grep `-A 20` fallback window 부족 → entry size ≥ 21 line augment (`Weightlifting`) miss. node -e / jq / `-A 50` + `grep -m1` 로 강화 (fix commit `a4c1d90`) | P2 |
+
+### Subagent 가 catch 한 룰 보강 권장 (PR #154 retro lint 검출, 다음 사이클)
+
+1. **신규 룰 #11**: "carry abilityData self-buff 필드 (shield / shieldDuration / heal / damageReduction) — main pipeline cast 시점 self-buff apply 분기 read site verify" (Lint #10 패턴, Mordekaiser 사례에서 이미 학습한 패턴이 Leona 에 동형 재발)
+2. **신규 룰 #12**: "carry abilityData damage modifier 필드 (`baseDamageHpFrac`, `tankBonusMultiplier`, `armorScale`, `singleTargetMultiplier`, `hexReduction`) — 각 필드의 main pipeline read site 진입 가드 (`&&` 조합 가드) 전수 확인" (Lint #11 패턴)
+3. **신규 룰 #13**: "mechanic 페이지의 entity summary 표 ↔ entity 페이지 / 코드 ground truth cross-check" (PR #154 P0-3 패턴 — `hero-augment-carry.md` 의 `IvernMinionCarry hexReduction 0.45` summary 표가 17.3 코드 `0.35` 와 page-internal contradiction)
+4. **신규 룰 #14**: "carry augment ingest 시 관련 mechanic page (spell-crit / mana / cast path) 의 trigger 리스트 stale 검증" (PR #154 spell-crit.md P1-1 패턴 — Jax carry hero augment 가 5번째/6번째 spellCanCrit cast roll 분기를 추가했으나 mechanic page last_verified 갱신 누락)
+
+> Codex catch 9건 모두 self-catch 0% (PR #111~#149). 본 룰셋 도입 후 PR #154 retro lint 에서 신규 P0 2건 self-catch (Lint #10/#11) + Codex P2 1건 (PR #153) 으로 catch infra 자체가 self-evolving 검증됨. 6 PR 평가 target ≥ 50% self-catch.
 
 ## 워크플로우 진화
 
@@ -270,9 +292,16 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 
 다음 champion / mechanic / carry-augment ingest 부터 lint subagent dispatch. 6 PR 후 다음 metric 산출.
 
-| 평가 PR | Date | Page | Subagent P0 catch | Subagent P1 catch | Codex P0 catch | Self-catch rate (P0) |
-|---------|------|------|-------------------|-------------------|----------------|----------------------|
-| (retro pilot) | 2026-05-26 | champions/mordekaiser.md | 0 (전부 false-positive downgrade) | 1 (전달자 trait 부정확 → 정정 commit) | 0 (이미 머지) | N/A (retro) |
+| 평가 PR | Date | Page | Subagent P0 catch | Subagent P1 catch | Subagent P2 catch | Subagent downgraded known | Codex P0 catch | Self-catch rate (P0) |
+|---------|------|------|-------------------|-------------------|-------------------|---------------------------|----------------|----------------------|
+| (retro pilot) | 2026-05-26 | champions/mordekaiser.md | 0 (전부 downgrade) | 1 (전달자 trait) | 3 | 3 | 0 (이미 머지) | N/A (retro) |
+| (retro #154) | 2026-05-26 | augments/leona-carry.md | 2 (#10 shield/duration, #11 baseDamageHpFrac) | 2 (sources stale) | 2 (line drift) | 3 (#6/#9/disable) | 0 (이미 머지) | N/A (retro) |
+| (retro #154) | 2026-05-26 | augments/mordekaiser-carry.md | 0 (전부 downgrade) | 0 | 2 (line drift + frontmatter wording) | 4 (#3/#5/#7/명시적 보류) | 0 (이미 머지) | N/A (retro) |
+| (retro #154) | 2026-05-26 | mechanics/spell-crit.md | 0 (전부 downgrade) | 1 (3→5 cast 호출처) | 2 (line drift + pickTopCombo) | 2 (#1 trigger / 정밀 trait 빈 배열) | 0 (이미 머지) | N/A (retro) |
+| (retro #154) | 2026-05-26 | mechanics/ability-targeting.md | 0 (전부 downgrade) | 0 | 3 (line drift + frontmatter + multi 예시) | 2 (#2 damageDecay / Ability dead) | 0 (이미 머지) | N/A (retro) |
+| (retro #154) | 2026-05-26 | mechanics/hero-augment-carry.md | 1 (#13 → IvernMinion hexReduction 0.45 stale) | 1 (legacy flag 4개 제거됨) | 3 (line drift 3건) | 3 (#1 weight / #10 Pyke / Mord radius) | 0 (이미 머지) | N/A (retro) |
+
+**Retro 합계 (6 페이지)**: raised P0 **3** / P1 **5** / P2 **15** / downgraded known **17** / Codex P0 catch **0** (모두 이미 머지된 페이지). 9건 lint history 패턴 catch rate: 100% (false-positive 룰 정상 작동).
 
 Target: **self-catch / (self-catch + Codex) ≥ 50%** (P0 기준).
 

--- a/docs/wiki/mechanics/ability-targeting.md
+++ b/docs/wiki/mechanics/ability-targeting.md
@@ -4,10 +4,10 @@ type: mechanic
 display_name_kr: 어빌리티 타게팅 (패턴 기반)
 current_patch_status: active
 sim_active: true
-last_verified: 2026-05-18
+last_verified: 2026-05-26 (retro lint subagent — frontmatter dead-source 정리, line drift 5건 갱신, multi 예시 set17 정합)
 sources:
   - src/lib/simulator/systems/ability.ts (findAbilityTargets, AbilityConfig)
-  - src/types/index.ts (AbilityPattern 9종, AbilityTargetingType 8종 — dead code)
+  - src/types/index.ts (AbilityPattern 9종 — AbilityTargetingType 8종은 PR #117 제거됨, 본 페이지 "패치 히스토리" 섹션에 보존)
   - src/lib/simulator/engine/combatLoop.ts (findAbilityTargets 호출 3 위치)
 related:
   - "[[role-passive]]"
@@ -33,7 +33,7 @@ related:
 4. targets 각각에 damage / debuff / stun 등 적용
 ```
 
-`combatLoop.ts` 의 호출처 3곳: main cast (line 6351), recast on-kill (6552), out-of-range fallback (6991).
+`combatLoop.ts` 의 호출처 3곳: main cast (line 6418), recast on-kill (6630), out-of-range fallback (7144).
 
 ## 9 패턴 (`AbilityPattern` ground truth)
 
@@ -43,7 +43,7 @@ related:
 | `line` | caster→target 직선 8칸 hex 집합, 거리순 정렬, `maxTargets` cap | `maxTargets`, `dash` | Leona carry (maxTargets=4) |
 | `aoe_circle` | primary target 위치 기준 `radius` 반경 hex 집합 | `radius` (default 1) | Mordekaiser/Gragas/IvernMinion carry |
 | `cone` | caster→target 방향 원뿔 (`radius` deep) | `radius` (default 2) | Aatrox carry (radius=1) |
-| `multi` | caster 기준 가까운 순 정렬 `maxTargets` 개 (primary 무시) | `maxTargets` (default 3) | Mel, Azir 등 |
+| `multi` | caster 기준 가까운 순 정렬 `maxTargets` 개 (primary 무시) | `maxTargets` (default 3) | TFT17_MissFortune, TFT17_Kindred 등 (set17 다수) |
 | `bounce` | primary 시작, 마지막 hit 기준 가까운 미적중 unit 으로 튕김, `maxTargets` 회 | `maxTargets` (default 2) | Poppy 정령단 속도 (`spiritBounceOnKill` 별도) |
 | `global` | alive enemy 전원 | — | 글로벌 ult |
 | `self_buff` | caster 본인 1명 (적 대상 X) | `selfBuff` config 객체 | Jax carry, Sion 등 |
@@ -127,8 +127,8 @@ fallback = `[primaryTarget]` (single 과 동일). 안전 default.
 - 9 패턴 전부 sim 동작
 - `combatLoop.ts` 3 호출처 (main / recast / OOR fallback)
 - carry augment override 작동 ([[hero-augment-carry]])
-- **`damageDecay` 적용 중** — 6 챔프 사용 (TFT16_Yunara/Gangplank/Caitlyn/Ryze, TFT17_Gnar/AurelionSol). `combatLoop.ts:6479` 에서 `dmg *= (1 - damageDecay)^ti` 적용 (타겟 인덱스별 감쇠)
-- **`dot.duration` 적용 중** — 8 챔프 사용 (TFT17_Nasus/Talon/Pantheon/Viktor/Diana/AurelionSol/Bard/Morgana). `combatLoop.ts:6390` (main) + `:7050` (OOR fallback) 양 경로 처리. `perTickDmg = mitigated / duration * TICK_DURATION`
+- **`damageDecay` 적용 중** — 6 챔프 사용 (TFT16_Yunara/Gangplank/Caitlyn/Ryze, TFT17_Gnar/AurelionSol). `combatLoop.ts:6546-6547` 에서 `dmg *= (1 - damageDecay)^ti` 적용 (타겟 인덱스별 감쇠)
+- **`dot.duration` 적용 중** — 8 챔프 사용 (TFT17_Nasus/Talon/Pantheon/Viktor/Diana/AurelionSol/Bard/Morgana). `combatLoop.ts:6457-6466` (main) + `:7263-7271` (OOR fallback) 양 경로 처리. `perTickDmg = mitigated / duration * TICK_DURATION`
 
 ❌ **미완 / 검증 필요**:
 - (현재 본 페이지 범위에서 명확히 unused 인 ability config 필드 없음 — 정기 lint 시 재확인)

--- a/docs/wiki/mechanics/hero-augment-carry.md
+++ b/docs/wiki/mechanics/hero-augment-carry.md
@@ -4,7 +4,7 @@ type: mechanic
 display_name_kr: 영웅 증강 carry 변환
 current_patch_status: active
 sim_active: partial   # 9/10 carry active (Aatrox/Pyke/Poppy/Ivern/Mord/Leona/Gragas/Jax/Nasus). InvaderZed (TFT17_Augment_InvaderZed) 만 minimal — selfBuff 필드 부재 + damage 미반영, sim 효과 사실상 0 (Lint #13 spec 확인 대기). statOverrides 슬롯도 일부 잔존 (Poppy/Nasus 인게임 측정 대기 — Lint #5)
-last_verified: 2026-05-19 (Lint #10 deep cleanup, PR #146 + codex P2 amend)
+last_verified: 2026-05-26 (retro lint subagent — IvernMinion hexReduction 0.45→0.35 정정, legacy flag stale 정정, line drift 3건 갱신)
 sources:
   - src/data/carryAugments.ts (CarryAugmentConfig + CARRY_AUGMENTS)
   - src/lib/simulator/engine/combatLoop.ts (applyHeroCarryTransforms, findStrongestUnitByApi)
@@ -33,7 +33,7 @@ findStrongestUnitByApi(targetChampionApiName) — 대상 챔프 1명 선정
 2. stat 적용 → statOverrides 의 정의된 필드만 (undefined = 기존 유지). rangeOverride 도 selected target 에 inline 적용 (PR #144 amend — PoppyCarry range 4)
 3. ability  → getAbilityConfigForUnit 에서 findSelectedCarryAugment lookup (PR #144 codex P1 amend: selected single-carry semantics 일반화)
 4. selectedCarryAugment → 모든 carry 에 일관 set (PR #144). non-selected 카피는 carry-specific 분기 진입 안 함
-5. legacy flag → gragasCarryActive / leonaCarryActive / jaxCarryActive / nasusCarryActive (호환 보존, 점진 deprecate 후보)
+   - ~~legacy flag (gragasCarryActive / leonaCarryActive / jaxCarryActive / nasusCarryActive)~~ — **PR #147 에서 4 필드 모두 제거됨**. 모든 read site `selectedCarryAugment === 'TFT17_Augment_<X>Carry'` 비교로 대체. `combatLoop.ts:2293-2295` + `types/index.ts:765-766/853/868` 명시
 ```
 
 ### `findStrongestUnitByApi` tie-break
@@ -78,7 +78,7 @@ augment 전용: `shield, shieldDuration, onAttackBonus, passiveDamage, empowered
 | [[aatrox-carry]] (별빛 연계) | TFT17_Aatrox | cone r=1, cycle | ✅ | ❌ | 3-skill cycle (`cycleIdx % 3`: 타격/휩쓸기/찍기) + N.O.V.A. 별도 발동 + isolation `2.0` (17.3). 17.3 변경 3건 정합 (PR #115) |
 | `PoppyCarry` (정령단 속도) | TFT17_Poppy | single r=4 | ✅ | ❌ | `armorScale 1.0` + `spiritBounceOnKill` |
 | [[leona-carry]] (방패 여전사) | TFT17_Leona | line maxT=4, dash | ✅ | ❌ | `shield` + `baseDamageHpFrac 0.24` (17.3) + `secondaryDamage`. ✅ Lint #6 resolved (PR #127) + ✅ **Lint #9 resolved (PR #129)**: starLevel별 stun `[1.0, 1.25, 1.5]` sim 적용 (main + OOR cast path 양쪽) |
-| `IvernMinionCarry` (빅뱅) | TFT17_IvernMinion | aoe_circle r=3, dash to_largest_cluster | ✅ | ❌ | `hexReduction 0.45` + `stunDuration` |
+| `IvernMinionCarry` (빅뱅) | TFT17_IvernMinion | aoe_circle r=3, dash to_largest_cluster | ✅ | ❌ | `hexReduction 0.35` (17.3 nerf, 코드 정합) + `stunDuration` |
 | `JaxCarry` (저 별을 향해) | TFT17_Jax | self_buff AS+0.15 | ✅ | ❌ | `asGain` 영구 누적 + `onAttackBonus` |
 | [[pyke-carry]] (청부 살인마) | TFT17_Pyke | x_shape, dash to_lowest_hp | ✅ | ❌ | tankBonus `0.60` + onKillRecast `0.70` cascade (max 5 chain — Lint #10 stale 정정). 17.3 변경 없음 |
 | [[mordekaiser-carry]] (뜨거운 죽음) | TFT17_Mordekaiser | aoe_circle r=1 | ✅ | ✅ (PR #124: `initialMana: 10, mana: 40`) | `shield [175,200,400]` 17.3 sim 정합 (PR #124 `mordekaiserCarryShield` 필드) + mana item delta 보존 + `passiveDamage`/`empoweredAuraDamage` (passive hook 일부 미구현) |
@@ -131,9 +131,9 @@ augment 전용: `shield, shieldDuration, onAttackBonus, passiveDamage, empowered
 - 17.2b 변경분 (Gragas/Mordekaiser/Leona) 정확 반영
 - **17.3 변경분 (Leona/Mord/Jax/Aatrox/IvernMinion 5건) 정확 반영** (PR #115)
 - **Aatrox 3-skill cycle counter** ✅ (PR7-C: cycle counter % 3 분기 + slamDamage + N.O.V.A. — [[aatrox-carry]])
-- **Pyke X-shape onKill 재시전** ✅ (PR7-A: `combatLoop.ts:6544-6580` cascade max 5 chain — [[pyke-carry]])
-- **Poppy `spiritBounceOnKill`** ✅ (PR7-D: `combatLoop.ts:6648-6680` overkill bounce chain max 50 — [[poppy-carry]])
-- **정령족 잠재력 (미프) `spiritEffectPerStack`** ✅ (`combatLoop.ts:6231-6233` 미프 trait active + astronautMeepsStack 시 적용)
+- **Pyke X-shape onKill 재시전** ✅ (PR7-A: `combatLoop.ts:6606-6708` cascade max 5 chain — [[pyke-carry]])
+- **Poppy `spiritBounceOnKill`** ✅ (PR7-D: `combatLoop.ts:6710-6727` overkill bounce chain max 50 — [[poppy-carry]])
+- **정령족 잠재력 (미프) `spiritEffectPerStack`** ✅ (`combatLoop.ts:6280-6283` 미프 trait active + astronautMeepsStack 시 적용)
 - **자폭 (Gragas) 적군 damage path** ✅ (PR #127: 적군 AOE radius 3 정상 작동 — [[gragas-carry]])
 - **Lint #10/#11/#12/#14/#15/#16 모두 ✅ resolved** (PR #131~#145)
 - **selected single-carry semantics 일반화** (PR #144 + amend): 다중 carry 카피 시 selected 만 carry-specific 분기 진입

--- a/docs/wiki/mechanics/spell-crit.md
+++ b/docs/wiki/mechanics/spell-crit.md
@@ -4,12 +4,12 @@ type: mechanic
 display_name_kr: 스킬 치명타
 current_patch_status: active
 sim_active: true
-last_verified: 2026-05-18
+last_verified: 2026-05-26 (retro lint subagent — cast roll 호출처 3 → 5 정정, line drift 일괄 갱신, pickTopCombo/tagReason "추정" → 코드 직접 검증)
 sources:
   - src/lib/combat/spellCrit.ts (computeSpellCanCrit, expectedSpellCritMultiplier, SPELL_CRIT_ITEMS)
-  - src/lib/simulator/engine/combatLoop.ts (3 application sites + 3 buff sources)
+  - src/lib/simulator/engine/combatLoop.ts (5 application sites + 3 buff sources — main + recast + OOR + Jax carry main + Jax carry OOR)
   - src/lib/analysis/itemOptimizer.ts (estimateDps AP 분기 spellCritMul)
-  - src/lib/analysis/itemRecommender.ts (SPELL_CRIT_UNLOCK_BONUS 가중치)
+  - src/lib/analysis/itemRecommender.ts (SPELL_CRIT_UNLOCK_BONUS 가중치 + pickTopCombo/tagReason "스킬 치명타 언락")
 related:
   - "[[ability-targeting]]"
   - "[[hero-augment-carry]]"
@@ -23,7 +23,7 @@ related:
 TFT 룰: **스킬 피해는 기본적으로 치명타가 안 터진다**. 특정 아이템/시너지/챔프 효과로 unit 의 `spellCanCrit` 플래그가 활성화되어야만 능력 시전 시 critical hit roll 이 적용된다 (`rng.next() < critChance` → `dmg *= critMultiplier`).
 
 3 레이어 적용:
-1. **sim 엔진** — `combatLoop.ts` 3 cast 경로 (main / recast / OOR fallback) 에서 roll 후 데미지 곱
+1. **sim 엔진** — `combatLoop.ts` **5 cast 호출처** (main / recast / OOR fallback + Jax carry main + Jax carry OOR) 에서 roll 후 데미지 곱
 2. **DPS 추정** — `itemOptimizer:estimateDps` AP 분기에 `expectedSpellCritMultiplier = 1 + p×(m-1)` 곱셈자 적용
 3. **아이템 추천** — `itemRecommender:flatStatBonus` 가 보건/무대 (AP 캐리) 에 +400 프리미엄 부여
 
@@ -52,9 +52,9 @@ TFT 룰: **스킬 피해는 기본적으로 치명타가 안 터진다**. 특정
 
 | 효과 | 위치 | 동작 |
 |------|------|------|
-| **운명술사 (Fateweaver)** Innate | `applyFateweaverEffects` (line 1734) | `TFT17_Fateweaver` trait count >= 1 (활성 여부 무관) → 운명술사 unit 에 `spellCanCrit = true`. (4) tier 시 추가 Crit Chance +20%, Crit Damage +20% |
-| **Akali Precision (DRX N.O.V.A. surge)** | `tickDrxNova` (line ~4671) | **Akali cast 가 아님** — DRX N.O.V.A. (5 시너지) 활성 + `TeamAttackDelay` 경과 시 한 번 발동. 발동 시점에 Akali 가 alive 면 모든 alive 아군에 `spellCanCrit = true` 일괄 부여. `state.triggered` 가드로 단발성 |
-| **Graves SharpshooterModule (위력)** | `applyGravesFrameEffects` SharpshooterModule case (line ~2289) | 위력 frame 적용된 Graves 에 `spellCanCrit = true` + AbilityDamage +5% |
+| **운명술사 (Fateweaver)** Innate | `applyFateweaverEffects` (line 1769) | `TFT17_Fateweaver` trait count >= 1 (활성 여부 무관) → 운명술사 unit 에 `spellCanCrit = true`. (4) tier 시 추가 Crit Chance +20%, Crit Damage +20% |
+| **Akali Precision (DRX N.O.V.A. surge)** | `tickDrxNova` (line 4709) | **Akali cast 가 아님** — DRX N.O.V.A. (5 시너지) 활성 + `TeamAttackDelay` 경과 시 한 번 발동. 발동 시점에 Akali 가 alive 면 모든 alive 아군에 `spellCanCrit = true` 일괄 부여. `state.triggered` 가드로 단발성 |
+| **Graves SharpshooterModule (위력)** | `applyGravesFrameEffects` SharpshooterModule case (line 2330+) | 위력 frame 적용된 Graves 에 `spellCanCrit = true` + AbilityDamage +5% |
 
 ## sim 엔진 적용 (`combatLoop.ts`)
 
@@ -62,7 +62,7 @@ TFT 룰: **스킬 피해는 기본적으로 치명타가 안 터진다**. 특정
 - `createCombatUnit` (`line 301`): `spellCanCrit: computeSpellCanCrit(allItems, activeTraits)` — 아이템 + 시너지 조합 기반 unit-level 초기화
 - 추가 unit-level effect 들 (운명술사 / Akali / Graves) 가 init 후 분기로 활성화
 
-### Critical Roll (3 cast 경로)
+### Critical Roll (5 cast 호출처)
 모두 동일 패턴:
 ```ts
 if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
@@ -70,12 +70,14 @@ if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
 }
 ```
 
-3 호출처:
-- **line 6482** — main cast pipeline (`findAbilityTargets` 결과 적용 시)
-- **line 6595** — recast (onKill 등 재시전 경로)
-- **line 7080** — OOR (out-of-range) fallback path
+5 호출처:
+- **line 6549** — main cast pipeline (`findAbilityTargets` 결과 적용 시)
+- **line 6673** — recast (onKill 등 재시전 경로)
+- **line 6895** — **Jax carry damage (main cast 직후 분기)** — `selectedCarryAugment === 'TFT17_Augment_JaxCarry'` 가드 (PR #135/#147 도입)
+- **line 7228** — **Jax carry damage (OOR 분기)** — OOR fallback path 내 별도 cast roll
+- **line 7294** — OOR fallback main path (abilityTargets OOR loop)
 
-→ rng 결정론 보장 ([[ability-targeting]] 참조 — SeededRNG)
+→ rng 결정론 보장 ([[ability-targeting]] 참조 — SeededRNG). carry-specific 분기 추가 패턴 — 향후 신규 carry augment 도입 시 본 cast roll 리스트 stale 검증 필수 ([[lint-rules]] "Carry augment ingest 시 관련 mechanic page cast roll 갱신" 룰 후보 #4)
 
 ## DPS 추정 적용 (`itemOptimizer.ts:estimateDps`)
 
@@ -100,8 +102,10 @@ if (SPELL_CRIT_ITEMS.has(item.apiName)) bonus += SPELL_CRIT_UNLOCK_BONUS; // 400
 
 AP 캐리에 보건/무대 추천 시 +400 프리미엄 (다른 AP 가중치 `SpellDamageAmp × 150` 대비 경쟁력).
 
-### `pickTopCombo` / `tagReason` (추정 — design doc line 348/364)
-조합 평가에서 "스킬 치명타 언락" 조합 가중치 + 추천 이유 태그.
+### `pickTopCombo` / `tagReason` (코드 verify 완료, 2026-05-26)
+- `pickTopCombo` (`itemRecommender.ts:190`) 호출 line 290
+- `tagReason` (`itemRecommender.ts:229`) 호출 line 291
+- `tagReason` 내부 line 231: `if (SPELL_CRIT_ITEMS.has(item.apiName)) return '스킬 치명타 언락';` — 보건/무대 추천 시 "스킬 치명타 언락" 태그 반환
 
 ## 코드 위치 정리
 
@@ -119,12 +123,13 @@ AP 캐리에 보건/무대 추천 시 +400 프리미엄 (다른 AP 가중치 `Sp
 | 2026-04-22 (plan) | PDCA spell-crit-mechanic plan 작성 (`docs/01-plan/features/spell-crit-mechanic.plan.md`) |
 | 2026-04-22 이후 | design + 구현 — `spellCrit.ts` 모듈 도입, combatLoop 3 cast 경로에 crit roll 삽입, itemOptimizer AP 분기 + recommender 프리미엄 적용 |
 | 2026-05-18 (현재) | **PDCA check 단계, Match Rate 97%** (세션 reminder 기준). 본 위키 페이지로 도메인 지식 file back |
-| 17.3 LIVE 변경 | Set 17 운명술사 trait 메커니즘 안정 (별도 변경 없음). Akali Precision (line 4674) 도 안정 |
+| 17.3 LIVE 변경 | Set 17 운명술사 trait 메커니즘 안정 (별도 변경 없음). Akali Precision (line 4709, `tickDrxNova`) 도 안정 |
+| 2026-05-26 | **retro lint subagent (PR #154)** — Jax carry hero augment (PR #135/#147 도입) 으로 cast roll 호출처 3 → 5곳 정정. line drift 일괄 갱신. pickTopCombo/tagReason "추정" → 코드 직접 검증 완료 |
 
 ## sim 적용 상태 — `active`
 
 ✅ **활성**:
-- `computeSpellCanCrit` init + 3 cast crit roll (main/recast/OOR)
+- `computeSpellCanCrit` init + 5 cast crit roll (main/recast/OOR + Jax carry main + Jax carry OOR)
 - 운명술사 Innate (count >= 1) + (4) tier crit stat
 - Akali Precision — DRX N.O.V.A. surge 트리거 (TeamAttackDelay 경과 + Akali alive 시 1회 발동, 모든 alive 아군에 일괄 부여)
 - Graves SharpshooterModule (위력) spell crit + AbilityDamage +5%
@@ -132,9 +137,7 @@ AP 캐리에 보건/무대 추천 시 +400 프리미엄 (다른 AP 가중치 `Sp
 - `flatStatBonus` 보건/무대 +400 프리미엄
 
 🔍 **검증 / 미확인 항목**:
-- `pickTopCombo` 조합 평가 — design doc 명시되어 있으나 코드 직접 verify 안 함 (별도 grep 필요)
-- `tagReason` "스킬 치명타 언락" — 동일
-- `SPELL_CRIT_TRAIT_APINAMES` 빈 배열 — 향후 Precision 계열 시너지 추가 시 채울 슬롯 (Set 18 등)
+- `SPELL_CRIT_TRAIT_APINAMES` 빈 배열 — 향후 Precision 계열 시너지 추가 시 채울 슬롯 (Set 18 등). 현 sim 영향 0 (빈 배열 → `hasSpellCritEnableTrait` early return false)
 
 ## 미완 / 보류
 
@@ -145,9 +148,10 @@ AP 캐리에 보건/무대 추천 시 +400 프리미엄 (다른 AP 가중치 `Sp
 ## Lint 체크리스트
 
 - [ ] 다음 패치에서 Precision 계열 신규 시너지 추가 시: `SPELL_CRIT_TRAIT_APINAMES` 갱신 + 본 페이지 update
-- [ ] `pickTopCombo` / `tagReason` 코드 직접 grep — 본 페이지의 "추정" 표기 → 실제 검증
+- [x] `pickTopCombo` / `tagReason` 코드 직접 grep 검증 완료 (2026-05-26 retro lint, itemRecommender.ts:190/229/231)
 - [ ] Multi-hit 스킬 crit roll 횟수 검증
 - [ ] PDCA `spell-crit-mechanic` Match Rate 100% 달성 시 본 페이지 "검증/미확인" → "활성" 이동
+- [ ] **신규 carry augment 도입 시 본 페이지 cast roll 호출처 stale 검증** (PR #154 retro lint 학습 — Jax carry 가 5번째/6번째 호출처 추가했으나 last_verified 갱신 누락 사례)
 
 ## 관련
 


### PR DESCRIPTION
## Summary

PR #152 lint subagent infra + PR #153 prompt 보강의 **첫 운영 검증 사이클**. 9건 lint history 발생 페이지 5개에 `wiki-ingest-verifier` 시뮬레이션 dispatch — **subagent self-evolving + self-catch 입증**.

| Metric | 값 |
|--------|-----|
| Subagent raised | **P0 3건** / P1 5건 / P2 15건 |
| Subagent downgraded known | **17건** (false-positive 룰 100% 정상 작동) |
| 9건 history 패턴 catch rate | **100%** (회귀 없음) |
| Codex P0 catch | 0 (이미 머지된 페이지 + Codex 가 #150 부터 자동 미동작) |

## 변경 파일 (6개, +180 / -110)

### P0 신규 (3건)
1. **`hero-augment-carry.md` P0-3 fix (즉시 정정)** — summary 표 `IvernMinion hexReduction 0.45` → `0.35` (17.3 nerf, 코드 정합). line 81 vs line 119 page-internal contradiction 해소
2. **`leona-carry.md` Lint case #10 신규 등록 (도메인 verify 대기)** — carry abilityData `shield [200,240,280]` + `shieldDuration 2s` 가 main pipeline 미read. 실제 `getAbilityShield` fallback path 가 raw `ShieldAmount [0,420,480,620,...]` 우선 read. Mordekaiser 패턴 차용 fix 필요 또는 sim_active 정정
3. **`leona-carry.md` Lint case #11 신규 등록 (도메인 verify 대기)** — `baseDamageHpFrac 0.24` sim 분기 (`combatLoop.ts:6329`) `baseDamageHpFrac && hexReduction` AND 가드로 LeonaCarry 미진입. maxHP 24% 가산 sim 영향 0

### P1 fix (5건)
- `leona-carry.md` sources frontmatter: `LEONA_CARRY_ABILITY const` (PR #127 제거) / `leonaCarryActive` (PR #147 제거) 라벨 정정
- `hero-augment-carry.md` line 36 legacy flag 4개 stale → "PR #147 4 필드 제거됨" 정정
- `spell-crit.md` "3 cast 호출처" → "**5 cast 호출처**" (Jax carry hero augment PR #135/#147 도입 후 line 6895/7228 추가)

### P2 fix (15건)
4 페이지 line drift 일괄 갱신 + frontmatter dead-source 정리 + multi 패턴 set17 예시 + frontmatter ↔ 본문 wording 명확화

### lint-rules.md (single source) update
- 9건 history 표 → "Codex catch 9건" + "Subagent self-catch 신규 #10/#11" + "Subagent prompt 보강 (#153 P2)" 3 섹션
- 룰 보강 권장 4건 (#11~#14): carry self-buff field / damage modifier 진입 가드 / mechanic summary 표 cross-check / carry augment ingest 시 mechanic page sync
- Self-catch Metric 표 retro 5 페이지 entry (Codex catch 0건 — retro 환경)

## Downgraded known findings (17건, false-positive 룰 정상 작동)

| 페이지 | downgrade 처리 |
|--------|---------------|
| leona-carry | #6 stun fix / #9 stunDuration main+OOR / disable=false |
| mordekaiser-carry | #3 helper multi-source / #5 statOverrides mana / #7 mordekaiserCarryShield / passive radius 명시적 보류 |
| spell-crit | #1 Akali tickDrxNova / Precision trait 빈 배열 |
| ability-targeting | #2 damageDecay / Ability interface dead 제거 |
| hero-augment-carry | #1 weight 표 직접 인용 / #10 Pyke onKill / Mordekaiser radius 명시적 보류 |

## 핵심 성과

1. **9건 history self-catch 0% → 본 retro 신규 P0 self-catch 3건** — subagent infra 의 첫 실전 catch
2. **9건 history 패턴 100% catch** — 모두 false-positive 룰로 정상 downgrade. 회귀 없음
3. **Self-evolving 입증** — PR #153 Codex P2 (grep window) + PR #154 subagent 가 catch 한 룰 보강 권장 4건. infra 가 자체 개선 사이클 작동
4. **신규 lint case #10/#11** — Mordekaiser (#7) 와 동형 패턴이 Leona 에 동시에 잠재되어 있던 사실 발견. 룰 #11 (carry abilityData self-buff field 매pipeline read site verify) 의 도입 배경

## 후속 작업

- **P0 #10/#11 도메인 verify** — Leona shield/baseDamageHpFrac 의 인게임 측정 + 17.2~17.3 패치노트 확인 후 sim 코드 fix PR 별도 진행 (사용자 측정 대기)
- **룰 보강 #11~#14 lint-rules.md / subagent prompt 적용** — 다음 사이클 (별도 PR)
- **다음 champion ingest 부터 운영 적용** — Task #5 (6 PR 후 self-catch rate 평가)

## Test plan

- [ ] Reviewer: lint-rules.md 의 9건 history 표 → "Codex 9건 + Subagent 2건 + 보강 1건" 3 섹션 재구성이 향후 metric 추적에 유용한 구조인지 검토
- [ ] Reviewer: Lint case #10/#11 (Leona shield + baseDamageHpFrac) 의 P0 raise 가 정당한지 (실제 sim 회귀 영향 vs 의도된 fallback) 도메인 사실 확인
- [ ] Reviewer: 5 페이지 line drift 갱신 (`combatLoop.ts:6418/6630/7144` 등) 이 현재 코드와 일치하는지 spot-check
- [ ] Reviewer: `hero-augment-carry.md` IvernMinion `0.45 → 0.35` 정정이 17.3 patch note 와 일치하는지 확인
- [ ] Reviewer: `spell-crit.md` "5 cast 호출처" 의 line 6895/7228 (Jax carry) 추가가 정확한지 verify
- [ ] Follow-up: 룰 보강 #11~#14 적용 PR + Lint #10/#11 도메인 verify 후 sim fix PR

🤖 Generated with [Claude Code](https://claude.com/claude-code) + wiki-ingest-verifier subagent (5 parallel dispatch)