### PR TITLE
docs(wiki): aatrox.md 사후 verify 묶음 A — 요새(Bastion) trait 통합 문서화 + A2 주석 정정

### DIFF
--- a/docs/wiki/champions/aatrox.md
+++ b/docs/wiki/champions/aatrox.md
@@ -10,7 +10,7 @@ traits:
 role: Tank   # raw "ADTank" → mapGameRole() → sim Tank (types/index.ts:41 includes('Tank')). ⚠️ TFT17_Augment_AatroxCarry 활성 시 Fighter 로 변환 (applyHeroCarryTransforms) — Jax/Nasus/Poppy 와 동일 규칙 (frontmatter 는 base/canonical role)
 raw_role: ADTank
 current_patch_status: active
-sim_active: partial   # carry 3-skill cycle + N.O.V.A. 타격 + shredPct(trait) 정합. A1 base heal(HealHP/HealAP) healVar 미매칭 → 미발동 / A2 주석 단독 ×2.5 stale(실제 2.0) / A3 armorReduction "AP 스케일" 주석 vs flat 코드 / A4 base NOVAModifier(비-carry NOVA 타격) sim 부재 / A5 base ModifiedDamage 의 DamagePercentArmor(scaleArmor) sim 미소비 (DamageAD scaleAD 만)
+sim_active: partial   # carry 3-skill cycle + N.O.V.A. 타격 + shredPct(trait) + 요새(Bastion) trait 정합. A1 base heal(HealHP/HealAP) healVar 미매칭 → 미발동 / A2 주석 단독 ×2.5 → 2.0 정정 완료(fix/aatrox-fortress-trait-doc, 코드 동작은 원래 정합) / A3 armorReduction "AP 스케일" 주석 vs flat 코드 / A4 base NOVAModifier(비-carry NOVA 타격) sim 부재 / A5 base ModifiedDamage 의 DamagePercentArmor(scaleArmor) sim 미소비 (DamageAD scaleAD 만)
 last_verified: 2026-06-02
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Aatrox entry — cost 1, role ADTank, traits N.O.V.A./요새, ability '별빛 베기' variables HealHP/HealAP/DamageAD/DamagePercentArmor/NOVAModifier)"
@@ -106,7 +106,7 @@ TFT17_Aatrox: { pattern: 'single', heal: true }
 | `slamStunDuration` | 1.0 | ✅ `config.stun` (`:6276`) | 찍기 공중 띄움 1초 |
 | `armorReduction` | 10 | ✅ flat -10 armor (`:6996` `t.stats.armor - 10`) | ⚠️ carryAugments 주석은 "AP 스케일" 인데 코드는 flat — **Lint A3** |
 | `novaDamage` | [120, 180, 270] | ✅ N.O.V.A. 타격 (아래) | |
-| `singleTargetMultiplier` | **2.0** | ✅ 찍기 단독 적중 (`:1329-1332`, aliveTargetCount===1) | 17.3 nerf 2.5 → 2.0. ⚠️ `combatLoop.ts:6239` 주석은 "단독 적중 ×2.5" stale — **Lint A2** |
+| `singleTargetMultiplier` | **2.0** | ✅ 찍기 단독 적중 (`:1329-1332`, aliveTargetCount===1) | 17.3 nerf 2.5 → 2.0. `combatLoop.ts:6239` 주석 ×2.5 → ×2.0 정정 완료 (**Lint A2 해소**) |
 
 > **찍기 단독 적중 multiplier** (`applyCarryDamageModifiers` `:1328-1333`): `aatroxIsSingleTargetSlam && aliveTargetCount === 1 && singleTargetMultiplier` 조건. 찍기 cycle 에서 적이 1명만 남았을 때 damage ×2.0 (고립 대상 처형 메커니즘).
 
