### PR TITLE
fix(sim): synergy scaling off-by-one — 도전자/전달자/구원자/불한당 첫 tier 0 적용 버그

### DIFF
--- a/public/data/tft_set17_scaling.json
+++ b/public/data/tft_set17_scaling.json
@@ -90,8 +90,8 @@
     "TFT17_ASTrait": {
       "name": "도전자",
       "desc": "아군 AS + 도전자 추가 AS, 대상 사망 시 버스트",
-      "teamwideAS": [0, 0.1, 0.15, 0.2, 0.3],
-      "championAS": [0, 0.2, 0.35, 0.55, 0.9],
+      "teamwideAS": [0.1, 0.15, 0.2, 0.3],
+      "championAS": [0.2, 0.35, 0.55, 0.9],
       "burstDuration": 3,
       "burstPercent": 0.5
     },
@@ -107,20 +107,20 @@
     "TFT17_ManaTrait": {
       "name": "전달자",
       "desc": "아군 마나 재생 + 전달자 추가",
-      "teamManaRegen": [0, 2, 4, 8, 15],
-      "channelerManaRegen": [0, 5, 10, 18, 30],
+      "teamManaRegen": [2, 4, 8, 15],
+      "channelerManaRegen": [5, 10, 18, 30],
       "innateManaGain": 0.15
     },
     "TFT17_RhaastUniqueTrait": {
       "name": "구원자",
       "desc": "활성 특성당 AS/방어력/마저",
-      "offensiveStat": [0, 0.03, 0.05, 0.08],
-      "defensiveStat": [0, 3, 5, 8]
+      "offensiveStat": [0.03, 0.05, 0.08],
+      "defensiveStat": [3, 5, 8]
     },
     "TFT17_AssassinTrait": {
       "name": "불한당",
       "desc": "AD/AP 획득, 체력 50% 이하 시 은신",
-      "adap": [0, 15, 30, 45, 60],
+      "adap": [15, 30, 45, 60],
       "healthThreshold": 0.5
     }
   }

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -449,7 +449,9 @@ function applySet17SynergyBuffs(traits: ActiveTrait[], units: CombatUnit[]): voi
     const sc = getSynergyScaling(at.trait.apiName);
     if (!sc) continue;
 
-    // 활성 티어 인덱스 (effects 배열에서 몇 번째)
+    // 활성 티어 인덱스 (effects 배열에서 몇 번째, 0-based)
+    // ⚠️ scaling.json synergies 배열은 effects 와 1:1 정렬 (idx 0 = 첫 tier). leading-0 금지.
+    //    (PR #185 발견: 도전자/전달자/구원자/불한당 배열에 leading inactive 0 있어 첫 tier 에 0 적용되던 off-by-one → scaling.json 데이터 수정으로 정렬)
     const tierIdx = at.trait.effects.findIndex(e => e === at.activeEffect);
     const ti = Math.max(0, tierIdx);
 

