### PR TITLE
infra(wiki): pre-commit hook 으로 wiki-ingest-verify dispatch 강제 (#175 재발 방지)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,58 @@
+#!/bin/sh
+# ──────────────────────────────────────────────────────────────
+# pre-commit: TFT Domain Wiki ingest-verify gate
+#
+# champion / mechanic / carry-augment 페이지가 staged 되면 wiki-ingest-verifier
+# subagent dispatch 를 강제하는 reminder gate (CLAUDE.md "TFT Domain Wiki Ingest 검증").
+#
+# 한계: git hook(별개 shell 프로세스)은 Claude Code 세션 내부의 subagent dispatch
+# 실행 여부를 직접 검증할 수 없다. 따라서 "verify 를 의식적으로 거쳤다는 명시적
+# 신호"(WIKI_VERIFIED env)가 없으면 차단하여 무의식적 누락(#175 사례)을 막는다.
+#
+# 통과:  dispatch + P0 fix 완료 후  →  WIKI_VERIFIED=1 git commit ...
+# 우회:  git commit --no-verify ...  (비권장 — dispatch 누락 재발 위험)
+# 상세:  docs/wiki/lint-rules.md
+# ──────────────────────────────────────────────────────────────
+
+staged=$(git diff --cached --name-only --diff-filter=ACM)
+
+# scope (CLAUDE.md dispatch 규칙과 동일):
+#   docs/wiki/champions/*.md        (모든 champion)
+#   docs/wiki/mechanics/*.md        (모든 mechanic)
+#   docs/wiki/augments/*-carry.md   (carry augment 만, 일반 augment 제외)
+matched=$(printf '%s\n' "$staged" | grep -E '^docs/wiki/(champions/[^/]+\.md|mechanics/[^/]+\.md|augments/[^/]+-carry\.md)$')
+
+# 대상 페이지 없음 → 통과
+[ -z "$matched" ] && exit 0
+
+# verify 신호 존재 → 통과
+if [ -n "$WIKI_VERIFIED" ]; then
+  echo "✅ wiki-ingest-verify gate: WIKI_VERIFIED 신호 확인 — 통과"
+  echo "   verified pages:"
+  printf '%s\n' "$matched" | sed 's/^/     - /'
+  exit 0
+fi
+
+# 신호 없음 → 차단
+{
+  echo "──────────────────────────────────────────────────────────────"
+  echo "🚫 wiki-ingest-verify gate — 커밋 차단"
+  echo ""
+  echo "다음 wiki 페이지가 staged 되어 있습니다 (champion / mechanic / carry-augment):"
+  printf '%s\n' "$matched" | sed 's/^/     - /'
+  echo ""
+  echo "CLAUDE.md 규칙: 이 페이지들은 commit 전 wiki-ingest-verifier subagent"
+  echo "dispatch 가 필수입니다. P0 finding 은 commit 전 반드시 fix."
+  echo ""
+  echo "  1) dispatch:"
+  echo "       Agent(subagent_type=\"wiki-ingest-verifier:wiki-ingest-verifier\")"
+  echo "  2) P0 finding fix 완료 후 통과:"
+  echo "       WIKI_VERIFIED=1 git commit ..."
+  echo ""
+  echo "  우회 (비권장 — dispatch 누락 #175 재발 위험):"
+  echo "       git commit --no-verify ..."
+  echo ""
+  echo "상세: docs/wiki/lint-rules.md"
+  echo "──────────────────────────────────────────────────────────────"
+} >&2
+exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -14,7 +14,9 @@
 # 상세:  docs/wiki/lint-rules.md
 # ──────────────────────────────────────────────────────────────
 
-staged=$(git diff --cached --name-only --diff-filter=ACM)
+# --diff-filter=ACMR: R(rename) 포함 — git mv 로 wiki 페이지 이동/도입 시 ACM 만으로는
+# 누락되어 gate 우회 가능 (PR #181 Codex P2). name-only 는 rename 시 destination 경로 출력.
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
 
 # scope (CLAUDE.md dispatch 규칙과 동일):
 #   docs/wiki/champions/*.md        (모든 champion)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,15 +222,26 @@ MVP에서 제외하는 것:
 ### Dispatch 호출 예시
 
 ```
-Agent (subagent_type=wiki-ingest-verifier) — dispatch with page paths
+Agent (subagent_type=wiki-ingest-verifier:wiki-ingest-verifier) — dispatch with page paths
 ```
+
+> ⚠️ subagent_type 은 **plugin namespaced 이름** `wiki-ingest-verifier:wiki-ingest-verifier` (PR #174 plugin install 후). 짧은 `wiki-ingest-verifier` 은 "Agent type not found" 에러.
 
 Subagent 는 read-only. P0/P1/P2 finding 을 tiered 로 반환하며, **P0 finding 은 commit 전 반드시 fix**. P1 은 본 PR 내 가능하면 fix, P2 는 다음 사이클 허용.
 
+### Pre-commit hook 강제 (`.githooks/pre-commit`)
+
+dispatch 누락(#175 사례)을 막기 위해 `.githooks/pre-commit` gate 가 champion / mechanic / carry-augment 페이지 staged 시 커밋을 **차단**한다.
+
+- **통과**: dispatch + P0 fix 완료 후 → `WIKI_VERIFIED=1 git commit ...`
+- **우회** (비권장 — dispatch 누락 재발 위험): `git commit --no-verify ...`
+- **설치**: `core.hooksPath .githooks` — clone+install 시 `prepare` script (`package.json`) 가 자동 설정
+- **한계**: git hook(별개 프로세스)은 subagent 실제 실행 여부를 검증 못 함 → `WIKI_VERIFIED` 신호로 "의식적 verify" 를 강제하는 **reminder gate** (무의식적 누락 방지, 마음먹은 우회는 불가능)
+
 ### Single source of truth
 
-- 룰셋: `docs/wiki/lint-rules.md` — 5단계 verify rule + entity-type checklist + 9건 lint history + Severity Tier 정의. 룰 진화 시 본 파일만 수정 (git diff 추적).
-- Subagent: `.claude/agents/wiki-ingest-verifier.md` — lint-rules.md 를 dispatch 첫 단계에서 Read 하여 룰 로드.
+- 룰셋: `docs/wiki/lint-rules.md` — 5단계 verify rule + entity-type checklist + lint history + Severity Tier 정의. 룰 진화 시 본 파일만 수정 (git diff 추적).
+- Subagent: `.claude/plugins/wiki-ingest-verifier/agents/wiki-ingest-verifier.md` (PR #174 plugin 패키징) — lint-rules.md 를 dispatch 첫 단계에서 Read 하여 룰 로드.
 - 메모리 `feedback_wiki_ingest_verify` (user-local) — main agent 작성 워크플로우 (positive verify). lint subagent (negative verify) 와 책임 분리.
 
 ### 평가

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:golden": "vitest run tests/golden"
+    "test:golden": "vitest run tests/golden",
+    "prepare": "git config core.hooksPath .githooks || true"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## 배경

6 PR 평가의 잔존 약점 ② (**머지 전 dispatch 누락** — PR #175 Aatrox 사례) 해소. champion / mechanic / carry-augment 페이지가 staged 되면 `wiki-ingest-verifier` dispatch 를 강제하는 pre-commit reminder gate.

## 본질적 한계 (정직한 설계)

git hook(별개 shell 프로세스)은 Claude Code 세션 내부의 **subagent dispatch 실행 여부를 직접 검증할 수 없다**. 따라서 "verify 를 의식적으로 거쳤다는 명시적 신호"(`WIKI_VERIFIED` env)가 없으면 차단하여 **무의식적 누락(#175)** 을 막는다. 마음먹은 우회(`--no-verify`)는 구조상 불가능 — 이것이 git hook 의 한계.

## `.githooks/pre-commit`

- staged 에 `docs/wiki/champions/*.md` + `mechanics/*.md` + `augments/*-carry.md` 감지 (CLAUDE.md dispatch scope 와 동일)
- `WIKI_VERIFIED` 신호 없으면 **차단 (exit 1)** + dispatch 안내 출력
- **통과**: dispatch + P0 fix 완료 후 → `WIKI_VERIFIED=1 git commit ...`
- **우회** (비권장): `git commit --no-verify ...`

## 설치 (git-tracked, npm 의존성 없음)

- `core.hooksPath .githooks` (로컬 설정 완료)
- `package.json` `prepare` script 로 clone+install 시 자동 설정
- `pre-commit` 실행권한 git mode **100755** 추적 (clone 시 권한 유지)

## CLAUDE.md

- "Pre-commit hook 강제" 섹션 추가
- dispatch 예시 → namespaced 이름 정정 (`wiki-ingest-verifier:wiki-ingest-verifier`, PR #174 plugin install 후 stale 이었음)
- subagent 경로 정정 (`.claude/plugins/wiki-ingest-verifier/agents/`, PR #174 plugin 패키징)

## 검증

| 케이스 | 결과 |
|--------|------|
| wiki 페이지 staged | 차단 (exit 1) ✅ |
| `WIKI_VERIFIED=1` | 통과 ✅ |
| wiki 무관 파일만 | 통과 ✅ |
| scope (carry augment 만, 일반 augment·lint-rules.md 제외) | ✅ |
| 본 PR 자체 (.githooks/package.json/CLAUDE.md) | hook 통과 → 정상 커밋 ✅ |

> 잔존 약점 2건 (외부 patch notes 의존 #20 / 머지 전 dispatch 누락) **모두 해소**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)