@@ -145,6 +145,19 @@ cycle ability 와 **별개의 추가 효과** (사용자 정정 spec: "기존 �
 
 > ⚠️ **DRX trait 비활성 또는 surge 미발동 시 미발동** (codex P1 PR #73): selector flag 만으로 불충분 — `ownDrxState.triggered` (6초 도달) 까지 gating. surge 전 cast 에서는 cycle ability 만 발동.
 
+### 요새 (Bastion) trait — sim 통합 (보조 trait)
+
+Aatrox 는 frontmatter `traits: [N.O.V.A., 요새]` 의 **두 번째 trait 으로 요새 (Bastion)** 를 보유. raw desc (`tft_set17_traits.json` 요새): "아군이 방어력·마법저항력을 `@TeamwideResists@` 얻습니다. 요새는 추가 수치를 얻고, 전투 시작 후 `@Duration@`초 동안 추가 수치를 2배로 얻습니다."
+
+| 효과 | sim 적용 | 근거 |
+|------|---------|------|
+| 아군 전체 Armor/MR (`TeamwideResists`) | ✅ | `applyBastionEffects` (`combatLoop.ts:1824`), 전투 시작 시 양팀 호출 (`:4610-4611`) |
+| 요새 unit 추가 `BonusArmor`/`BonusMR` | ✅ | `unitHasTrait(u, '요새')` 분기 (`:1844`) — Aatrox `traits.includes('요새')` 로 **자동 진입** |
+| 첫 `Duration`초 doubled buff | ✅ | setup 시 2배 적용 → `:5197` main loop tick 에서 만료 시 차감 (`:1860` helper) |
+| (6) tier 비-요새 unit `EnhancedTeamwideArmor` | ✅ | `isHighTier && !unitHasTrait(u, '요새')` 분기 (`:1840`) — Aatrox 는 요새라 해당 없음 |
+
+> ✅ **sim 통합 완료 — Aatrox-specific 처리 불필요**. 요새는 `unitHasTrait` 기반 **generic Bastion 경로** 이므로 carry/base 무관하게 동일 적용 (N.O.V.A. 와 달리 champion-specific 분기 없음). 후속 champion 인제스트 시 요새 trait 중복 verify 불필요.
+
 ## Cast path 분석 (PR #129 룰 — 3종 전수)
 
 | cast path | Aatrox 처리 | 근거 |
@@ -168,10 +181,11 @@ cycle ability 와 **별개의 추가 효과** (사용자 정정 spec: "기존 �
 - 타격 선택기 자동 할당 (가장 강한 NOVA unit)
 - surge alive 재평가 / surge gating (codex P1 가드)
 - OOR cast path cycle 미적용 명시 처리
+- **요새 (Bastion) trait** — `applyBastionEffects` (`:1824`, 양팀 `:4610-4611`) generic 경로로 Teamwide Armor/MR + 요새 추가 BonusArmor/MR + 첫 Duration초 doubled 자동 수령 (`unitHasTrait(u, '요새')` `:1844`)
 
 ⚠️ **부정확 / 미반영** (Lint 후보):
 - **A1 (P2)**: base "별빛 베기" 체력 회복 (`HealHP`/`HealAP`) 미발동 — `config.heal` 핸들러 healVar lookup 이 `HealHP`/`HealAP` 이름 미포함. base (비-carry) Aatrox 의 heal 효과 sim 부재. carry (별빛 연계) 는 heal 없는 3-skill 이라 무영향
-- **A2 (P2)**: `combatLoop.ts:6239` 주석 "찍기 ... 단독 적중 ×2.5" stale — 실제 `singleTargetMultiplier 2.0` (17.3 nerf). 코드 동작은 abilityData 직접 read 라 정합, 주석만 stale
+- **A2 (P2) — 해소**: `combatLoop.ts:6239` 주석 "찍기 ... 단독 적중 ×2.5" → "×2.0 (17.3: 2.5→2.0)" 정정 완료 (본 PR). 코드 동작은 abilityData 직접 read 라 원래부터 정합, 주석만 stale 이었음
 - **A3 (P2)**: `carryAugments.ts:143` `armorReduction: 10, // 휩쓸기 armor 감소 (AP 스케일)` 주석은 AP 스케일 표기인데 코드 (`:6996`) 는 flat -10 (AP scaling 없음). 주석 vs 코드 불일치 (도메인상 AP 스케일이 맞는지 인게임 verify 필요)
 - **A4 (P2)**: base (비-carry) Aatrox 의 N.O.V.A. 타격 (`NOVAModifier 0.5` × `ModifiedNovaDamage`) sim 부재 — NOVA 타격 추가 발동은 `isAatroxCarry` 경로 한정. base 1코스트 Aatrox 가 carry 없이 NOVA selector 받는 경우 추가 타격 없음 (의도된 단순화 가능성)
 - **A5 (P2)**: base 단일 물리 피해의 `DamagePercentArmor` (scaleArmor) sim 미소비 — raw `ModifiedDamage` 는 scaleAD + scaleArmor 인데 `resolveAbilityDamage` default 가 `DamageAD` (scaleAD) 만 선택, `DamagePercentArmor` 는 repo-wide grep 0 hit. base damage 가 armor scaling 만큼 과소 적용 (carry 는 cycle damage 직접 사용이라 무관)
@@ -181,7 +195,7 @@ cycle ability 와 **별개의 추가 효과** (사용자 정정 spec: "기존 �
 | # | 항목 | 의미 | Tier | 적용 분기 (룰 #17) | 처리 |
 |---|------|------|------|---------------------|------|
 | A1 | base 별빛 베기 heal (`HealHP`/`HealAP`) healVar 미매칭 → 미발동 | `config.heal` 핸들러가 `'Heal'\|'APHeal'\|'PercentMaximumHealthHealing'\|'HealthDrain'` 이름만 검색 → Aatrox 변수명 (`HealHP`/`HealAP`) 미매칭 → heal 0. base Aatrox active 의 회복 단계 sim 부재 | **P2** | (c) cast-time 1회 helper — healVar lookup 에 `HealHP`/`HealAP` (또는 `ModifiedHeal` resolve) 추가. HealHP=flat%(maxHp), HealAP=AP scaling 분리 처리 | 본 wiki PR scope 밖 (sim fix). 1코스트 base carry 빈도 낮아 P2. 문서에 미발동 명시로 처리 |
-| A2 | `:6239` 주석 단독 적중 "×2.5" stale | 실제 `singleTargetMultiplier 2.0` (17.3 nerf 2.5→2.0). 코드 동작 정합, 주석만 과거 값 | **P2** | 주석 cleanup (코드 동작은 abilityData 직접 read) | 후속 PR 주석 정리 — 본 wiki PR scope 밖 |
+| A2 | `:6239` 주석 단독 적중 "×2.5" stale | 실제 `singleTargetMultiplier 2.0` (17.3 nerf 2.5→2.0). 코드 동작 정합, 주석만 과거 값 | **P2** | 주석 cleanup (코드 동작은 abilityData 직접 read) | ✅ **해소** — 본 PR (`fix/aatrox-fortress-trait-doc`) 에서 `:6239` 주석 ×2.5→×2.0 (17.3) 정정 |
 | A3 | `carryAugments.ts:143` armorReduction 주석 "AP 스케일" vs 코드 flat -10 | 코드는 flat 차감인데 주석은 AP 스케일 표기 — 도메인 의도 (raw 가 AP scaling 인지) 확인 필요 | **P2** | (b) per-target — 휩쓸기 cone hit 시 armor 감소. AP 스케일 맞으면 `armorReduction × (1 + ap/100)` 적용 후 차감 | 인게임 측정 후 결정. 현재 flat -10 (낮은 영향) |
 | A4 | base (비-carry) NOVAModifier 0.5 N.O.V.A. 타격 sim 부재 | NOVA 타격 추가 발동이 `isAatroxCarry` 한정 — base Aatrox 가 NOVA selector 받아도 추가 타격 없음 | **P2** | (c) cast-time — base Aatrox NOVA selector 시 `ModifiedNovaDamage` (NOVAModifier × ModifiedDamage) 발동 분기 추가 | 의도된 단순화 가능성 (carry 중심 메타) — 인게임 spec verify 후 결정 |
 | A5 | base 단일 피해 `DamagePercentArmor` (scaleArmor) sim 미소비 | raw `ModifiedDamage` = scaleAD + scaleArmor 인데 `getAbilityDamage` default 가 `DamageAD` (scaleAD) 만 선택 → base damage 가 armor scaling 만큼 과소. `DamagePercentArmor` repo-wide grep 0 hit | **P2** | (b) per-target — base single hit damage 에 caster armor × `DamagePercentArmor[star]` 가산. 단 base ability 가 abilityOverride 없는 generic resolve 경로라 champion-specific 분기 필요 | carry (별빛 연계) 는 cycle damage 직접 사용이라 무관. base Aatrox 한정 — 인게임 측정 후 결정 |
@@ -196,8 +210,9 @@ cycle ability 와 **별개의 추가 효과** (사용자 정정 spec: "기존 �
 - [x] **raw role `ADTank` → mapGameRole → Tank (base), carry → Fighter** — base/carry role 분기 명시
 - [x] **3-skill cycle** verify — `combatLoop.ts:6256` cycleCounter % 3 분기 + cycle damage 직접 사용 (`:6292`)
 - [x] **abilityData 값** verify — `carryAugments.ts:131-148` damage/secondaryDamage/slamDamage/armorReduction/novaDamage/singleTargetMultiplier 전수
-- [x] **단독 적중 multiplier** verify — `:1328-1333` aliveTargetCount===1 조건, 실제 2.0 (주석 ×2.5 stale = A2)
+- [x] **단독 적중 multiplier** verify — `:1328-1333` aliveTargetCount===1 조건, 실제 2.0 (`:6239` 주석 ×2.5→×2.0 정정 = A2 해소)
 - [x] **N.O.V.A. shredPct** verify — DRX raw `ShredAndSunder 0.30` (`tft_set17_traits.json`) → `:4721` read → `:4749-4753` armor/MR ×0.7. 정합
+- [x] **요새 (Bastion) trait 통합** verify (룰 #16 — traits frontmatter 각 entry sim 통합 여부 명시) — `applyBastionEffects` (`:1824`) + 양팀 호출 (`:4610-4611`) + `unitHasTrait(u, '요새')` 분기 (`:1844`) + doubled 만료 (`:5197`). Aatrox `traits.includes('요새')` 자동 진입 → generic Bastion 경로 ✅ sim 통합 완료 (champion-specific 분기 불필요)
 - [x] **N.O.V.A. 타격 추가 발동** verify — `:6817-6856` selector + surge gating (`ownDrxState.triggered`) + novaDamage + 1초 stun
 - [x] **actual sim integration verify (5단계)** — base heal: `config.heal` 핸들러 (`:7002`) healVar lookup 이 `HealHP`/`HealAP` 미매칭 확인 → heal 미발동 (A1). 효과 주장 전 read site 부재 확인
 - [x] **cast path 3종 (PR #129 룰)** — main (cycle ✅) / OOR (`:7342-7348` cycle 미적용 명시 ✅) / recast (N/A). [[ability-targeting]] 3 호출처 참조

--- a/docs/wiki/champions/aatrox.md
+++ b/docs/wiki/champions/aatrox.md
@@ -156,7 +156,7 @@ Aatrox 는 frontmatter `traits: [N.O.V.A., 요새]` 의 **두 번째 trait 으�
 | 첫 `Duration`초 doubled buff | ✅ | setup 시 2배 적용 → `:5197` main loop tick 에서 만료 시 차감 (`:1860` helper) |
 | (6) tier 비-요새 unit `EnhancedTeamwideArmor` | ✅ | `isHighTier && !unitHasTrait(u, '요새')` 분기 (`:1840`) — Aatrox 는 요새라 해당 없음 |
 
-> ✅ **sim 통합 완료 — Aatrox-specific 처리 불필요**. 요새는 `unitHasTrait` 기반 **generic Bastion 경로** 이므로 carry/base 무관하게 동일 적용 (N.O.V.A. 와 달리 champion-specific 분기 없음). 후속 champion 인제스트 시 요새 trait 중복 verify 불필요.
+> ✅ **sim 통합 완료 — champion-specific 구현 불필요**. 요새는 `unitHasTrait` 기반 **generic Bastion 경로** 이므로 carry/base 무관하게 동일 적용 (N.O.V.A. 와 달리 champion-specific 분기 없음). 단 **룰 #16 verify 자체는 면제 아님** — 후속 요새 champion 인제스트 시에도 `applyBastionEffects` / `unitHasTrait('요새')` wiring 을 grep 재검증·line 인용해야 함 (line drift / trait wiring 변경 감지). "champion-specific 분기를 추가할 필요가 없다" 는 의미일 뿐, generic Bastion 경로 존재 여부 verify 는 매 champion 마다 수행.
 
 ## Cast path 분석 (PR #129 룰 — 3종 전수)
 

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6236,7 +6236,7 @@ export function simulateCombat(
             // cast 마다 cycle counter % 3 으로 분기:
             //   0 = 타격 (single AD)
             //   1 = 휩쓸기 (cone radius 1, AD + armor 감소 10)
-            //   2 = 찍기 (aoe_circle radius 1, AD + knockup + 단독 적중 ×2.5)
+            //   2 = 찍기 (aoe_circle radius 1, AD + knockup + 단독 적중 ×2.0; 17.3: 2.5→2.0)
             // N.O.V.A. 타격 (carry Aatrox + aatroxNovaStrikeSelector=true): pattern → global
             // + 모든 적 knockup. cycle damage 그대로 적용 (사용자 spec).
             // 사망 시 cycle reset: aatroxPreviouslyDead 검사 (resurrect 메커니즘 연동, 미래 대비).


### PR DESCRIPTION
## 배경

PR #175 (TFT17_Aatrox champion ingest) 머지 후 `wiki-ingest-verifier` **사후(post-merge) 검증**을 수행. 머지 전 dispatch가 누락되어 self-catch 기회를 놓쳤던 점을 보완. P0는 없었고 (머지 상태 안전), Codex가 정정한 role/base-damage도 현재 코드 ground truth와 정합 재확인됨.

발견된 finding 중 **Aatrox 도메인 묶음(P1-1 + P2-A2)** 을 본 PR로 처리. (spell-crit.md line drift = P2-2 는 별도 주기적 정리 PR로 분리)

## 변경

### P1-1 — 요새(Bastion) trait sim 통합 사실 본문 미언급 (룰 #16)
- frontmatter `traits: [N.O.V.A., 요새]` 의 두 번째 trait **요새**가 sim 통합 완료 상태인데, 메커니즘/sim 상태/체크리스트 어디에도 명시가 없던 정보 공백 보완.
- **ground truth (직접 verify)**:
  - `applyBastionEffects` 정의 `combatLoop.ts:1824`
  - 전투 시작 시 양팀 호출 `:4610-4611`
  - `unitHasTrait(u, '요새')` 요새 unit 추가 BonusArmor/MR 분기 `:1844`
  - 첫 Duration초 doubled buff 만료 차감 `:5197` (helper `:1860`)
  - Aatrox `traits.includes('요새')` → **generic Bastion 경로 자동 진입** (N.O.V.A. 와 달리 champion-specific 분기 불필요)
- 반영 위치: 메커니즘 섹션 신규 표 + `sim 적용 상태 ✅ 활성` + Lint 체크리스트

### P2-A2 해소 — `combatLoop.ts:6239` 주석 stale 정정
- `"단독 적중 ×2.5"` → `"×2.0 (17.3: 2.5→2.0)"`. 코드 동작(`singleTargetMultiplier: 2.0` 직접 read, `carryAugments.ts:145`)은 **원래 정합**, 주석만 17.3 너프 미반영이었음.
- aatrox.md 의 A2 관련 표기 4곳을 "해소"로 일관 업데이트.

## 검증
- `pnpm typecheck`: clean
- `pnpm lint`: 0 errors (14 pre-existing warnings — 변경 파일과 무관)
- `pnpm build`: 성공
- 주석/문서 변경이라 sim 동작 무영향 (회귀 없음)

## Self-catch 메모
머지 전 dispatch했다면 P1(요새 trait 미언급) + P2(A2 주석)를 self-catch 가능했음 — CLAUDE.md champion 페이지 **머지 전 dispatch 규칙**의 가치를 입증한 사례.

🤖 Generated with [Claude Code](https://claude.com/claude-code)