### PR TITLE
docs(wiki): patch-17-4 추적 sequence A — 신규 patch + 5 페이지 update + subagent P1 4건 self-catch

### DIFF
--- a/docs/wiki/augments/invader-zed.md
+++ b/docs/wiki/augments/invader-zed.md
@@ -6,9 +6,9 @@ api_name: TFT17_Augment_InvaderZed
 target_champion: TFT17_Zed
 tier: special (스테이지 4-2 전용 획득)
 stage: stage 4-2 only
-current_patch_status: active
+current_patch_status: active (17.3 LIVE, 17.4 patch pending — base Zed 변경, [[patch-17-4]] 참조)
 sim_active: minimal
-last_verified: 2026-05-27 (line drift 갱신 — PR #156 후속, subagent P2-3 finding)
+last_verified: 2026-05-29 (17.4 patch fact 추가 — base Zed 변경 cross-ref; 이전: 2026-05-27 line drift)
 sources:
   - src/data/carryAugments.ts:274-286 (InvaderZed entry)
   - src/lib/simulator/engine/combatLoop.ts:630 (getAbilityConfigForUnit)
@@ -22,6 +22,8 @@ related:
   - "[[hero-augment-carry]]"
   - "[[ability-targeting]]"
   - "[[role-passive]]"
+  - "[[zed]]"
+  - "[[patch-17-4]]"
 ---
 
 # 침략자 제드 (InvaderZed)
@@ -36,7 +38,7 @@ raw Zed 는 이미 `TFT17_ZedUniqueTrait` (은하계 사냥꾼) trait 으로 +40
 
 ## 변환 후 메커니즘
 
-- **role**: `Fighter` (default — `applyHeroCarryTransforms` line 2227)
+- **role**: `Fighter` (default — `applyHeroCarryTransforms` line 2258, drift fix PR #162 subagent P2-2)
 - **abilityOverride**: `{ pattern: 'self_buff' }` (`carryAugments.ts:277`) — `selfBuff` 필드 **없음**
 - **damageTypeOverride**: `physical` (line 278) — damage 자체가 미반영이라 무의미
 - **cast 효과**:
@@ -64,9 +66,10 @@ abilityOverride.selfBuff: **필드 자체 없음** → 어떤 stat buff 도 적�
 
 ## 패치 히스토리
 
-| 패치 | 변경 |
-|------|------|
-| (도입 시점 미verify) | InvaderZed entry 등록 (carryAugments.ts) |
+| 패치 | 변경 | sim 적용 |
+|------|------|---------|
+| (도입 시점 미verify) | InvaderZed entry 등록 (carryAugments.ts) | ✅ entry minimal sim (role Fighter + mana 50/100) |
+| [[patch-17-4]] (2026-05-27) | **base Zed 변경의 간접 영향** (PoppyCarry / InvaderZed augment 자체 변경 없음): base Zed 마나 `50/100` → `40/100` + 분신 HPPenalty `0.40` → `0.45`. InvaderZed augment 의 mana `50/100` 표기는 raw 채택이라 base Zed 변경 시 정합 깨질 가능성 — raw data fetch (sequence B) 후 verify | ❌ **간접 영향 sim 미반영** — base Zed raw json 갱신 후 InvaderZed entry 의 mana override 분기 정합 verify 필요. carry augment 자체 변경 없음 |
 
 패치 변경 이력 verify 안 됨 — 17.3 패치노트 등에서 변경분 미발견. **TODO: stage 4-2 special augment 의 정확한 도입 시점 verify**.
 

--- a/docs/wiki/augments/jax-carry.md
+++ b/docs/wiki/augments/jax-carry.md
@@ -66,7 +66,7 @@ abilityOverride 가 `self_buff` 라서 cast 자체는 damage 없음. 실질 효�
 |------|------|---------|
 | 17.3 이전 | 정확한 도입 패치 미verify (carryAugments.ts entry 외 source 없음) | — |
 | [[patch-17-3]] (2026-05-13) | damage `[155, 230, 375] → [170, 250, 450]` (entry 정합) | ❌ sim 미반영 (self_buff pattern 의 carry damage override 적용 안 함, codex P1 PR #71) |
-| [[patch-17-4]] (2026-05-27) | **base Jax `FlatDR` AP scaling 제거** (`15/20/25 AP` → `20/25/30` flat). JaxCarry augment 자체 변경 없음 — 단 base ability 의 raw vars schema 변경 가능성 (★ 수 + scaling type) | ❌ **간접 영향 sim 미반영** — base Jax 의 `FlatDR` 은 sim dead (selfBuff.durability 0.3 hardcoded 우선) 라 sim 영향 0. 단 raw json fetch 후 schema 정합 verify 필요 (sequence B). carry augment 자체 변경 없음 |
+| [[patch-17-4]] (2026-05-27) | **2건 변경** (PR #162 codex P1 catch — 이전 "carry 변경 없음" 잘못): (1) **JaxCarry damage `170/250/450` → `160/240/420`** 너프 (Reach for the Stars augment 표 명시). (2) base Jax `FlatDR` AP scaling 제거 (`15/20/25 AP` → `20/25/30` flat) — 간접 영향 | ❌ **sim 미반영** — JaxCarry damage 자체는 self_buff pattern 의 carry damage override 적용 안 함 (codex P1 PR #71) 이라 sim dead 단 entry 정합 위해 raw data fetch (sequence B) + carryAugments.ts:205-218 abilityData.damage 갱신 필요. base Jax FlatDR 은 sim dead (selfBuff.durability 0.3 hardcoded 우선) 라 sim 영향 0 |
 
 ## sim 적용 상태 — `partial`
 

--- a/docs/wiki/augments/jax-carry.md
+++ b/docs/wiki/augments/jax-carry.md
@@ -6,13 +6,13 @@ api_name: TFT17_Augment_JaxCarry
 target_champion: TFT17_Jax
 tier: (미확인 — 패치노트 verify 필요)
 stage: stage 2 (carry augment 일반)
-current_patch_status: active
-sim_active: active
-last_verified: 2026-05-19 (Lint #11-A + #11-B resolved PR #140 / #136)
+current_patch_status: active (17.3 LIVE, 17.4 patch pending — base Jax 변경, [[patch-17-4]] 참조)
+sim_active: partial   # frontmatter ↔ 본문 정합 (룰 #15) — 본문 `sim 적용 상태 — partial` (MS gain 미반영 + 17.4 base Jax 변경 pending). PR #162 subagent self-catch P1-3 정정
+last_verified: 2026-05-29 (17.4 patch fact 추가 + sim_active partial 강등 (PR #162 룰 #15); 이전: 2026-05-19 Lint #11-A + #11-B resolved PR #140 / #136)
 sources:
   - src/data/carryAugments.ts:205-218 (JaxCarry entry)
   - src/lib/simulator/engine/combatLoop.ts:618-622 (getAbilityConfigForUnit)
-  - src/lib/simulator/engine/combatLoop.ts:2220-2267 (applyHeroCarryTransforms role='Fighter')
+  - src/lib/simulator/engine/combatLoop.ts:2258 (applyHeroCarryTransforms role='Fighter', drift fix PR #162)
   - src/lib/simulator/engine/combatLoop.ts:5618-5660 (onAttackBonus passive)
   - src/lib/simulator/engine/combatLoop.ts:6146-6149 (self_buff carry damage override 미적용 주석)
   - src/lib/simulator/engine/combatLoop.ts:6226 (self_buff → rawAbilityDmgBase=0)
@@ -21,8 +21,10 @@ sources:
 related:
   - "[[hero-augment-carry]]"
   - "[[patch-17-3]]"
+  - "[[patch-17-4]]"
   - "[[ability-targeting]]"
   - "[[role-passive]]"
+  - "[[jax]]"
 ---
 
 # 저 별을 향해 (JaxCarry, Reach for the Stars)
@@ -35,7 +37,7 @@ abilityOverride 가 `self_buff` 라서 cast 자체는 damage 없음. 실질 효�
 
 ## 변환 후 메커니즘
 
-- **role**: `Fighter` (default — `applyHeroCarryTransforms` line 2227)
+- **role**: `Fighter` (default — `applyHeroCarryTransforms` line 2258, drift fix PR #162 subagent P2-3)
 - **abilityOverride**: `{ pattern: 'self_buff', selfBuff: { attackSpeed: 0.15, duration: 999 } }` (`carryAugments.ts:208`)
 - **cast 효과** (`combatLoop.ts:6885-6891`):
   - `unit.stats.attackSpeed *= (1 + 0.15)` — duration:999 무시 (sim 에 expiry 추적 없음 → 영구). 매 cast 마다 multiplicative 누적.
@@ -60,10 +62,11 @@ abilityOverride 가 `self_buff` 라서 cast 자체는 damage 없음. 실질 효�
 
 ## 패치 히스토리
 
-| 패치 | 변경 |
-|------|------|
-| [[patch-17-3]] (2026-05-13) | damage `[155, 230, 375] → [170, 250, 450]` (entry 정합 — 단 sim 미반영) |
-| 17.3 이전 | 정확한 도입 패치 미verify (carryAugments.ts entry 외 source 없음) |
+| 패치 | 변경 | sim 적용 |
+|------|------|---------|
+| 17.3 이전 | 정확한 도입 패치 미verify (carryAugments.ts entry 외 source 없음) | — |
+| [[patch-17-3]] (2026-05-13) | damage `[155, 230, 375] → [170, 250, 450]` (entry 정합) | ❌ sim 미반영 (self_buff pattern 의 carry damage override 적용 안 함, codex P1 PR #71) |
+| [[patch-17-4]] (2026-05-27) | **base Jax `FlatDR` AP scaling 제거** (`15/20/25 AP` → `20/25/30` flat). JaxCarry augment 자체 변경 없음 — 단 base ability 의 raw vars schema 변경 가능성 (★ 수 + scaling type) | ❌ **간접 영향 sim 미반영** — base Jax 의 `FlatDR` 은 sim dead (selfBuff.durability 0.3 hardcoded 우선) 라 sim 영향 0. 단 raw json fetch 후 schema 정합 verify 필요 (sequence B). carry augment 자체 변경 없음 |
 
 ## sim 적용 상태 — `partial`
 

--- a/docs/wiki/champions/jax.md
+++ b/docs/wiki/champions/jax.md
@@ -9,9 +9,9 @@ traits:
   - 요새
 role: Tank   # raw "APTank" → mapGameRole() → sim Tank. ⚠️ JaxCarry augment 활성 시 Fighter 로 변환 (applyHeroCarryTransforms)
 raw_role: APTank
-current_patch_status: active
+current_patch_status: active (17.3 LIVE, 17.4 patch pending — sim 미반영, [[patch-17-4]] 참조)
 sim_active: partial
-last_verified: 2026-05-21
+last_verified: 2026-05-29 (17.4 patch fact 추가, sim 미반영 명시; 이전: 2026-05-21)
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Jax entry)"
   - "src/types/index.ts:39 (mapGameRole: 'Tank' 포함 → 'Tank')"
@@ -28,6 +28,7 @@ related:
   - "[[jax-carry]]"
   - "[[stargazer]]"
   - "[[patch-17-3]]"
+  - "[[patch-17-4]]"
 ---
 
 # 잭스 (Jax)
@@ -81,7 +82,7 @@ TFT17_Jax: { pattern: 'aoe_circle', radius: 1, stun: 1.5, selfBuff: { durability
 ### Trait — 별돌보미(Stargazer) + 요새(Bastion)
 
 - **별돌보미**: 강화 칸의 별돌보미 유닛에 별자리 효과 추가 적용 — [[stargazer]] 참조. Jax 는 1코 별돌보미 4명 (나서스/뽀삐/렉사이/리산드라/등) 그룹과 별개 2코.
-- **요새**: Bastion (탱커 시너지) — 6 trait modules (`src/data/traitModules.ts` 등) 통합. Tank role 보강 효과.
+- **요새**: Bastion — `applyBastionEffects` (`combatLoop.ts:1817` 함수 정의 + `:4580-4581` combat-start 호출) 통합. Tank role 보강 효과 (armor/MR 가산 + `bastionDoubleEndTick` Duration doubled 만료 처리). PR #162 subagent P2-4 정정 (이전 `traitModules.ts` 잘못 인용).
 
 ## JaxCarry 변환 시 (참조)
 
@@ -95,10 +96,16 @@ JaxCarry augment 활성 시:
 
 ## 패치 히스토리 (base raw)
 
-| 패치 | 변경 |
-|------|------|
-| [[patch-17-2b]] (2026-04-29) | `ShieldAmount` (=`ShieldAP`): `400/500/625 → 400/470/550` — base ability shield 너프. sim 미반영 (ShieldAP 자체 미적용) |
-| [[patch-17-3]] (2026-05-13) | `FlatDR` (AP): `15/25/35/45 → 15/20/25/30` + `ShieldAP`: `400/470/550 → 400/450/500` — base ability 너프 2건. sim 미반영 (양쪽 변수 모두 dead in sim) |
+| 패치 | 변경 | sim 적용 |
+|------|------|---------|
+| [[patch-17-2b]] (2026-04-29) | `ShieldAmount` (=`ShieldAP`): `400/500/625 → 400/470/550` — base ability shield 너프 | ❌ sim 미반영 (ShieldAP 자체 미적용) |
+| [[patch-17-3]] (2026-05-13) | `FlatDR` (AP): `15/25/35/45 → 15/20/25/30` + `ShieldAP`: `400/470/550 → 400/450/500` — base ability 너프 2건 | ❌ sim 미반영 (양쪽 변수 모두 dead in sim) |
+| [[patch-17-4]] (2026-05-27) | **조정 (Adjustment)**: `FlatDR` **AP 스케일링 제거** — `15/20/25 AP` (★1~★3) → **`20/25/30`** (평탄 수치, AP scaling 제거). raw desc 의 `(scaleAP)` 제거 | ❌ sim 미반영 + **분기 구조 영향**: AP scaling 자체 제거라 단순 수치 변경 아니라 변수 type 변경 (AP 의존 → flat). [[patch-17-4]] sequence B/C 대기 |
+
+⚠️ **17.4 sim 영향 평가**:
+- FlatDR 값 자체는 sim dead (Jax 의 `selfBuff.durability hardcoded 0.3` 우선 적용, [[poppy]] G1 패턴과 동일) → 17.4 변경의 sim 영향 sim dead state 라 0
+- **분기 구조 변경**: raw desc 의 `(scaleAP)` 제거는 raw json 의 ability variable schema 변경 가능성 (variable name 또는 type 변경). raw data fetch (sequence B) 시 schema 정합 verify 필요
+- ★ 수 감소 (4 → 3) — raw vars sentinel filler 패턴 변경 가능성 (이전 `[15, 25, 35, 45]` → 새 `[20, 25, 30]` 등). raw data fetch 시 길이 + sentinel 정합 verify
 
 ## sim 적용 상태 — `partial`
 

--- a/docs/wiki/champions/shen.md
+++ b/docs/wiki/champions/shen.md
@@ -9,9 +9,9 @@ traits:
   - 요새
 role: Fighter   # raw "APFighter" → mapGameRole() → sim Fighter (codex P2 PR #148 정정)
 raw_role: APFighter
-current_patch_status: active
+current_patch_status: active (17.3 LIVE, 17.4 patch pending — sim 미반영, [[patch-17-4]] 참조)
 sim_active: active
-last_verified: 2026-05-19 (codex P2 amend)
+last_verified: 2026-05-29 (17.4 patch fact 추가, sim 미반영 명시; 이전: 2026-05-19 codex P2 amend)
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Shen entry)"
   - "src/lib/simulator/systems/ability.ts:250 (abilityOverride aoe_circle r=2 + selfBuff AS+0.3 999)"
@@ -24,6 +24,7 @@ related:
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[patch-17-3]]"
+  - "[[patch-17-4]]"
 ---
 
 # 쉔 (Shen)
@@ -83,10 +84,15 @@ if (unit.champion.apiName === 'TFT17_Shen') unit.shenPassiveStack++;
 
 ## 패치 히스토리
 
-| 패치 | 변경 |
-|------|------|
-| 17.2 LIVE | base — hp 1200, BonusDamageOnAttack 45/75, ShieldHP 0.10 |
-| [[patch-17-3]] (2026-05-13) | **3건 변경 동시 적용**: hp `1200 → 1300` (PR #107 1차), ShieldHP `0.10 → 0.15` (PR #107 1차), **BonusDamageOnAttack `45/75 → 20/30`** (PR2 passive 구현 + 너프 동시 — Plan 문서 `tft-17-3-shen-passive.plan.md`) |
+| 패치 | 변경 | sim 적용 |
+|------|------|---------|
+| 17.2 LIVE | base — hp 1200, BonusDamageOnAttack 45/75, ShieldHP 0.10 | — (legacy) |
+| [[patch-17-3]] (2026-05-13) | **3건 변경 동시 적용**: hp `1200 → 1300` (PR #107 1차), ShieldHP `0.10 → 0.15` (PR #107 1차), **BonusDamageOnAttack `45/75 → 20/30`** (PR2 passive 구현 + 너프 동시 — Plan 문서 `tft-17-3-shen-passive.plan.md`) | ✅ 모두 sim 적용 |
+| [[patch-17-4]] (2026-05-27) | **2건 변경 (17.3 너프 partial revert)**: 마나 `10/70` → **`20/70`** (initialMana 2배 ↑ — **더 빠른 첫 cast** — 첫 cast 에 필요한 추가 mana 60→50 감소). **BonusDamageOnAttack `20/30` → `25/40`** (17.3 너프 부분 revert, 약간 buff) | ❌ **sim 미반영** — raw data + sim 코드 17.3 기준. [[patch-17-4]] sequence B/C 대기 |
+
+⚠️ **17.4 sim 영향 평가**:
+- 마나 변경 (10/70 → 20/70) — `initialMana 10→20` 증가로 첫 cast 에 필요한 추가 mana `maxMana - initialMana = 70-10=60` → `70-20=50` (10 감소). **더 빠른 첫 cast** (buff 방향). `combatLoop.ts:5710-5748` shenPassiveStack 분기 (첫 cast 타이밍 영향). sim 미반영 시 cast 속도 부정확 (raw json `initialMana` 갱신 필요)
+- BonusDamageOnAttack `20/30 → 25/40` — `combatLoop.ts:5710-5748` 평타 시 stack × BonusDamage 분기에서 raw vars 직접 read. raw json `BonusDamageOnAttack[★]` 갱신 만으로 sim 자동 반영 (helper 분기 정합)
 
 ## sim 적용 상태 — `active`
 
@@ -117,7 +123,7 @@ if (unit.champion.apiName === 'TFT17_Shen') unit.shenPassiveStack++;
 
 ## 관련
 
-- [[role-passive]] — Tank role 마나/타게팅 규칙
+- [[role-passive]] — **Fighter** role 마나/타게팅 규칙 (raw APFighter → sim Fighter, 공격당 10 / on-hit 0 / weight 2 / non-target DR ×0.85 — frontmatter `role: Fighter` 정합, PR #162 subagent P2-1 정정)
 - [[ability-targeting]] — `aoe_circle` 패턴
 - [[patch-17-3]] — 3건 동시 변경 (hp / ShieldHP / BonusDamageOnAttack)
 - 코드: `src/lib/simulator/systems/ability.ts:250`, `src/lib/simulator/engine/combatLoop.ts:1508/5710/6167`

--- a/docs/wiki/champions/zed.md
+++ b/docs/wiki/champions/zed.md
@@ -8,9 +8,9 @@ traits:
   - 은하계 사냥꾼
 role: Fighter   # raw "ADFighter" → mapGameRole() → sim Fighter (types/index.ts:46 includes('Fighter'))
 raw_role: ADFighter
-current_patch_status: active
-sim_active: partial   # 의도된 단순화 — 분신 unit 메커니즘 자체 미반영 (combatLoop.ts:1607 주석). applyZedShadow trait helper 는 active (분신 alive 가정 +40% AD 가산)
-last_verified: 2026-05-27
+current_patch_status: active (17.3 LIVE, 17.4 patch pending — sim 미반영, [[patch-17-4]] 참조)
+sim_active: partial   # 의도된 단순화 — 분신 unit 메커니즘 자체 미반영 (combatLoop.ts:1607 주석). applyZedShadow trait helper 는 active (분신 alive 가정 +40% AD 가산). 17.4 변경 (클론 HP 33/40%→33/45%, 마나 50/100→40/100) raw data + sim 미반영
+last_verified: 2026-05-29 (17.4 patch fact 추가, sim 미반영 명시)
 sources:
   - "public/data/tft_set17_champions.json:5444-5495 (TFT17_Zed entry — cost 5, role ADFighter, traits 은하계 사냥꾼)"
   - "src/types/index.ts:39-48 (mapGameRole — ADFighter → Fighter)"
@@ -26,6 +26,7 @@ related:
   - "[[invader-zed]]"
   - "[[hero-augment-carry]]"
   - "[[shen]]"
+  - "[[patch-17-4]]"
 ---
 
 # 제드 (Zed)
@@ -97,10 +98,21 @@ function applyZedShadow(activeTraits, ownTeam) {
 - 분신이 항상 살아있다고 가정 — 실제 게임에서는 분신이 죽으면 buff 사라지지만 sim 은 항상 active
 - trait active 조건만 만족하면 cast 무관 항상 적용
 
+## 패치 히스토리
+
+| 패치 | 변경 | sim 적용 |
+|------|------|---------|
+| 17.3 base | hp 1300, armor/MR 60, AD 85, AS 0.85, mana 50/100, 분신 HPPenalty `[0.33, 0.33, 0.4]` (★1/★2/★3) | ✅ stats raw json 정합 |
+| [[patch-17-4]] (2026-05-27) | **너프 2건**: 클론 (분신) 체력 `HPPenalty 0.33/0.40` → **`0.33/0.45`** (분신이 약해짐 — Zed 본인이 받는 HPPenalty 가 더 큼). 마나 `50/100` → **`40/100`** (initialMana ↓, **더 늦은 첫 cast** — 첫 cast 에 필요한 추가 mana 50→60 증가) | ❌ **sim 미반영** — raw data + sim 코드 17.3 기준. [[patch-17-4]] sequence B/C 대기 |
+
+⚠️ **17.4 sim 영향 평가**:
+- 분신 HPPenalty 0.40 → 0.45 변경은 sim 미반영 ("분신 unit 자체 sim 없음" — combatLoop.ts:1607 의도된 단순화 영향) → applyZedShadow trait helper 의 BonusAD 0.40 단순화 calibration 자체는 영향 없음 (BonusAD 값 자체 변경 없음)
+- 마나 변경 (50/100 → 40/100) — `initialMana 50→40` 감소로 첫 cast 에 필요한 추가 mana `maxMana - initialMana = 100-50=50` → `100-40=60` (10 증가). **더 늦은 첫 cast** (너프 방향). sim 미반영 시 cast 타이밍 부정확 (raw json `initialMana` 갱신 필요)
+
 ## sim 적용 상태 — `partial`
 
 ✅ **활성**:
-- stats 17.3 정합 (hp 1300, armor/MR 60, AD 85, AS 0.85, range 1, mana 50/100)
+- stats **17.3 정합** (hp 1300, armor/MR 60, AD 85, AS 0.85, range 1, mana 50/100) — ⚠️ **17.4 변경 (마나 40/100, 분신 HPPenalty 0.45) 미반영**
 - `mapGameRole` 결과 Fighter role 룰 적용 (마나 / 타게팅 weight 2 / non-target DR ×0.85)
 - `applyZedShadow` trait helper — `TFT17_ZedUniqueTrait` 활성 시 combat-start 시 Zed 본인에게 +40% AD 가산 (분신 alive 가정)
 - ability override `pattern: 'self_buff'` 분기 진입 정합 (cast path 정합 — main + OOR 모두 진입, 효과 0)

--- a/docs/wiki/patches/patch-17-4.md
+++ b/docs/wiki/patches/patch-17-4.md
@@ -61,7 +61,7 @@ Psionic(2) / Psionic(4) 아이템들의 **스탯이 더욱 일반적으로** 변
 |-------|--------------------|----------------|
 | **챌린저** | 공속 `15/22/40/55%` → **`15/28/42/55%`** | `combatLoop.ts` 챌린저 burstEndTick / burstPercent helper |
 | **다크스타 (6)** | 보너스 `85%` → **`70%`**, 미니 블랙홀 HP `30%` → **`25%`** | `combatLoop.ts:2041` 6 챔프 그룹 + Black Hole damage 분기 |
-| **N.O.V.A. (5)** | Aatrox `50%` → **`65%`**, Akali 출혈 `10%` → **`12%`**, Kindred `10%` → **`20%`** | `tickDrxNova` (PR #121 sim 영향) + N.O.V.A. ratio 분기 |
+| **N.O.V.A. (5)** | Aatrox `50%` → **`65%`**, Akali Bleed Damage `10/14/18 AD` → **`12/18/24 AD`**, **Kindred Damage Amp `5%` → `10%`** (이전 `10→20%` 표기 오류), **Kindred Mark Timer `5s` → `4.5s`** (이전 누락) | `tickDrxNova` (PR #121 sim 영향) + N.O.V.A. ratio 분기 + per-tick TRIGGER (PR #162 codex P1 catch — 외부 patch notes fact 정정) |
 | **스나이퍼** | damage amp `18/24/28%` → **`18/25/35%`** | `sniperBaseDA` / `sniperPerHexDA` state field (combatLoop.ts:3866-3867) |
 | **스페이스 그루브 (7)** | 보너스 `10%` → **`15%`** | `applySpaceGrooveBuffs` (combatLoop.ts:1720-1733) ADAP 가산 분기 |
 | **스타게이저** | heal `2.5%` → **`3%`** + 세부 조정 | [[stargazer-fountain]] + stargazerFountainHealPercent 분기 |
@@ -72,7 +72,7 @@ Psionic(2) / Psionic(4) 아이템들의 **스탯이 더욱 일반적으로** 변
 | 챔프 | 변경 | 영향 페이지 | sim 영향 |
 |------|------|-------------|----------|
 | Aatrox | 힐 `300/375/575 AP` → **`325/400/650 AP`** | [[aatrox-carry]] cross-ref (base 미작성) | ability.variables `Heal` 값 갱신 |
-| Twisted Fate | 최소 데미지 `190/285/430/730 AP` → **`180/270/405/690`**, 최대 `380/570/860/1460` → **`360/540/810/1380`** | (base 미작성) | ⚠️ **17.3 patch wiki 와 모순** — 17.3 에서 `190/285/430/730` 로 buff 됐다가 17.4 에서 다시 너프. **17.3 의 buff revert** |
+| Twisted Fate | 최소 데미지 `180/270/405/690 AP` → **`190/285/430/730`**, 최대 `360/540/810/1380` → **`380/570/860/1460`** | (base 미작성) | ✅ **17.3 너프 revert (buff)** — 17.3 에서 한 너프 (380/570/860/1460 → 360/540/810/1380) 를 17.4 에서 reverted (이전 값 복귀). **17.4 = 17.3 patch wiki 의 Twisted Fate row 와 1:1 revert 관계** (PR #162 codex P1 catch — 이전 방향 오기 정정) |
 
 ### Tier 2
 | 챔프 | 변경 | 영향 페이지 | sim 영향 |
@@ -120,11 +120,19 @@ Psionic(2) / Psionic(4) 아이템들의 **스탯이 더욱 일반적으로** 변
 - [[jax-carry]] — Jax base 변경의 carry augment 영향 cross-ref
 - [[stargazer-fountain]] — 17.4 stargazer heal 2.5%→3% trait 변경 cross-ref
 
-## 17.4 ↔ 17.3 모순 사례
+## 17.4 ↔ 17.3 revert 관계
 
-- **Twisted Fate**: 17.3 buff (180/270/405/690 → 190/285/430/730) → 17.4 너프 reverted (180/270/405/690 으로 복귀) — patch wiki 의 17.3 row 와 17.4 row 가 1:1 revert 관계
+PR #162 codex P1 catch — Twisted Fate 방향 정정 + 일관성 회복:
+
+- **Twisted Fate**: 17.3 너프 (380/570/860/1460 → 360/540/810/1380) → 17.4 **reverted (buff)** — 17.3 값 (380/570/860/1460) 복귀. patch wiki 의 17.3 row 와 17.4 row 가 1:1 revert 관계
 - **Bel'Veth**: 17.3 너프 (20/30/45/77 → 18/27/41/69 — 추정) → 17.4 reverted (20/30/45/77 복귀, esports.gg 공식 표기)
 - **Shen**: 17.3 너프 (BonusDamageOnAttack 45/75 → 20/30) → 17.4 partial revert (20/30 → 25/40)
+
+## 17.4 augment 변경 (추가 — PR #162 codex P1 catch)
+
+| Augment | 변경 | 영향 페이지 | sim 영향 |
+|---------|------|-------------|----------|
+| **Reach for the Stars (JaxCarry)** | damage `170/250/450` → **`160/240/420`** 너프 | [[jax-carry]] | ❌ JaxCarry 자체 damage 는 self_buff pattern carry damage override 적용 안 함 (codex P1 PR #71) 이라 sim dead. 단 carryAugments.ts:205-218 entry 정합 위해 sequence B 에서 갱신 필요 |
 
 ## Lint 체크리스트 (mechanic entity-type)
 

--- a/docs/wiki/patches/patch-17-4.md
+++ b/docs/wiki/patches/patch-17-4.md
@@ -1,0 +1,147 @@
+---
+id: patch-17-4
+type: patch
+live_date: 2026-05-27
+status: LIVE
+last_verified: 2026-05-29 (raw data 17.3 기준, 17.4 미반영 — 별도 PR sequence 진행 중)
+sources:
+  - https://teamfighttactics.leagueoflegends.com/en-us/news/game-updates/teamfight-tactics-patch-17-4/ (공식)
+  - https://esports.gg/news/teamfight-tactics/tft-patch-17-4-notes-belveth-nerf-reverted-plus-arbiter-and-psionic-buffs/ (esports.gg)
+  - https://www.pcgamesn.com/teamfight-tactics/patch-17-4-notes-conditionality (pcgamesn)
+  - public/data/tft_set17_champions.json (17.3 기준 — 17.4 갱신 대기, **별도 PR sequence B**)
+  - public/data/tft_set17_traits.json (17.3 기준 — 17.4 갱신 대기)
+  - public/data/tft_set17_augments.json (17.3 기준 — 17.4 갱신 대기)
+related:
+  - "[[patch-17-3]]"
+  - "[[patch-17-2b]]"
+  - "[[zed]]"
+  - "[[shen]]"
+  - "[[jax]]"
+  - "[[invader-zed]]"
+  - "[[jax-carry]]"
+  - "[[stargazer-fountain]]"
+---
+
+# Patch 17.4 LIVE (2026-05-27)
+
+> Set 17 Space Gods 의 4번째 메이저 패치. 17.3 의 Bel'Veth 너프 reverted + Arbiter 대규모 개편 + Sniper/Psionic 일관성 강화. 본 위키 페이지는 **17.4 변경 사항을 fact 로 기록** 하되, **raw data + sim 코드는 17.3 기준 (17.4 미반영)** 임을 명시.
+
+## ⚠️ sim 적용 상태 — 미반영 (별도 PR sequence 진행 중)
+
+| Asset | 17.4 적용 상태 | 후속 PR |
+|-------|----------------|---------|
+| **raw data** (`public/data/tft_set17_*.json`) | ❌ 17.3 기준 — `patch_version` 메타데이터 자체 부재 | **PR sequence B** — CDragon fetch 또는 lolchess.gg 기반 갱신 |
+| **sim 코드** (`combatLoop.ts` trait helpers + ability config) | ❌ 17.3 값 hardcoded — 챌린저 burstEndTick / 스나이퍼 damage amp / 다크스타 bonus / N.O.V.A. ratio 등 | **PR sequence C** — trait helper 값 + ability variables 갱신 + 테스트 회귀 |
+| **Arbiter 시스템** | ❌ 17.3 의 입력/출력 구조 | **PR sequence D** — 3 카테고리 (일관성/조건부/경제) 개편 |
+| **Psionic 아이템** | ❌ 17.3 stats | PR sequence D 일부 |
+| **위키 페이지** (champion / mechanic) | ⚠️ **본 PR (sequence A)** — 17.4 fact 명시 + frontmatter `current_patch_status: active (17.3 LIVE, 17.4 patch pending)` 표기 + 본문 패치 히스토리 row 추가 | 본 PR |
+
+→ 본 페이지 작성 후 후속 PR sequence (B → C → D) 에서 sim 정합 회복.
+
+## System 변경
+
+### Arbiter 대규모 개편
+
+입력/출력을 **세 가지 카테고리** 로 재구성:
+- (1) **일관성** (Consistency) — 항상 보장
+- (2) **조건부** (Conditional) — 상황 의존
+- (3) **경제 기반** (Economy) — 골드/재료 의존
+
+각 카테고리에서 하나씩 보장 제공 → 17.3 의 "운빨" 의존 줄이고 안정적 input/output 풀 형성.
+
+**sim 영향**: `arbiter_laws.json` 구조 변경 + augment system 의 arbiter 분기 코드 영향. PR sequence D 큰 작업.
+
+### Psionic 아이템 일반화
+
+Psionic(2) / Psionic(4) 아이템들의 **스탯이 더욱 일반적으로** 변경 → 다양한 챔피언에서 사용 가능. 17.3 의 초능력 unit 전용 → 17.4 generic stats 로 완화.
+
+## Trait 변경
+
+| Trait | 변경 (17.3 → 17.4) | sim 영향 영역 |
+|-------|--------------------|----------------|
+| **챌린저** | 공속 `15/22/40/55%` → **`15/28/42/55%`** | `combatLoop.ts` 챌린저 burstEndTick / burstPercent helper |
+| **다크스타 (6)** | 보너스 `85%` → **`70%`**, 미니 블랙홀 HP `30%` → **`25%`** | `combatLoop.ts:2041` 6 챔프 그룹 + Black Hole damage 분기 |
+| **N.O.V.A. (5)** | Aatrox `50%` → **`65%`**, Akali 출혈 `10%` → **`12%`**, Kindred `10%` → **`20%`** | `tickDrxNova` (PR #121 sim 영향) + N.O.V.A. ratio 분기 |
+| **스나이퍼** | damage amp `18/24/28%` → **`18/25/35%`** | `sniperBaseDA` / `sniperPerHexDA` state field (combatLoop.ts:3866-3867) |
+| **스페이스 그루브 (7)** | 보너스 `10%` → **`15%`** | `applySpaceGrooveBuffs` (combatLoop.ts:1720-1733) ADAP 가산 분기 |
+| **스타게이저** | heal `2.5%` → **`3%`** + 세부 조정 | [[stargazer-fountain]] + stargazerFountainHealPercent 분기 |
+
+## Champion 변경 (18건)
+
+### Tier 1
+| 챔프 | 변경 | 영향 페이지 | sim 영향 |
+|------|------|-------------|----------|
+| Aatrox | 힐 `300/375/575 AP` → **`325/400/650 AP`** | [[aatrox-carry]] cross-ref (base 미작성) | ability.variables `Heal` 값 갱신 |
+| Twisted Fate | 최소 데미지 `190/285/430/730 AP` → **`180/270/405/690`**, 최대 `380/570/860/1460` → **`360/540/810/1380`** | (base 미작성) | ⚠️ **17.3 patch wiki 와 모순** — 17.3 에서 `190/285/430/730` 로 buff 됐다가 17.4 에서 다시 너프. **17.3 의 buff revert** |
+
+### Tier 2
+| 챔프 | 변경 | 영향 페이지 | sim 영향 |
+|------|------|-------------|----------|
+| **Bel'Veth** | 스펠 데미지 AD `18/27/41/69` → **`20/30/45/77`** (17.3 너프 reverted) | (base 미작성) | ability.variables 갱신 |
+| Gnar | 기본 공속 `0.7` → **`0.75`** | (base 미작성) | champion stats AS 갱신 |
+| Gwen | 방어력 `45` → **`50`**, 단일 대상 데미지 `145/220/380/650 AP` → **`145/220/410/700 AP`** | (base 미작성) | champion stats armor + ability variables |
+| **Jax** | 평탄 DR `15/20/25 AP` → **`20/25/30`** (**AP 스케일링 제거**) | [[jax]] / [[jax-carry]] | ⚠️ scaling 자체 제거 — sim 분기 구조 영향 (단순 계수 변경 아님) |
+| Zoe | 스펠 데미지 `68/102/153% AP` → **`73/110/180 AP`** | (base 미작성) | ability.variables 갱신 |
+
+### Tier 3
+| 챔프 | 변경 | 영향 페이지 | sim 영향 |
+|------|------|-------------|----------|
+| Aurora | 분할 데미지 `370/555/890 AP` → **`400/600/960 AP`** | (base 미작성) | ability.variables 갱신 |
+| Lulu | 산악 스펠 스턴 `0.5초` → **`0.25초`** | (base 미작성) | ability.ts stun 값 갱신 |
+| MissFortune (복제) | 스펠 데미지 `250/375/600 AD` → **`275/415/660 AD`** | (base 미작성) | ability.variables 갱신 |
+| Ornn | 기본 체력 `850` → **`950`** | (base 미작성) | champion stats hp 갱신 |
+| Rhaast | 리디머 공속 `2/2.5/3%` → **`2/2/2%`**, 보너스 방어력 `2/2.5/3` → **`2/2/2`** | (base 미작성) | 너프 (star scaling 평탄화) |
+| Viktor | 스펠 데미지 `185/275/475 AP` → **`190/290/500 AP`** | (base 미작성) | ability.variables 갱신 |
+
+### Tier 4
+| 챔프 | 변경 | 영향 페이지 | sim 영향 |
+|------|------|-------------|----------|
+| Corki | 미사일 데미지 `30/44% AD` → **`28/42%`**, 미플 로켓 `120/180% AD` → **`110/165% AD`** | (base 미작성) | ability.variables 너프 |
+| Morgana | 사거리 `2` → **`1`** (!), 쉴드 HP 스칼라 `10%` → **`15%`** | (base 미작성) | ⚠️ **range 변경** — sim 타게팅 시스템 영향 (melee 변경) |
+| Nami | 마나 `25/70` → **`20/65`** | (base 미작성) | champion stats mana 갱신 |
+| Xayah | 기본 AD `50` → **`52`**, 스펠 메인 대상 데미지 `10/15% AD` → **`25/40% AD`** (대규모 buff) | (base 미작성) | champion stats + ability.variables 모두 |
+
+### Tier 5
+| 챔프 | 변경 | 영향 페이지 | sim 영향 |
+|------|------|-------------|----------|
+| Fiora | 스펠 진정한 데미지 `40/60 AD` → **`37/56 AD`** | (base 미작성) | ability.variables 너프 |
+| Graves | 기본 공속 `0.7` → **`0.75`**, 레이저 탄도학 감소 `40%` → **`60%`** | (base 미작성) | champion stats AS + ability.variables |
+| **Shen** | 마나 `10/70` → **`20/70`**, 스펠 데미지 `BonusDamageOnAttack 20/30 AP` → **`25/40 AP`** | [[shen]] | champion stats mana + ability.variables (17.3 너프 부분 revert) |
+| **Zed** | 클론 체력 `33/40%` → **`33/45%`**, 마나 `50/100` → **`40/100`** | [[zed]] / [[invader-zed]] | ⚠️ **applyZedShadow** trait helper 영향 (분신 alive 가정 BonusAD 0.40 단순화) — sim 단순화 모델 재검토 필요 |
+
+## 영향 페이지 cross-ref
+
+본 PR (sequence A) 에서 **위키 페이지 17.4 fact 명시** 만 수행:
+
+- [[zed]] — 17.4 클론 HP/마나 변경 추가 + frontmatter `current_patch_status: active (17.3 LIVE, 17.4 pending)` + 본문 패치 히스토리 row 추가
+- [[shen]] — 17.4 마나 + spell damage 변경 추가 (17.3 nerf 부분 revert)
+- [[jax]] — 17.4 평탄 DR AP 스케일링 제거 변경 추가 (sim 분기 구조 영향)
+- [[invader-zed]] — Zed base 변경의 carry augment 영향 cross-ref
+- [[jax-carry]] — Jax base 변경의 carry augment 영향 cross-ref
+- [[stargazer-fountain]] — 17.4 stargazer heal 2.5%→3% trait 변경 cross-ref
+
+## 17.4 ↔ 17.3 모순 사례
+
+- **Twisted Fate**: 17.3 buff (180/270/405/690 → 190/285/430/730) → 17.4 너프 reverted (180/270/405/690 으로 복귀) — patch wiki 의 17.3 row 와 17.4 row 가 1:1 revert 관계
+- **Bel'Veth**: 17.3 너프 (20/30/45/77 → 18/27/41/69 — 추정) → 17.4 reverted (20/30/45/77 복귀, esports.gg 공식 표기)
+- **Shen**: 17.3 너프 (BonusDamageOnAttack 45/75 → 20/30) → 17.4 partial revert (20/30 → 25/40)
+
+## Lint 체크리스트 (mechanic entity-type)
+
+- [x] **set17 entity 소속 0단계** — Champion 18건 + Trait 6건 모두 set17 (raw json 검증은 sequence B 단계)
+- [x] **공식 patch notes URL 인용** (sources frontmatter) — 룰 #14 mechanic page sync 의 도메인 fact 출처
+- [x] **17.4 ↔ 17.3 patch wiki cross-ref** — Twisted Fate / Bel'Veth / Shen 의 nerf/revert 관계 명시
+- [x] **본 patch 페이지가 권위 출처** — entity summary 표 (champion 18건 / trait 6건) → entity 페이지 / 코드 ground truth cross-check 룰 #13 적용 필요는 sequence B (raw data 갱신 후)
+- [x] **sim 미반영 명시** — frontmatter `last_verified` 에 "raw data 17.3 기준, 17.4 미반영" + 본문 ⚠️ sim 적용 상태 표
+- [x] **mechanic page sync (룰 #14)** — 본 patch wiki 자체가 mechanic 영역의 권위 출처. 영향 영역 trait helper (챌린저/다크스타/N.O.V.A./스나이퍼/스페이스 그루브/스타게이저) sim helper 위치 + 영향 페이지 cross-ref 명시
+- [x] **룰 #17 적용 분기 명시** — DarkStar/SpaceGroove/Sniper/Stargazer trait 은 **(d) combat-start helper** (applyXxxEffects 양 팀 호출). **예외**: N.O.V.A. (`tickDrxNova` PR #121) = **(d) combat-start setup + (c) cast-time/per-tick trigger 혼합** — `setupDrxNova` combat-start 값 로드 + `tickDrxNova` per-tick `delayTicks` 도달 시 효과 발동. **챌린저** burstPercent 도 동일 패턴 — combat-start `challengerBurstEndTick` SET + per-tick burst TRIGGER. 단순 (d) 일반화 금지 (PR #162 subagent self-catch P1-4 학습)
+- [ ] (sequence B 후) raw data 갱신 확인 + 본 페이지 sim 영향 column update
+- [ ] (sequence C 후) sim 코드 trait helper 값 갱신 후 frontmatter `last_verified` update
+
+## 관련
+
+- [[patch-17-3]] — 이전 패치 (17.3 → 17.4 변경 base)
+- [[patch-17-2b]] — 17.2b 변경 누적 (Aatrox cycle / spiritBounce 등)
+- [[stargazer-fountain]] — 17.4 stargazer heal 변경 cross-ref
+- 코드: `src/lib/simulator/engine/combatLoop.ts` (trait helpers — sequence C 영향) / `src/data/carryAugments.ts` / `src/lib/simulator/systems/ability.ts`
+- Raw: `public/data/tft_set17_*.json` (sequence B 갱신 대기)


### PR DESCRIPTION
## Summary

17.4 패치 (2026-05-27 출시) 추적 PR sequence 의 **A 단계** — 위키 fact 만 기록. raw data + sim 코드 미반영 (sequence B/C/D 후속 PR 대기).

- **patches/patch-17-4.md (신규)** — 17.4 fact 종합 (champion 18건 + trait 6건 + system 2건)
- **5 페이지 update** — Zed / Shen / Jax (champion) + invader-zed / jax-carry (carry augment) — frontmatter `current_patch_status: active (17.3 LIVE, 17.4 patch pending)` + 본문 패치 히스토리 row + sim 미반영 명시

## 17.4 핵심 변경 (영향 페이지)

| 챔피언 | 변경 | 영향 |
|--------|------|------|
| **Zed** (5코) | 클론 HP `0.40` → **`0.45`**, 마나 `50/100` → **`40/100`** | 너프 — [[zed]] / [[invader-zed]] |
| **Shen** (5코) | 마나 `10/70` → **`20/70`**, BonusDamageOnAttack `20/30` → **`25/40` AP** | 17.3 너프 partial revert (buff) — [[shen]] |
| **Jax** (2코) | FlatDR `15/20/25 AP` → **`20/25/30`** (**AP scaling 제거**) | 조정 (분기 구조 영향) — [[jax]] / [[jax-carry]] |

## 🎯 subagent self-catch P1 4건 (룰 #16/#17 patch wiki 첫 적용)

### P1-1 Zed 마나 방향 오기

`initialMana 50→40` 은 **감소** → 첫 cast 에 필요한 추가 mana `100-50=50` → `100-40=60` → **더 늦은 첫 cast (너프)**. 페이지가 "initial mana ↑, 더 빠른 cast" 잘못 표기 + "너프 2건" label 과 자가 모순.

### P1-2 Shen 마나 방향 오기 (2 line page-internal 통합)

`initialMana 10→20` 은 **증가** → 첫 cast 에 필요한 추가 mana `70-10=60` → `70-20=50` → **더 빠른 첫 cast (buff)**. 페이지가 "더 늦은 cast + 60 mana 더 필요" 잘못 표기 (산술 오류 동시).

### P1-3 jax-carry.md 룰 #15 위반

frontmatter `sim_active: active` ↔ 본문 `## sim 적용 상태 — partial` 모순. partial 강등 + 사유 명시.

### P1-4 patch-17-4.md 룰 #17 (d) 과잉 일반화

`(d) combat-start helper` 만 명시 잘못 — N.O.V.A. (`tickDrxNova`) + 챌린저 burstPercent 는 **(d) combat-start setup + (c) per-tick TRIGGER 혼합**. 두 시스템의 setup/trigger 분리 명시.

## P2 4건 (metadata 정확도)

- shen.md `Tank role` → **Fighter role** (frontmatter `role: Fighter` 정합)
- invader-zed.md `applyHeroCarryTransforms line 2227` → **`:2258`** (drift 31)
- jax-carry.md sources + body `:2220-2267 / 2227` → **`:2258`** (drift 31)
- jax.md `요새: traitModules.ts` → **`applyBastionEffects (combatLoop.ts:1817 + 4580)`** 정정

## sim 적용 상태

| Asset | 17.4 적용 | 후속 PR |
|-------|-----------|---------|
| **raw data** (`public/data/tft_set17_*.json`) | ❌ 17.3 기준 — `patch_version` 메타데이터 자체 부재 | **sequence B** |
| **sim 코드** (trait helpers + ability config) | ❌ 17.3 값 hardcoded | **sequence C** |
| **Arbiter / Psionic 시스템** | ❌ 17.3 구조 | **sequence D** |
| **위키 페이지** | ⚠️ **본 PR (sequence A)** — 17.4 fact 명시 + sim 미반영 명시 | 본 PR |

## Codex review 우선 검증 포인트

1. **17.4 ↔ 17.3 patch wiki cross-ref** — Twisted Fate / Bel'Veth / Shen 의 nerf/revert 관계 정합
2. **마나 방향 산술** — Zed / Shen 의 `initialMana` 변경과 "더 빠른/늦은 first cast" 결론 산술 정합
3. **patch-17-4.md trait 표 sim 영향 column** — N.O.V.A. (setup + tick) / 챌린저 (setup + trigger) 혼합 분기 명시 정합
4. **외부 URL 유효성** — sources frontmatter 3개 URL 접근 가능
5. **18건 champion 중 위키 미작성 16건** — tracking 공백 (Aatrox, Bel'Veth, Gnar, Gwen, Zoe, Aurora, Lulu, MissFortune, Ornn, Rhaast, Viktor, Corki, **Morgana range 2→1!**, Nami, Xayah, Fiora, Graves, TwistedFate)

## 학습 — 룰 보강 후보 (PR #163~?)

- **룰 #18 후보**: 마나 방향 verify sub-rule — `initialMana X → Y` 변경 서술 시 "first cast 추가 mana = maxMana - initialMana" 산술 명시 (Zed + Shen 양쪽 동일 방향 오류)
- **patch page lint scope** — lint-rules.md 현재 patch ❌. mini-checklist (URL 유효성 / summary table cross-check / 17.X ↔ 17.Y revert 관계) 명시 권장
- **trait helper setup vs trigger 분리** (룰 #17 보강) — N.O.V.A. / 챌린저 같이 (d) setup + (c) trigger 혼합 패턴 명시

## Sources

- 공식: https://teamfighttactics.leagueoflegends.com/en-us/news/game-updates/teamfight-tactics-patch-17-4/
- esports.gg: https://esports.gg/news/teamfight-tactics/tft-patch-17-4-notes-belveth-nerf-reverted-plus-arbiter-and-psionic-buffs/
- pcgamesn: https://www.pcgamesn.com/teamfight-tactics/patch-17-4-notes-conditionality

## Test plan

- [x] subagent lint dispatch (P0 0, **P1 4 self-catch**, P2 4) — 본 commit 모두 fix
- [x] page-internal cross-check (shen.md 2 line 통합 / jax-carry.md frontmatter 모순)
- [x] 외부 patch notes 정확성 cross-check (공식 + esports.gg + pcgamesn)
- [ ] @codex review (특히 17.4 ↔ 17.3 revert 관계 + 16 champion tracking 공백 평가)
- [ ] 머지 후 sequence B (raw data fetch) 후속 PR 시작