### PR TITLE
docs(wiki): augments/invader-zed.md line drift fix (PR #156 subagent P2-3 후속)

### DIFF
--- a/docs/wiki/augments/invader-zed.md
+++ b/docs/wiki/augments/invader-zed.md
@@ -8,15 +8,15 @@ tier: special (스테이지 4-2 전용 획득)
 stage: stage 4-2 only
 current_patch_status: active
 sim_active: minimal
-last_verified: 2026-05-19
+last_verified: 2026-05-27 (line drift 갱신 — PR #156 후속, subagent P2-3 finding)
 sources:
   - src/data/carryAugments.ts:274-286 (InvaderZed entry)
-  - src/lib/simulator/engine/combatLoop.ts:618-622 (getAbilityConfigForUnit)
-  - src/lib/simulator/engine/combatLoop.ts:2220-2267 (applyHeroCarryTransforms role='Fighter')
-  - src/lib/simulator/engine/combatLoop.ts:1565-1582 (applyZedShadow trait — augment 무관)
-  - src/lib/simulator/engine/combatLoop.ts:6146-6149 (self_buff carry damage override 미적용 주석)
-  - src/lib/simulator/engine/combatLoop.ts:6226 (self_buff → rawAbilityDmgBase=0)
-  - src/lib/simulator/engine/combatLoop.ts:6885-6891 (config.selfBuff stat 적용 — selfBuff undefined 시 skip)
+  - src/lib/simulator/engine/combatLoop.ts:630 (getAbilityConfigForUnit)
+  - src/lib/simulator/engine/combatLoop.ts:2258 (applyHeroCarryTransforms role='Fighter')
+  - src/lib/simulator/engine/combatLoop.ts:1610-1620 (applyZedShadow trait — augment 무관)
+  - src/lib/simulator/engine/combatLoop.ts:6196 (self_buff carry damage override 미적용 주석)
+  - src/lib/simulator/engine/combatLoop.ts:6277 (self_buff → rawAbilityDmgBase=0)
+  - src/lib/simulator/engine/combatLoop.ts:7001-7019 (config.selfBuff stat 적용 — selfBuff undefined 시 skip)
   - src/lib/simulator/systems/ability.ts:251 (TFT17_Zed raw `{ pattern: 'self_buff' }` — 분신 소환, 시뮬 stat-only)
 related:
   - "[[hero-augment-carry]]"
@@ -30,7 +30,7 @@ related:
 
 Zed (`TFT17_Zed`) carry augment, **스테이지 4-2 전용 special**. desc: "5단계 공격력 전사로 변하며 자신의 분신을 생성".
 
-raw Zed 는 이미 `TFT17_ZedUniqueTrait` (은하계 사냥꾼) trait 으로 +40% AD 가산을 받는다 (분신 alive 가정 단순화, `combatLoop.ts:1565-1582`). InvaderZed augment 가 추가하는 sim 효과는 **role 변환 + mana 조정** 외에는 사실상 없음 — abilityOverride `{ pattern: 'self_buff' }` 만 정의되어 있고 `selfBuff` 필드 자체 없어 cast 효과 0.
+raw Zed 는 이미 `TFT17_ZedUniqueTrait` (은하계 사냥꾼) trait 으로 +40% AD 가산을 받는다 (분신 alive 가정 단순화, `combatLoop.ts:1610-1620`). InvaderZed augment 가 추가하는 sim 효과는 **role 변환 + mana 조정** 외에는 사실상 없음 — abilityOverride `{ pattern: 'self_buff' }` 만 정의되어 있고 `selfBuff` 필드 자체 없어 cast 효과 0.
 
 **가장 sim 효과 적은 carry augment**.
 
@@ -40,15 +40,15 @@ raw Zed 는 이미 `TFT17_ZedUniqueTrait` (은하계 사냥꾼) trait 으로 +40
 - **abilityOverride**: `{ pattern: 'self_buff' }` (`carryAugments.ts:277`) — `selfBuff` 필드 **없음**
 - **damageTypeOverride**: `physical` (line 278) — damage 자체가 미반영이라 무의미
 - **cast 효과**:
-  - self_buff 패턴 → `rawAbilityDmgBase = 0` 강제 (`combatLoop.ts:6226`)
-  - `config.selfBuff` undefined → `combatLoop.ts:6886` if 가드 false → 어떤 stat 변경도 발생 안 함
+  - self_buff 패턴 → `rawAbilityDmgBase = 0` 강제 (`combatLoop.ts:6277`)
+  - `config.selfBuff` undefined → `combatLoop.ts:7001` if 가드 false → 어떤 stat 변경도 발생 안 함
   - 결론: **cast 자체는 mana 소비 외 sim 효과 없음**
 - **mana**: 50/100 (raw 채택, statOverrides 없음)
-- **분신 (shadow)**: sim 에 분신 unit 메커니즘 자체 없음 (`combatLoop.ts:1569` 명시). raw Zed `TFT17_Zed: { pattern: 'self_buff' }` (`ability.ts:251`) 도 동일하게 stat-only 단순화.
+- **분신 (shadow)**: sim 에 분신 unit 메커니즘 자체 없음 (`combatLoop.ts:1607` 주석 명시). raw Zed `TFT17_Zed: { pattern: 'self_buff' }` (`ability.ts:251`) 도 동일하게 stat-only 단순화.
 
 ### applyZedShadow 와의 관계 (별도 메커니즘)
 
-- `applyZedShadow` (`combatLoop.ts:1572`) 는 **trait `TFT17_ZedUniqueTrait`** 활성 조건. InvaderZed augment 와 무관.
+- `applyZedShadow` (`combatLoop.ts:1610`) 는 **trait `TFT17_ZedUniqueTrait`** 활성 조건. InvaderZed augment 와 무관.
 - 분신 alive 가정 → Zed 본인에게 즉시 +40% AD 가산 (`u.stats.damage *= 1.40`).
 - InvaderZed augment 없이도 Zed + trait active 면 동일 buff 적용.
 
@@ -92,9 +92,9 @@ abilityOverride.selfBuff: **필드 자체 없음** → 어떤 stat buff 도 적�
 
 | Cast path | Zed self_buff 진입? | sim 정합 |
 |-----------|:-------------------:|:--------:|
-| Main pipeline (line ~6137) | ✅ self_buff 분기 (line 6226 damage 0) | ✓ (효과 0) |
-| Recast (onKill) (line ~6544) | ❌ (PykeCarry 전용) | — |
-| OOR fallback (line 6973-7037) | ✅ self_buff OOR 경로 (line 7001-2 self-hit 회귀 방지) | ✓ (효과 0) |
+| Main pipeline (line ~6184) | ✅ self_buff 분기 (line 6277 damage 0) | ✓ (효과 0) |
+| Recast (onKill) (line ~6606) | ❌ (PykeCarry 전용 — `onKillRecast` cascade) | — |
+| OOR fallback (line ~7117-7160) | ✅ self_buff OOR 경로 (line 7131 self-hit 회귀 방지 + line 7160 selfBuff 가드) | ✓ (효과 0) |
 
 **확인**: self_buff 패턴 cast path 자체는 main + OOR 양쪽 일관. 단, selfBuff 필드 부재로 어떤 stat 변경도 발생 안 함 → cast path 정합성과 무관하게 효과 0.
 
@@ -129,4 +129,4 @@ abilityOverride.selfBuff: **필드 자체 없음** → 어떤 stat buff 도 적�
 - [[hero-augment-carry]] — carry augment 시스템 전체
 - [[role-passive]] — Fighter role mana/타게팅 규칙
 - [[ability-targeting]] — `self_buff` 패턴 (3 cast path, single fix 회귀 가드)
-- 코드: `src/data/carryAugments.ts:274-286`, `src/lib/simulator/engine/combatLoop.ts:618/2220/1572/6226/6886`
+- 코드: `src/data/carryAugments.ts:274-286`, `src/lib/simulator/engine/combatLoop.ts:630/2258/1610/6277/7001`


### PR DESCRIPTION
## Summary

PR #156 wiki-ingest-verifier subagent 가 catch 한 cross-ref line drift 5건 + cast path 표 drift 일괄 fix. 기능 변경 0건, 모두 함수 자체 위치만 이동 (drift > 10 line).

## Drift 갱신 (frontmatter sources + 본문 다중 위치)

| 항목 | before | after | drift |
|------|--------|-------|-------|
| `getAbilityConfigForUnit` | `:618-622` | `:630` | 12 |
| `applyHeroCarryTransforms` | `:2220-2267` | `:2258` | 38 |
| `applyZedShadow` | `:1565-1582` | `:1610-1620` | 45 |
| self_buff carry override 주석 | `:6146-6149` | `:6196` | 50 |
| `rawAbilityDmgBase = 0` | `:6226` | `:6277` | 51 |
| `selfBuff` 가드 | `:6885-6891` | `:7001-7019` | 116 |
| 분신 unit 미반영 주석 | `:1569` | `:1607` | 38 |

## Cast path 표 갱신 (line 95-97)

- Main pipeline: `~6137` → `~6184` (`getAbilityConfigForUnit` 호출 site)
- Recast (PykeCarry 전용): `~6544` → `~6606` (`onKillRecast` cascade)
- OOR fallback: `6973-7037` → `~7117-7160` (self-hit 회귀 방지 line 7131 + selfBuff 가드 line 7160)

## last_verified

`2026-05-19` → `2026-05-27` 갱신.

## Subagent dispatch 결정

본 PR 은 **drift fix only** (fact 변경 0건, scope 16 insertions / 16 deletions). 효율 측면 lint subagent dispatch skip. 검증은 line citation grep (`grep -n combatLoop.ts: docs/wiki/augments/invader-zed.md`) 으로 12개 인용 위치 정합 확인 완료.

## 관련

- PR #156 (subagent P2-3 finding 의 후속 정리 PR)
- 메모리 `wiki-ingest-verifier-subagent` (subagent 진화 + 진행도)
- Line drift 정책: `docs/wiki/lint-rules.md` "Line 번호 인용 정책 (2026-05-26 결정)" — drift > 10 line 시 P2 informational, 함수 자체 존재하면 fact 정합

## Test plan

- [x] `grep -n combatLoop.ts: docs/wiki/augments/invader-zed.md` 로 12개 인용 위치 검증
- [x] 실제 코드 line 번호 grep 으로 정합 (`grep -n "function applyZedShadow\|function applyHeroCarryTransforms\|function getAbilityConfigForUnit\|if (config.selfBuff)\|rawAbilityDmgBase = 0" src/lib/simulator/engine/combatLoop.ts`)
- [ ] Codex review 응답 (오면) — PR #156 처럼 응답 없을 가능성, 5~10분 폴링 후 머지 정책 결정