### PR TITLE
docs(wiki): spell-crit.md line drift 일괄 정리 + page-internal stale fix

### DIFF
--- a/docs/wiki/mechanics/spell-crit.md
+++ b/docs/wiki/mechanics/spell-crit.md
@@ -4,7 +4,7 @@ type: mechanic
 display_name_kr: 스킬 치명타
 current_patch_status: active
 sim_active: true
-last_verified: 2026-05-26 (retro lint subagent — cast roll 호출처 3 → 5 정정, line drift 일괄 갱신, pickTopCombo/tagReason "추정" → 코드 직접 검증)
+last_verified: 2026-06-02 (PR #176 사후 P2-2 — combatLoop.ts 인용 10곳 line drift 일괄 갱신 [5 cast 호출처 +32~+57 + helper 4곳], 의미 매핑·JaxCarry 가드 재verify, fact 변경 0. 이전: 2026-05-26 retro lint cast roll 3→5 정정)
 sources:
   - src/lib/combat/spellCrit.ts (computeSpellCanCrit, expectedSpellCritMultiplier, SPELL_CRIT_ITEMS)
   - src/lib/simulator/engine/combatLoop.ts (5 application sites + 3 buff sources — main + recast + OOR + Jax carry main + Jax carry OOR)
@@ -52,14 +52,14 @@ TFT 룰: **스킬 피해는 기본적으로 치명타가 안 터진다**. 특정
 
 | 효과 | 위치 | 동작 |
 |------|------|------|
-| **운명술사 (Fateweaver)** Innate | `applyFateweaverEffects` (line 1769) | `TFT17_Fateweaver` trait count >= 1 (활성 여부 무관) → 운명술사 unit 에 `spellCanCrit = true`. (4) tier 시 추가 Crit Chance +20%, Crit Damage +20% |
-| **Akali Precision (DRX N.O.V.A. surge)** | `tickDrxNova` (line 4709) | **Akali cast 가 아님** — DRX N.O.V.A. (5 시너지) 활성 + `TeamAttackDelay` 경과 시 한 번 발동. 발동 시점에 Akali 가 alive 면 모든 alive 아군에 `spellCanCrit = true` 일괄 부여. `state.triggered` 가드로 단발성 |
-| **Graves SharpshooterModule (위력)** | `applyGravesFrameEffects` SharpshooterModule case (line 2330+) | 위력 frame 적용된 Graves 에 `spellCanCrit = true` + AbilityDamage +5% |
+| **운명술사 (Fateweaver)** Innate | `applyFateweaverEffects` (line 1776) | `TFT17_Fateweaver` trait count >= 1 (활성 여부 무관) → 운명술사 unit 에 `spellCanCrit = true`. (4) tier 시 추가 Crit Chance +20%, Crit Damage +20% |
+| **Akali Precision (DRX N.O.V.A. surge)** | `tickDrxNova` (line 4739, Akali `spellCanCrit` 부여 line 4765) | **Akali cast 가 아님** — DRX N.O.V.A. (5 시너지) 활성 + `TeamAttackDelay` 경과 시 한 번 발동. 발동 시점에 Akali 가 alive 면 모든 alive 아군에 `spellCanCrit = true` 일괄 부여. `state.triggered` 가드로 단발성 |
+| **Graves SharpshooterModule (위력)** | `applyGravesFrameEffects` (line 2337, SharpshooterModule case line 2358) | 위력 frame 적용된 Graves 에 `spellCanCrit = true` + AbilityDamage +5% |
 
 ## sim 엔진 적용 (`combatLoop.ts`)
 
 ### Init (전투 시작)
-- `createCombatUnit` (`line 301`): `spellCanCrit: computeSpellCanCrit(allItems, activeTraits)` — 아이템 + 시너지 조합 기반 unit-level 초기화
+- `createCombatUnit` (`line 300`): `spellCanCrit: computeSpellCanCrit(allItems, activeTraits)` — 아이템 + 시너지 조합 기반 unit-level 초기화
 - 추가 unit-level effect 들 (운명술사 / Akali / Graves) 가 init 후 분기로 활성화
 
 ### Critical Roll (5 cast 호출처)
@@ -71,11 +71,11 @@ if (unit.spellCanCrit && rng.next() < unit.stats.critChance) {
 ```
 
 5 호출처:
-- **line 6549** — main cast pipeline (`findAbilityTargets` 결과 적용 시)
-- **line 6673** — recast (onKill 등 재시전 경로)
-- **line 6895** — **Jax carry damage (main cast 직후 분기)** — `selectedCarryAugment === 'TFT17_Augment_JaxCarry'` 가드 (PR #135/#147 도입)
-- **line 7228** — **Jax carry damage (OOR 분기)** — OOR fallback path 내 별도 cast roll
-- **line 7294** — OOR fallback main path (abilityTargets OOR loop)
+- **line 6581** — main cast pipeline (`findAbilityTargets` 결과 적용 시)
+- **line 6705** — recast (onKill 등 재시전 경로)
+- **line 6927** — **Jax carry damage (main cast 직후 분기)** — `selectedCarryAugment === 'TFT17_Augment_JaxCarry'` 가드 (PR #135/#147 도입)
+- **line 7285** — **Jax carry damage (OOR 분기)** — OOR fallback path 내 별도 cast roll, `oorCarryCfg` + 동일 JaxCarry 가드
+- **line 7351** — OOR fallback main path (abilityTargets OOR loop, `applyCarryDamageModifiers` 통합 helper 직후)
 
 → rng 결정론 보장 ([[ability-targeting]] 참조 — SeededRNG). carry-specific 분기 추가 패턴 — 향후 신규 carry augment 도입 시 본 cast roll 리스트 stale 검증 필수 ([[lint-rules]] "Carry augment ingest 시 관련 mechanic page cast roll 갱신" 룰 후보 #4)
 
@@ -112,9 +112,9 @@ AP 캐리에 보건/무대 추천 시 +400 프리미엄 (다른 AP 가중치 `Sp
 | 모듈 | 책임 |
 |------|------|
 | `src/lib/combat/spellCrit.ts` | `SPELL_CRIT_ITEMS` Set, `computeSpellCanCrit`, `expectedSpellCritMultiplier`, `SPELL_CRIT_UNLOCK_BONUS` |
-| `src/lib/simulator/engine/combatLoop.ts` | unit init + 3 cast crit roll + 운명술사/Akali/Graves 분기 |
+| `src/lib/simulator/engine/combatLoop.ts` | unit init + 5 cast crit roll (main/recast/OOR + Jax carry main + Jax carry OOR) + 운명술사/Akali/Graves 분기 |
 | `src/lib/analysis/itemOptimizer.ts` | `estimateDps` AP 분기 spellCritMul + `extractItemDpsModifiers.canSpellCrit` |
-| `src/lib/analysis/itemRecommender.ts` | flatStatBonus 보건/무대 프리미엄 + (추정) pickTopCombo + tagReason |
+| `src/lib/analysis/itemRecommender.ts` | flatStatBonus 보건/무대 프리미엄 + pickTopCombo (line 190/290) + tagReason (line 229/291) |
 
 ## 패치 히스토리
 
@@ -123,7 +123,8 @@ AP 캐리에 보건/무대 추천 시 +400 프리미엄 (다른 AP 가중치 `Sp
 | 2026-04-22 (plan) | PDCA spell-crit-mechanic plan 작성 (`docs/01-plan/features/spell-crit-mechanic.plan.md`) |
 | 2026-04-22 이후 | design + 구현 — `spellCrit.ts` 모듈 도입, combatLoop 3 cast 경로에 crit roll 삽입, itemOptimizer AP 분기 + recommender 프리미엄 적용 |
 | 2026-05-18 (현재) | **PDCA check 단계, Match Rate 97%** (세션 reminder 기준). 본 위키 페이지로 도메인 지식 file back |
-| 17.3 LIVE 변경 | Set 17 운명술사 trait 메커니즘 안정 (별도 변경 없음). Akali Precision (line 4709, `tickDrxNova`) 도 안정 |
+| 17.3 LIVE 변경 | Set 17 운명술사 trait 메커니즘 안정 (별도 변경 없음). Akali Precision (line 4739, `tickDrxNova`) 도 안정 |
+| 2026-06-02 | **line drift 일괄 정리** (PR #176 사후 검증 P2-2) — combatLoop.ts 인용 10곳 갱신: 5 cast 호출처 (6549/6673/6895/7228/7294 → 6581/6705/6927/7285/7351, drift +32~+57) + helper 4곳 (createCombatUnit 301→300 / applyFateweaverEffects 1769→1776 / tickDrxNova 4709→4739 / applyGravesFrameEffects 2330+→2337). 의미 매핑·Jax 가드 재verify 완료. **dispatch verify (wiki-ingest-verifier) 로 page-internal stale 2건 추가 fix**: 코드 위치 정리 표 "3 cast → 5 cast crit roll" (P1, Jax carry 분기 도입 후 표 갱신 누락) + itemRecommender 행 "(추정)" 제거 (P2, line 105 verify 완료와 모순) + Akali 부여 line 4761→4765 정정. itemOptimizer/itemRecommender 인용은 drift 없음 |
 | 2026-05-26 | **retro lint subagent (PR #154)** — Jax carry hero augment (PR #135/#147 도입) 으로 cast roll 호출처 3 → 5곳 정정. line drift 일괄 갱신. pickTopCombo/tagReason "추정" → 코드 직접 검증 완료 |
 
 ## sim 적용 상태 — `active`


### PR DESCRIPTION
## 배경

PR #175 Aatrox 사후 검증에서 분리해둔 **P2-2 (spell-crit.md cast 호출처 line drift)** 처리. 코드가 combatLoop.ts 에 집중 추가되며 인용 line 이 +32~+57 밀린 상태였음.

## line drift 정리 — combatLoop.ts 인용 10곳

| 항목 | 문서(stale) | 실제 |
|------|------|------|
| main cast | 6549 | **6581** |
| recast | 6673 | **6705** |
| Jax carry main | 6895 | **6927** |
| Jax carry OOR | 7228 | **7285** |
| OOR main | 7294 | **7351** |
| createCombatUnit init | 301 | **300** |
| applyFateweaverEffects | 1769 | **1776** |
| tickDrxNova | 4709 | **4739** |
| applyGravesFrameEffects | 2330+ | **2337** |
| Akali spellCanCrit 부여 | (4761) | **4765** |

- 5 cast 호출처 의미 매핑 (main/recast/Jax main/Jax OOR/OOR main) + **JaxCarry 가드** (6927/7285 가 `selectedCarryAugment === 'TFT17_Augment_JaxCarry'` 안) 재verify 완료 → 라벨 정확.
- `itemOptimizer.ts` (268~279) / `itemRecommender.ts` (140/190/229/231/290/291) 인용은 **drift 없음** 확인.

## dispatch verify (wiki-ingest-verifier) 추가 fix — page-internal stale 2건

drift 정리 중 `wiki-ingest-verifier` dispatch 가 본문 내 모순 2건을 추가 catch:

- **P1**: "코드 위치 정리" 표의 `"3 cast crit roll"` → `"5 cast crit roll"`. Jax carry 2분기 도입(PR #135/#147) 후 요약 표 갱신 누락 — 본문 line 26/133 의 "5 cast" 와 모순.
- **P2**: itemRecommender 행 `"(추정) pickTopCombo"` → `"(추정)"` 제거. line 105 `"코드 verify 완료"` 와 모순.

## 검증

- `wiki-ingest-verifier` dispatch: P0 **0** / P1 1 / P2 1 (모두 본 PR fix) / downgraded known 2.
- 문서만 변경 (mechanic 페이지, 코드 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)