--- a/tests/unit/simulator/synergy-scaling-offbyone.test.ts
+++ b/tests/unit/simulator/synergy-scaling-offbyone.test.ts
@@ -1,0 +1,66 @@
+/**
+ * 회귀 가드 — synergy scaling 배열 off-by-one (PR #185 Codex catch).
+ *
+ * `applySet17SynergyBuffs` (combatLoop.ts) 는 활성 tier 를
+ *   `ti = trait.effects.findIndex(e => e === activeEffect)` (0-based)
+ * 로 구해 `scaling.json synergies[...][ti]` 를 인덱싱한다.
+ *
+ * 따라서 scaling.json synergies 배열은 raw effects 와 1:1 정렬 (idx 0 = 첫 활성 tier) 이어야 한다.
+ * leading inactive `0` 이 있으면 첫 tier 에서 0 이 적용되어 효과가 사라진다.
+ *
+ * 버그: 도전자/전달자/구원자/불한당 배열에 leading-0 이 있어
+ *   2도전자 AS 0 / 2전달자 마나재생 0 / 2불한당 ADAP 0 / 구원자 stat 0 으로 적용되던 것을
+ *   scaling.json leading-0 제거로 수정. 습격자(MeleeTrait)는 원래 정상 (leading-0 없음).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getSynergyScaling, setScalingData, type ScalingData } from '@/lib/simulator/systems/ability';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import scalingJson from '../../../public/data/tft_set17_scaling.json';
+
+const { traits } = loadServerCatalogs();
+
+beforeAll(() => {
+  setScalingData(scalingJson as unknown as ScalingData);
+});
+
+describe('synergy scaling off-by-one 회귀 가드 (PR #185)', () => {
+  it('도전자/전달자/구원자/불한당 첫 tier (idx 0) 효과 non-zero', () => {
+    const as = getSynergyScaling('TFT17_ASTrait')!;
+    expect((as.teamwideAS as number[])[0]).toBeGreaterThan(0);
+    expect((as.championAS as number[])[0]).toBeGreaterThan(0);
+
+    const mana = getSynergyScaling('TFT17_ManaTrait')!;
+    expect((mana.teamManaRegen as number[])[0]).toBeGreaterThan(0);
+    expect((mana.channelerManaRegen as number[])[0]).toBeGreaterThan(0);
+
+    const ass = getSynergyScaling('TFT17_AssassinTrait')!;
+    expect((ass.adap as number[])[0]).toBeGreaterThan(0);
+
+    const rha = getSynergyScaling('TFT17_RhaastUniqueTrait')!;
+    expect((rha.offensiveStat as number[])[0]).toBeGreaterThan(0);
+    expect((rha.defensiveStat as number[])[0]).toBeGreaterThan(0);
+  });
+
+  it('도전자 2도전자(ti=0) teamwideAS=0.1 / championAS=0.2 (raw 첫 tier 정합)', () => {
+    const as = getSynergyScaling('TFT17_ASTrait')!;
+    expect((as.teamwideAS as number[])[0]).toBeCloseTo(0.1, 3);
+    expect((as.championAS as number[])[0]).toBeCloseTo(0.2, 3);
+  });
+
+  it('tier breakpoint trait (도전자/전달자/불한당) 배열 길이 = effects 개수 (1:1 정렬)', () => {
+    for (const api of ['TFT17_ASTrait', 'TFT17_ManaTrait', 'TFT17_AssassinTrait']) {
+      const t = traits.find(x => x.apiName === api)!;
+      const sc = getSynergyScaling(api)!;
+      const arrFields = Object.keys(sc).filter(k => Array.isArray(sc[k]));
+      for (const f of arrFields) {
+        expect((sc[f] as number[]).length).toBe(t.effects.length);
+      }
+    }
+  });
+
+  it('습격자(MeleeTrait) 첫 tier 정상 유지 (회귀 가드 — 미수정 대상)', () => {
+    const melee = getSynergyScaling('TFT17_MeleeTrait')!;
+    expect((melee.championOmnivamp as number[])[0]).toBeCloseTo(0.05, 3);
+    expect((melee.championAD as number[])[0]).toBeCloseTo(0.2, 3);
+  });
+});


### PR DESCRIPTION
## 배경

champion 위키 ingest (Kindred PR #185) 중 Codex 가 catch 한 **실제 sim 버그**. 도전자 AS 만이 아니라 동일 원인으로 **4개 trait 공통** 영향.

## 원인

`applySet17SynergyBuffs` (`combatLoop.ts`) 는 활성 tier 를 `ti = trait.effects.findIndex(e => e === activeEffect)` (**0-based**) 로 구해 `scaling.json synergies[...][ti]` 를 인덱싱합니다.

그런데 4개 trait 의 scaling 배열에 **leading inactive `0`** 이 있어 첫 활성 tier 에서 0 이 적용됐습니다:

| trait | 2units 시 (현재 버그) | 의도 |
|-------|----------------------|------|
| 도전자(ASTrait) | teamwideAS/championAS **0** | 0.1 / 0.2 |
| 전달자(ManaTrait) | 마나재생 **0** | 2 / 5 |
| 불한당(AssassinTrait) | ADAP **0** | 15 |
| 구원자(Rhaast) | 활성특성당 stat **0** | 0.03 / 3 |

습격자(MeleeTrait)만 leading-0 없이 정상 동작 → **올바른 컨벤션은 0-based (idx 0 = 첫 tier)** = 코드 계약. 나머지 4개 데이터가 1-based 스타일로 잘못 작성된 것.

## 수정

- `scaling.json` synergies 4개 trait 배열에서 **leading-0 제거** → effects 와 1:1 정렬. 습격자 미변경. **코드 로직 변경 없음** (데이터 정렬 + 주석).
- `combatLoop.ts` 주석에 "scaling 배열 idx = effects idx (0-based), leading-0 금지" 명시 (재발 방지).

## 검증

- ✅ **회귀 가드 테스트 추가** (`synergy-scaling-offbyone.test.ts`) — 첫 tier non-zero + 배열 1:1 정렬 + 습격자 미영향 (leading-0 이면 fail)
- ✅ `pnpm lint && typecheck && build && test` 전부 통과 (907 passed, +4 신규)

Codex PR #185 P2 catch. 위키 `kindred.md` 에 Lint P2 로 등록됐던 도전자 off-by-one 항목 sim 해소.

🤖 Generated with [Claude Code](https://claude.com/claude-code)