### PR TITLE
docs(wiki): wiki-ingest-verifier 룰 보강 #11~#15 (PR #154 retro + Codex P2 학습)

### DIFF
--- a/.claude/agents/wiki-ingest-verifier.md
+++ b/.claude/agents/wiki-ingest-verifier.md
@@ -38,11 +38,12 @@ main agent 가 dispatch 시 다음 중 하나 또는 복수의 페이지 경로�
 4. **5단계 + 0단계 verify 수행**:
    - 0 set 소속 (+ 0-sub conditional augment `disable: true` verify) / 1 좁은 grep / 2 함수 컨텍스트 / 3 entity-wide grep / 4 호출 순서 (+ cast path 3종 sub-rule) / 5 actual integration verify
    - 각 단계마다 코드 grep / 함수 read 결과를 finding 의 근거로 인용
-5. **Entity-type 별 추가 checklist 적용** — lint-rules.md 의 entity-type 표 참조
-6. **Page-internal cross-check** (PR #152 도입) — 같은 entity / fact 가 페이지 여러 line 에서 모순 표기 시 **단일 finding 으로 통합**. frontmatter 와 본문 모순도 동일. lint-rules.md "Page-internal Cross-check" 섹션 참조
+5. **Entity-type 별 추가 checklist 적용** — lint-rules.md 의 entity-type 표 참조 (특히 **carry augment**: 룰 #11 self-buff field / #12 damage modifier 진입 가드 / #14 mechanic page sync, **mechanic**: 룰 #13 summary 표 cross-check)
+6. **Page-internal cross-check** (PR #152 도입 + PR #155 룰 #15 강화) — 같은 entity / fact 가 페이지 여러 line 에서 모순 표기 시 **단일 finding 으로 통합**. frontmatter 와 본문 모순도 동일. **본문에 P0 lint case (sim 미반영) 등록 시 frontmatter `sim_active: active` 유지 → P1 raise + `partial` 강등 권장** (룰 #15). lint-rules.md "Page-internal Cross-check" 섹션 참조
 7. **Line 번호 인용 drift 확인** (선택) — 본문/frontmatter 의 `src/...:NNNN` line 인용에 대해 인용 line 의 함수 여전히 존재하는지 grep. drift > 10 line 시만 P2 informational ("last_verified + line 번호 갱신 권장"), 함수 자체 사라짐은 P0. drift ≤ 10 line 은 finding 불요
-8. **Tiered finding 분류** — P0 / P1 / P2 (Severity Tier 정의는 lint-rules.md). False-positive 방지 룰 적용 (본문 "PR #XYZ resolved" / "🔍 검증 필요" / "disable: true 자동 무효" 표기 + 코드 verify 결과로 downgrade)
-9. **Output 보고** — 아래 형식 준수. `Finding 통계` 라인에 `raised P0/P1/P2 N/M/K + downgraded known D` 필수 명시. `Downgraded known findings` 섹션으로 false-positive 작동 사례 별도 보고
+8. **신규 carry augment ingest 시 mechanic page sync verify** (룰 #14, PR #155 도입) — 페이지가 carry augment 면 관련 mechanic page (spell-crit / mana / cast path / role-passive) 의 cast roll / trigger / 호출처 리스트가 신규 carry 의 분기를 반영하는지 grep 으로 확인. 누락 시 mechanic page 의 P1 finding 으로 raise
+9. **Tiered finding 분류** — P0 / P1 / P2 (Severity Tier 정의는 lint-rules.md). False-positive 방지 룰 적용 (본문 "PR #XYZ resolved" / "🔍 검증 필요" / "disable: true 자동 무효" 표기 + 코드 verify 결과로 downgrade)
+10. **Output 보고** — 아래 형식 준수. `Finding 통계` 라인에 `raised P0/P1/P2 N/M/K + downgraded known D` 필수 명시. `Downgraded known findings` 섹션으로 false-positive 작동 사례 별도 보고
 
 ## 출력 형식 (반드시 준수)
 
@@ -131,6 +132,12 @@ grep -rn "<trigger-identifier>" src/lib/simulator/
 
 # 2단계 — 함수 컨텍스트
 # grep hit line ± 50 line read 또는 함수 전체 read
+
+# 룰 #13 (PR #155 도입) — mechanic 페이지의 entity summary 표 cross-check
+# 페이지가 다른 페이지가 cross-ref 하는 권위 출처 (예: hero-augment-carry / role-passive)
+# 표의 각 entity 값 → entity 페이지 / 코드 ground truth 와 일치 verify
+grep -n "<entity-key>" src/data/carryAugments.ts  # 또는 src/lib/simulator/systems/...
+# 17.2 → 17.2b → 17.3 patch 변경 시 summary 표 sync 누락 catch
 ```
 
 ### Carry augment
@@ -140,7 +147,23 @@ grep -rn "<trigger-identifier>" src/lib/simulator/
 grep -rn "<EntityName>" src/lib/simulator/
 
 # 1단계 — entry
-grep -n "<EntityName>Carry" src/lib/simulator/carryAugments.ts
+grep -n "<EntityName>Carry" src/data/carryAugments.ts
+
+# 룰 #11 (PR #155 도입) — self-buff field main pipeline read site
+# 페이지가 abilityData.shield / shieldDuration / heal / damageReduction 정의 시
+grep -n "abilityData\?\.shield\|abilityData\?\.shieldDuration\|abilityData\?\.heal" src/lib/simulator/engine/combatLoop.ts
+# entity-specific 필드 (`*CarryShield` 패턴) 또는 일반 분기 우선 read 둘 중 하나 필수
+grep -n "<EntityName>CarryShield\|<EntityName>CarryHeal" src/lib/simulator/engine/combatLoop.ts src/types/index.ts
+
+# 룰 #12 (PR #155 도입) — damage modifier 진입 가드 (AND 조합) 전수 확인
+# 페이지가 baseDamageHpFrac / tankBonusMultiplier / armorScale / singleTargetMultiplier / hexReduction 정의 시
+grep -n -A 3 "ad\?\.baseDamageHpFrac\|ad\?\.hexReduction\|ad\?\.tankBonusMultiplier" src/lib/simulator/engine/combatLoop.ts
+# 진입 가드의 && 조합 확인 — 일부 필드만 정의된 carry 가 분기 진입 가능한지
+
+# 룰 #14 (PR #155 도입) — mechanic page sync (신규 cast roll / trigger 추가 시)
+# 페이지가 신규 carry 면 관련 mechanic 페이지의 호출처 리스트 verify
+grep -n "spellCanCrit && rng.next" src/lib/simulator/engine/combatLoop.ts  # spell-crit 호출처
+grep -n "gainManaOnAttack\|gainManaPerTick" src/lib/simulator/  # mana page 호출처
 ```
 
 ## 금지 사항
@@ -155,6 +178,11 @@ grep -n "<EntityName>Carry" src/lib/simulator/carryAugments.ts
 - ❌ **"특정 augment 활성 시 효과 미반영" finding raise 전 augment `disable: true` 확인 누락** — disable 이면 자동 무효 → finding 자체 raise 안 함 (downgrade only)
 - ❌ **같은 entity 의 여러 line 모순을 개별 finding 으로 raise** — page-internal cross-check 후 단일 통합 finding
 - ❌ **Line 번호 인용 자체를 finding 으로 raise** — line 인용은 허용. drift > 10 line + 함수 위치 변경 시만 P2 informational. 함수 자체 사라짐은 P0
+- ❌ **carry abilityData 의 self-buff 필드 (shield/shieldDuration/heal/damageReduction) 의 main pipeline read site verify 누락** (룰 #11, PR #155 도입) — entity-specific 필드 (`*CarryShield`) 또는 일반 분기 우선 read 둘 중 하나 필수. 없으면 P0
+- ❌ **carry abilityData damage modifier 필드의 진입 가드 (`&&` 조합) 전수 확인 누락** (룰 #12, PR #155 도입) — 일부 필드만 정의된 carry 가 의도된 분기 진입 가능한지. 미진입 시 sim 영향 0 → P0
+- ❌ **mechanic 페이지의 entity summary 표 stale 검증 누락** (룰 #13, PR #155 도입) — 표의 각 값 → entity 페이지 / 코드 ground truth cross-check 필수. mechanic 페이지가 다른 페이지의 권위 출처
+- ❌ **신규 carry augment ingest 시 관련 mechanic page (spell-crit / mana / cast path) sync verify 누락** (룰 #14, PR #155 도입) — cast roll / trigger 호출처 리스트 stale 시 P1
+- ❌ **본문 P0 lint case (sim 미반영) 등록 + frontmatter `sim_active: active` 유지** (룰 #15, PR #155 도입) — page-internal contradiction P1 raise + `partial` 강등 권장. 본 룰셋 #8 (mechanic-level 보수적 minimum) 의 carry-augment / champion 일반화
 - ❌ **Pass/fail 단순 판정** — 모든 finding 은 P0/P1/P2 tier + 근거 (grep 결과) + 권장 fix 동반
 - ❌ **Downgraded known findings 보고 누락** — false-positive 방지 작동 사례는 별도 섹션으로 명시 (Finding 통계 D 값에 카운트)
 

--- a/.claude/agents/wiki-ingest-verifier.md
+++ b/.claude/agents/wiki-ingest-verifier.md
@@ -151,19 +151,20 @@ grep -n "<EntityName>Carry" src/data/carryAugments.ts
 
 # 룰 #11 (PR #155 도입) — self-buff field main pipeline read site
 # 페이지가 abilityData.shield / shieldDuration / heal / damageReduction 정의 시
-grep -n "abilityData\?\.shield\|abilityData\?\.shieldDuration\|abilityData\?\.heal" src/lib/simulator/engine/combatLoop.ts
+# (ERE + 문자 클래스로 optional chaining `?.` 리터럴 매칭 — BRE `\?` 는 quantifier 라 false negative 발생)
+grep -nE "abilityData[?]\.(shield|shieldDuration|heal|damageReduction)" src/lib/simulator/engine/combatLoop.ts
 # entity-specific 필드 (`*CarryShield` 패턴) 또는 일반 분기 우선 read 둘 중 하나 필수
-grep -n "<EntityName>CarryShield\|<EntityName>CarryHeal" src/lib/simulator/engine/combatLoop.ts src/types/index.ts
+grep -nE "<EntityName>Carry(Shield|Heal|DamageReduction)" src/lib/simulator/engine/combatLoop.ts src/types/index.ts
 
 # 룰 #12 (PR #155 도입) — damage modifier 진입 가드 (AND 조합) 전수 확인
 # 페이지가 baseDamageHpFrac / tankBonusMultiplier / armorScale / singleTargetMultiplier / hexReduction 정의 시
-grep -n -A 3 "ad\?\.baseDamageHpFrac\|ad\?\.hexReduction\|ad\?\.tankBonusMultiplier" src/lib/simulator/engine/combatLoop.ts
+grep -nE -A 3 "ad[?]\.(baseDamageHpFrac|hexReduction|tankBonusMultiplier)" src/lib/simulator/engine/combatLoop.ts
 # 진입 가드의 && 조합 확인 — 일부 필드만 정의된 carry 가 분기 진입 가능한지
 
 # 룰 #14 (PR #155 도입) — mechanic page sync (신규 cast roll / trigger 추가 시)
 # 페이지가 신규 carry 면 관련 mechanic 페이지의 호출처 리스트 verify
 grep -n "spellCanCrit && rng.next" src/lib/simulator/engine/combatLoop.ts  # spell-crit 호출처
-grep -n "gainManaOnAttack\|gainManaPerTick" src/lib/simulator/  # mana page 호출처
+grep -rn "gainManaOnAttack\|gainManaPerTick" src/lib/simulator/  # mana page 호출처 (디렉토리 재귀 필수)
 ```
 
 ## 금지 사항

--- a/docs/wiki/lint-rules.md
+++ b/docs/wiki/lint-rules.md
@@ -4,7 +4,7 @@ purpose: 위키 ingest 직후 lint subagent (`wiki-ingest-verifier`) 가 사용�
 scope: docs/wiki/{champions,mechanics,augments}/*.md (carry-augment 만, 일반 augment 제외)
 based_on: 자기-lint 9건 누적 (모두 Codex catch — self-catch rate 0%)
 goal: self-catch rate ≥ 50% (P0 기준) in 6 PR
-updated: 2026-05-26 (PR #154 retro lint 5 페이지 — Lint case #10/#11 신규 등록, retro metric 표, 룰 보강 권장 4건 #11~#14)
+updated: 2026-05-26 (PR #155 룰 보강 #11~#15 적용 — carry self-buff field / damage modifier 진입 가드 / mechanic summary 표 cross-check / carry augment ingest 시 mechanic page sync / frontmatter ↔ P0 lint case 정합)
 ---
 
 # Wiki Ingest Lint Rules
@@ -164,6 +164,8 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 | Cast path 3종 (main / OOR / recast) 각 분기 일관성 | cast 변경 시 | Leona OOR stun 누락 (#9 amend) |
 | 절대값 stat override (`maxMana`, `maxHp` 등) 의 calculateStats 이후 호출 순서 | override 적용 시 | Mordekaiser mana 40 override → Tear 손실 (#7) |
 | Base ability variables 의 starLevel별 sim 적용 여부 (ShieldAP/FlatDR/MaxHealth 등) | 항상 | Jax base 5건 / Nasus base 4건 lint 후보 |
+| **Carry augment 활성 시 abilityData self-buff / damage modifier 가 base raw vars 보다 우선 read 되는지 verify** (룰 #11/#12 cross-ref, PR #155 도입) | carry augment 가진 champ | Mordekaiser shield 는 `mordekaiserCarryShield` 패턴 ✅. Leona / 다른 carry 도 동형 패턴 필요 (#154 #10/#11) |
+| **본문에 P0 lint case (sim 미반영) 등록 시 frontmatter `sim_active: active` 유지 → P1 raise + `partial` 강등 권장** (룰 #15, PR #155 도입) | P0 lint case 등록 시 | champion 페이지에 base ability vars sim 미반영 lint case (Jax L1~L5 등) 등록 시 sim_active 강등 검토 |
 
 ### Mechanic (`docs/wiki/mechanics/*.md`)
 
@@ -173,6 +175,7 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 | 트리거 함수의 컨텍스트 (단순 grep 라인 ❌, 함수 시그니처 + 호출처) | 항상 | spell-crit `spellCanCrit = true` → `tickDrxNova` (#1) |
 | `<field>` "미사용 같음" 추정 표기 시 grep 전수 확인 | 추정 표기 시 | `damageDecay` "미사용 추정" → 실제 6 챔프 + combatLoop active (#2) |
 | 패치별 active/inactive 분기 (current_patch_status frontmatter 와 본문 정합) | 항상 | Stargazer Fountain 17.2 inactive → 17.3 active |
+| **Entity summary 표 (carry 표 / 시너지 표 / 챔프 표) → entity 페이지 / 코드 ground truth cross-check** (룰 #13, PR #155 도입) | 항상 | hero-augment-carry `IvernMinion hexReduction 0.45` 표 stale → 코드 0.35 (#154 P0-3) |
 | `[[other-page]]` 링크 깨짐 / orphan | 항상 | dead link lint |
 
 ### Carry augment (`docs/wiki/augments/*-carry.md`)
@@ -184,6 +187,10 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 | `selfBuff` 필드 부재로 인한 sim no-op | new carry 도입 시 | Zed: selfBuff 부재 + damage 미반영 (#13) |
 | Cast path 3종 cycle/x_shape 일관성 | cycle/recast carry | Aatrox/Pyke follow-up verify |
 | 17.2 → 17.2b → 17.3 변경 누적 fact 정합 | 패치 boundary 페이지 | 3회 연속 변경 보존 |
+| **abilityData self-buff 필드 (`shield` / `shieldDuration` / `heal` / `damageReduction`) main pipeline cast-time apply 분기 read site verify** (룰 #11, PR #155 도입) | self-buff 필드 정의 시 | Leona shield/duration → raw `ShieldAmount` 우선 read (#154 #10). Mordekaiser 패턴 (`mordekaiserCarryShield` 필드) 차용 fix 필수 |
+| **abilityData damage modifier 필드 (`baseDamageHpFrac` / `tankBonusMultiplier` / `armorScale` / `singleTargetMultiplier` / `hexReduction`) 의 main pipeline read site 진입 가드 (`&&` 조합) 전수 확인** (룰 #12, PR #155 도입) | damage modifier 필드 정의 시 | Leona baseDamageHpFrac → `baseDamageHpFrac && hexReduction` AND 가드로 미진입 (#154 #11) |
+| **신규 carry augment 도입 시 관련 mechanic page (spell-crit / mana / cast path / role-passive) 의 cast roll / trigger / 호출처 리스트 stale 검증 + last_verified 갱신** (룰 #14, PR #155 도입) | 신규 carry / cast path 변경 시 | Jax carry hero augment (PR #135/#147) 가 5번째/6번째 spellCanCrit cast roll 추가 → spell-crit.md last_verified 갱신 누락 (#154 P1-1) |
+| **본문에 P0 lint case (sim 미반영) 등록 시 frontmatter `sim_active: active` 유지 → page-internal contradiction P1 raise + `partial` 강등 권장** (룰 #15, PR #155 도입, 룰 #8 의 carry-augment / champion 일반화) | P0 lint case 등록 시 | leona-carry frontmatter active ↔ 본문 Lint #10/#11 등록 모순 (#154 codex P2) |
 
 ## Page-internal Cross-check (PR #152 retro pilot 도입)
 
@@ -204,6 +211,7 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 - 같은 entity (trait / champ / mechanic / augment) 의 같은 fact 가 페이지 내 다중 line 에 등장 시 → **단일 finding + 모든 영향 line 명시**
 - 모순 (line A "X 적용" + line B "X 미적용") 발견 시 → P1 이상 priority + Page-internal contradiction 명시
 - frontmatter 와 본문 모순 (예: `sim_active: true` + 본문 "🔍 검증 필요") → 단일 finding, frontmatter 정정 + 본문 정정 동시 권장
+- **본문에 P0 lint case (sim 미반영) 등록 시 frontmatter `sim_active: active` 유지** → page-internal contradiction P1 raise + `partial` 강등 권장 (룰 #15, PR #155 도입). 본 룰셋 #8 (PR #146 mechanic-level 보수적 minimum) 의 carry-augment / champion 일반화. **사례**: leona-carry frontmatter active ↔ 본문 Lint #10/#11 등록 모순 (#154 codex P2)
 
 ## Lint Output 형식 (subagent → main agent)
 
@@ -262,18 +270,24 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 
 ### Subagent prompt 보강 사례 (P2 catch, infra self-evolution)
 
-| PR | catch 주체 | Finding | Tier |
-|----|----------|--------|------|
-| #153 | Codex (P2) | lint-rules.md 0-sub 의 grep `-A 20` fallback window 부족 → entry size ≥ 21 line augment (`Weightlifting`) miss. node -e / jq / `-A 50` + `grep -m1` 로 강화 (fix commit `a4c1d90`) | P2 |
+| PR | catch 주체 | Finding | Tier | 해소 |
+|----|----------|--------|------|------|
+| #153 | Codex (P2) | lint-rules.md 0-sub 의 grep `-A 20` fallback window 부족 → entry size ≥ 21 line augment (`Weightlifting`) miss. node -e / jq / `-A 50` + `grep -m1` 로 강화 | P2 | PR #153 fix commit `a4c1d90` ✅ |
+| #154 | Codex (P2) | leona-carry frontmatter `sim_active: active` ↔ 본문 P0 Lint #10/#11 등록 (sim 미반영) 모순. 본 룰셋 #8 (PR #146 mechanic-level 보수적 minimum) 의 carry-augment / champion 일반화 누락 | P2 | PR #154 fix commit `3e0412d` + **신규 룰 #15** 등록 (PR #155) ✅ |
 
-### Subagent 가 catch 한 룰 보강 권장 (PR #154 retro lint 검출, 다음 사이클)
+### 룰 보강 #11~#15 (PR #155 적용 완료, 2026-05-26)
 
-1. **신규 룰 #11**: "carry abilityData self-buff 필드 (shield / shieldDuration / heal / damageReduction) — main pipeline cast 시점 self-buff apply 분기 read site verify" (Lint #10 패턴, Mordekaiser 사례에서 이미 학습한 패턴이 Leona 에 동형 재발)
-2. **신규 룰 #12**: "carry abilityData damage modifier 필드 (`baseDamageHpFrac`, `tankBonusMultiplier`, `armorScale`, `singleTargetMultiplier`, `hexReduction`) — 각 필드의 main pipeline read site 진입 가드 (`&&` 조합 가드) 전수 확인" (Lint #11 패턴)
-3. **신규 룰 #13**: "mechanic 페이지의 entity summary 표 ↔ entity 페이지 / 코드 ground truth cross-check" (PR #154 P0-3 패턴 — `hero-augment-carry.md` 의 `IvernMinionCarry hexReduction 0.45` summary 표가 17.3 코드 `0.35` 와 page-internal contradiction)
-4. **신규 룰 #14**: "carry augment ingest 시 관련 mechanic page (spell-crit / mana / cast path) 의 trigger 리스트 stale 검증" (PR #154 spell-crit.md P1-1 패턴 — Jax carry hero augment 가 5번째/6번째 spellCanCrit cast roll 분기를 추가했으나 mechanic page last_verified 갱신 누락)
+본 5건 보강은 PR #154 retro lint + Codex catch 학습. lint-rules.md (entity-type checklist + Page-internal Cross-check) + `.claude/agents/wiki-ingest-verifier.md` (실행 절차 + 핵심 패턴 + 금지 사항) 양쪽 동시 갱신.
 
-> Codex catch 9건 모두 self-catch 0% (PR #111~#149). 본 룰셋 도입 후 PR #154 retro lint 에서 신규 P0 2건 self-catch (Lint #10/#11) + Codex P2 1건 (PR #153) 으로 catch infra 자체가 self-evolving 검증됨. 6 PR 평가 target ≥ 50% self-catch.
+| # | 룰 | 도입 사례 | 적용 위치 |
+|---|----|----------|-----------|
+| #11 | carry abilityData self-buff 필드 (shield / shieldDuration / heal / damageReduction) — main pipeline cast 시점 self-buff apply 분기 read site verify | Lint #10 (Leona shield, Mordekaiser 동형 재발) | Entity-type checklist "Carry augment" + "Champion" cross-ref |
+| #12 | carry abilityData damage modifier 필드 (`baseDamageHpFrac` / `tankBonusMultiplier` / `armorScale` / `singleTargetMultiplier` / `hexReduction`) — 각 필드의 main pipeline read site 진입 가드 (`&&` 조합) 전수 확인 | Lint #11 (Leona baseDamageHpFrac && hexReduction AND 가드) | Entity-type checklist "Carry augment" + "Champion" cross-ref |
+| #13 | mechanic 페이지의 entity summary 표 ↔ entity 페이지 / 코드 ground truth cross-check | PR #154 P0-3 (hero-augment-carry `IvernMinion hexReduction 0.45` 표 stale) | Entity-type checklist "Mechanic" |
+| #14 | 신규 carry augment 도입 시 관련 mechanic page (spell-crit / mana / cast path / role-passive) 의 cast roll / trigger / 호출처 리스트 stale 검증 + last_verified 갱신 | PR #154 spell-crit.md P1-1 (Jax carry 가 cast roll 호출처 2개 추가했으나 mechanic page last_verified 갱신 누락) | Entity-type checklist "Carry augment" |
+| #15 | 본문에 P0 lint case (sim 미반영) 등록 시 frontmatter `sim_active: active` 유지 → P1 raise + `partial` 강등 권장 (룰 #8 의 carry-augment / champion 일반화) | PR #154 codex P2 (leona-carry self-rule violation) | Entity-type checklist "Carry augment" + "Champion" + Page-internal Cross-check 룰 |
+
+> Codex catch 9건 모두 self-catch 0% (PR #111~#149). 본 룰셋 도입 후 PR #154 retro lint 에서 신규 P0 2건 self-catch (Lint #10/#11) + Codex P2 2건 (PR #153/#154) 으로 catch infra 자체가 self-evolving 검증됨. 룰 #11~#15 적용 (PR #155) 후 다음 champion ingest 부터 운영 적용. 6 PR 평가 target ≥ 50% self-catch.
 
 ## 워크플로우 진화
 


### PR DESCRIPTION
## Summary

PR #152 (infra) + PR #153 (prompt 보강 4건) + PR #154 (retro lint 5 페이지 + Codex P2) 의 누적 학습으로 **5건 룰 보강**. 다음 champion ingest 운영 적용 전 마지막 보강 사이클.

`docs/wiki/lint-rules.md` (single source) + `.claude/agents/wiki-ingest-verifier.md` (subagent prompt) 양쪽 동시 갱신 (+57 / -15).

## 룰 #11~#15

| # | 룰 | 도입 사례 | 적용 위치 |
|---|----|----------|-----------|
| **#11** | carry abilityData self-buff 필드 (shield/shieldDuration/heal/damageReduction) main pipeline read site verify | Lint #10 (Leona shield, Mordekaiser 동형 재발) | Entity-type checklist Carry augment + Champion cross-ref |
| **#12** | carry abilityData damage modifier 필드 (`baseDamageHpFrac`, `tankBonusMultiplier`, `armorScale`, `singleTargetMultiplier`, `hexReduction`) 진입 가드 (`&&` 조합) 전수 확인 | Lint #11 (Leona baseDamageHpFrac && hexReduction AND 가드 미진입) | Entity-type checklist Carry augment + Champion cross-ref |
| **#13** | mechanic 페이지 entity summary 표 → entity 페이지 / 코드 ground truth cross-check | PR #154 P0-3 (`IvernMinion hexReduction 0.45` 표 stale, 코드 0.35) | Entity-type checklist Mechanic |
| **#14** | 신규 carry augment ingest 시 관련 mechanic page (spell-crit / mana / cast path / role-passive) sync verify | PR #154 spell-crit P1-1 (Jax carry 가 cast roll 2 추가, mechanic page last_verified 갱신 누락) | Entity-type checklist Carry augment + 실행 절차 #8 신설 |
| **#15** | 본문 P0 lint case 등록 시 frontmatter `sim_active: active` 유지 → page-internal contradiction P1 raise + `partial` 강등 권장 | PR #154 codex P2 (leona-carry self-rule violation, 룰 #8 의 일반화 누락) | Entity-type checklist Carry augment + Champion + Page-internal Cross-check 룰 + 실행 절차 #6 강화 |

## 변경 detail

### `lint-rules.md`
- Entity-type checklist Champion 행 2개 추가 (#11/#12 cross-ref + #15)
- Entity-type checklist Carry augment 행 4개 추가 (#11/#12/#14/#15)
- Entity-type checklist Mechanic 행 1개 추가 (#13)
- Page-internal Cross-check 룰 1개 추가 (#15)
- "Subagent prompt 보강 사례" 표에 PR #154 Codex P2 (leona-carry frontmatter) entry 추가 — Codex P2 catch 2건 누적
- "Subagent 가 catch 한 룰 보강 권장 4건" → "**룰 보강 #11~#15 (PR #155 적용 완료)** 5건 표" 재구성

### Subagent prompt
- 실행 절차 9단계 → **10단계** (#8 mechanic page sync verify 신설)
- 절차 #5 entity-type checklist 적용 시 룰 #11/#12/#13/#14 cross-ref
- 절차 #6 Page-internal cross-check 에 룰 #15 강화
- 핵심 패턴 Champion 섹션 — 룰 #11 self-buff field grep + 룰 #12 damage modifier 진입 가드 grep + 룰 #14 mechanic page sync grep 추가
- 핵심 패턴 Mechanic 섹션 — 룰 #13 summary 표 cross-check grep 추가
- **금지 사항 5건 추가** (룰 #11~#15 누락 시 P0/P1 명시)

## Infra Self-evolution 추적 (누적)

| PR | Catch 패턴 | 결과 |
|----|----------|------|
| #152 | Pilot subagent 발견 4건 보강 권장 → 권장만 등록 | PR #153 적용 |
| #153 | Codex P2 (grep window 부족) | #153 fix commit + 룰 정정 |
| #154 | retro 신규 P0 self-catch 2건 (#10/#11) + Codex P2 (frontmatter ↔ 본문) | PR #154 fix + 본 PR 룰 #11~#15 등록 |
| **#155** (본 PR) | 룰 #11~#15 적용 완료 | 다음 champion ingest 운영 |

## 다음 작업

- 본 룰 보강 적용된 subagent 로 다음 champion ingest (**greenfield 운영 시작**)
- Task #5: 6 PR 후 self-catch rate 평가 — Codex catch reduction + subagent 자체 룰 보강 evolution rate 양쪽 측정
- Lint #10/#11 도메인 verify (Leona shield + baseDamageHpFrac 인게임 측정 + 패치노트) 시점 별도 sim fix PR

## Test plan

- [ ] Reviewer: 룰 #11~#15 의 entity-type checklist 위치 정합성 (champion / carry augment / mechanic) 확인
- [ ] Reviewer: 룰 #11/#12 의 grep snippet (subagent prompt Champion / Carry augment 섹션) 이 실제 sim 코드와 호환 가능한지 확인
- [ ] Reviewer: 룰 #15 의 "본 룰셋 #8 의 carry-augment / champion 일반화" 표현이 PR #146 의 mechanic-level 룰 의도와 정합한지 확인
- [ ] Reviewer: 실행 절차 9 → 10단계 추가 (#8 mechanic page sync verify) 가 subagent prompt 의 cost / 시간 trade-off 합리적인지 검토
- [ ] Reviewer: "Subagent prompt 보강 사례" 표가 Codex P2 catch 누적 추적 형식으로 적합한지 (향후 Codex catch evolution 추적 의도)
- [ ] Follow-up: 다음 champion ingest 시점에 본 룰 적용 결과 — Lint #10/#11 type 패턴 자동 catch 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)