### PR TITLE
docs(wiki): kindred.md 도전자 off-by-one Lint P2 → resolved cleanup (PR #186 반영)

### DIFF
--- a/docs/wiki/champions/kindred.md
+++ b/docs/wiki/champions/kindred.md
@@ -10,7 +10,7 @@ traits:
 role: Marksman   # raw "ADCarry" → mapGameRole() → sim Marksman (types/index.ts:43 includes('Carry')). carry augment 없음 → role 변환 분기 없음
 raw_role: ADCarry
 current_patch_status: active
-sim_active: partial   # active multi 화살(ADDamage scaleAD ★1=115/175/900) + 3표식 passive(SpellDamage) + N.O.V.A.(DRX) surge/Tank shield 800/selector +10% damageAmp/4.5초 주기 mark + 도전자(ASTrait) Burst 정합. P2 도전자 AS 인덱싱 off-by-one (applySet17SynergyBuffs findIndex 0-based vs scaling.json leading-0 → 2도전자 AS 0, 상위 한 칸씩 낮게, 도전자 전반 sim 버그). P2 passive 표식 평타만(desc "기본공격+스킬" 중 스킬 표식 미반영) / P2 passive mark 피해 SpellDamage flat (desc TotalDamage scaleAD+scaleAP — ad/ap scaling 미적용) / P2 active HexDistance(1) 도약 미구현 (기본 공격 AI 이동 위임) / info raw NovaDamageAmp 0.05·NovaRepeatTimer 5 미사용 (sim 17.4 하드코딩 0.10·4.5초, PR #166) / info NumTargets ★4=5 미반영 (★1-3=3, 4코 ★3까지)
+sim_active: partial   # active multi 화살(ADDamage scaleAD ★1=115/175/900) + 3표식 passive(SpellDamage) + N.O.V.A.(DRX) surge/Tank shield 800/selector +10% damageAmp/4.5초 주기 mark + 도전자(ASTrait) AS+Burst 정합 (AS off-by-one 은 PR #186 수정 완료 — scaling.json leading-0 제거). P2 passive 표식 평타만(desc "기본공격+스킬" 중 스킬 표식 미반영) / P2 passive mark 피해 SpellDamage flat (desc TotalDamage scaleAD+scaleAP — ad/ap scaling 미적용) / P2 active HexDistance(1) 도약 미구현 (기본 공격 AI 이동 위임) / info raw NovaDamageAmp 0.05·NovaRepeatTimer 5 미사용 (sim 17.4 하드코딩 0.10·4.5초, PR #166) / info NumTargets ★4=5 미반영 (★1-3=3, 4코 ★3까지)
 last_verified: 2026-06-04
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Kindred entry — cost 4, role ADCarry, traits [N.O.V.A./도전자], ability '우주의 추적' variables MaxMarks/NumTargets/SpellDamage/ADDamage/APDamage/HexDistance/NovaRepeatTimer/NovaDamageAmp)"
@@ -104,7 +104,7 @@ NOVA 공통 surge 메커니즘 (TeamAttackDelay 6초, setupDrxNova/tickDrxNova, 
 | **Tank shield** (surge 시) | ✅ | `hasKindred && kindredShield > 0` → 가장 강한 Tank (role Tank, maxHp 최고) 에 `kindredShield` (= DRX `ShieldValue` **800**) shield (`:4776-4787`, `setupDrxNova:4724`) |
 | **타격 선택기 +10% damageAmp** | ✅ | `kindredSelector` (aatroxNovaStrikeSelector flag) → `damageAmp += 0.10` (`:4884`). **17.4 buff 0.05→0.10** (PR #166, Codex P1 #162). raw `NovaDamageAmp` 0.05 는 미사용 (sim 하드코딩 0.10) |
 | **선택기 모든 적 표식 (즉시)** | ✅ | selector surge 시 모든 적 `mark` statusEffect (`kindred-nova-selector`, `:4885-4891`) |
-| **표식 4.5초 주기 갱신** | ✅ | `tickKindredNovaMark` (`:5221-5251`) — surge 후 `4.5초` 주기 모든 적 mark 재부여. **17.4 5s→4.5s** (PR #166). raw `NovaRepeatTimer` 5 미사용 (sim 하드코딩 4.5). ⚠️ 함수 상단 주석 (`:5218-5220`) 은 "5초" 라 stale — 코드 `:5229` 가 4.5초 ground truth |
+| **표식 4.5초 주기 갱신** | ✅ | `tickKindredNovaMark` (`:5223-5251`) — surge 후 `4.5초` 주기 모든 적 mark 재부여 (`:5231` `periodTicks = 4.5 × TICKS_PER_SECOND`). **17.4 5s→4.5s** (PR #166). raw `NovaRepeatTimer` 5 미사용 (sim 하드코딩 4.5) |
 
 > raw `NovaDamageAmp` 0.05 / `NovaRepeatTimer` 5 는 **base 값** — 17.4 패치가 코드에 0.10 / 4.5초로 하드코딩 (raw json 미반영). sim 은 17.4 LIVE 기준.
 
@@ -116,7 +116,7 @@ generic 도전자 통합 경로 (Kindred-specific 추가 분기 없음) — sim 
 
 | 효과 | sim 적용 | 근거 |
 |------|---------|------|
-| 아군 AS + 도전자 추가 AS | ⚠️ **인덱싱 off-by-one 버그** | `applySet17SynergyBuffs` (`:458-466`) — `sc.teamwideAS[ti]` + `sc.championAS[ti]`, `ti = effects.findIndex(activeEffect)` (**0-based**, `:453`). 그런데 `scaling.json` 배열은 leading inactive `0` 포함 5개 (teamwideAS [**0**,0.1,0.15,0.2,0.3] / championAS [**0**,0.2,0.35,0.55,0.9]). raw effects 는 [minUnits 2/3/4/5] **4개** → 2도전자 시 `ti=0` → `teamwideAS[0]=0` / `championAS[0]=0` → **AS 0 부여** (효과 없음), 3/4/5도전자도 한 칸씩 낮게 (ti=1/2/3 → scaling[1/2/3], 의도는 [2/3/4]). desc 의도값과 불일치. **Lint P2 — sim off-by-one (별도 fix 필요)** |
+| 아군 AS + 도전자 추가 AS | ✅ **정합 (PR #186 수정)** | `applySet17SynergyBuffs` (`:458-466`) — `sc.teamwideAS[ti]` + `sc.championAS[ti]`, `ti = effects.findIndex(activeEffect)` (**0-based**, `:453`). `scaling.json` teamwideAS [0.1,0.15,0.2,0.3] / championAS [0.2,0.35,0.55,0.9] (effects [minUnits 2/3/4/5] 와 **1:1 정렬**). 2도전자(ti=0)=0.1/0.2. **PR #186 전엔 leading inactive `0` 배열로 off-by-one (2도전자 AS 0, 상위 한 칸씩 낮게) 버그 → scaling.json leading-0 제거로 해소** (회귀 가드 `synergy-scaling-offbyone.test.ts`). Codex PR #185 catch |
 | Burst (대상 처치 후 재돌진 시 +50% AS) | ✅ | combat-start `:517-520` 도전자 unit `challengerBurstPercent = BurstPercent`(0.5) set → `challengerIds` 집합 (`:5541-5551`, **Burst dash 트리거 조건용 id 집합** — AS 적용 아님) → prev target 사망 후 새 대상 dash 시 `challengerBurstEndTick = tick + 2.5초` (`:5613`) → AS read `:3529-3530` `as *= (1 + challengerBurstPercent)`. ⚠️ burst duration 코드 하드코딩 **2.5초**, `scaling.json burstDuration: 3` 은 **dead config** (sim 미read, P2) |
 
 > champion-specific 구현(분기 추가)은 불필요하나 generic 경로 grep verify 는 매 champion 필수 (룰 #16/#19). **AS 적용 경로(`:458` applySet17SynergyBuffs)와 Burst 트리거 경로(`:5541` challengerIds)는 별개** — 혼동 금지. Kindred 는 도전자라 추가 AS (championAS) + Burst (새 대상 돌진 시 +50% AS, 2.5초) 수령. range 6 marksman 이라 대상 처치 후 재타겟 시 AS 폭발.
@@ -139,23 +139,21 @@ generic 도전자 통합 경로 (Kindred-specific 추가 분기 없음) — sim 
 - active multi 화살 — ADDamage scaleAD (★1=115/★2=175/★3=900), maxTargets 3
 - passive 3표식 늑대 — 평타 표식 누적 + SpellDamage (★1=75/★2=115/★3=600) physical
 - **N.O.V.A. (DRX)**: surge Tank shield 800 + selector +10% damageAmp (17.4 buff) + 모든 적 표식 즉시 + 4.5초 주기 갱신 (17.4)
-- **도전자 (ASTrait)** Burst (대상 처치 후 재돌진 시 +50% AS 2.5초) 정합
+- **도전자 (ASTrait)** — 아군 AS + 도전자 추가 AS (`applySet17SynergyBuffs`, 전 tier 정합, **PR #186 off-by-one 수정**) + Burst (대상 처치 후 재돌진 시 +50% AS 2.5초)
 
 ⚠️ **부정확 / 미반영** (Lint 후보):
-- **P2**: 도전자 AS **인덱싱 off-by-one** — `applySet17SynergyBuffs` `ti = findIndex(activeEffect)` (0-based) vs `scaling.json` leading-0 배열 → 2도전자 AS 0 (teamwideAS/championAS 모두 [0] = 0), 3/4/5도전자도 한 칸씩 낮게. 모든 도전자 보유 unit 공통 sim 버그 (별도 fix)
 - **P2**: passive 표식 평타만 (desc "기본공격+스킬" 중 active 스킬 표식 미반영)
 - **P2**: passive mark 피해 SpellDamage flat — desc `TotalDamage`(scaleAD+scaleAP) 인데 ad/ap scaling 미적용 (raw ADDamage/APDamage 미사용)
 - **P2**: active HexDistance(1) 도약 미구현 (기본 공격 AI 이동 위임)
 - (info): raw `NovaDamageAmp` 0.05 / `NovaRepeatTimer` 5 미사용 — sim 17.4 하드코딩 0.10 / 4.5초 (PR #166)
 - (info): active NumTargets ★4=5 미반영 (maxTargets 하드코딩 3, 4코 ★3까지 실전 무관)
-- (info): `tickKindredNovaMark` 상단 주석 (`:5218-5220`) "5초" stale — 코드 `:5229` 4.5초가 ground truth
 - (info): 도전자 raw trait vars `AttackSpeedPercent` (0.15~0.55) ≠ sim 적용 `championAS` (0.2~0.9, scaling.json) — sim 은 scaling.json 우선 / `scaling.json burstDuration: 3` 은 dead config — 코드 `:5614` 는 2.5초 하드코딩 (raw trait json `BurstDuration: 2.5` 와 일치, scaling.json 3 만 불일치, sim 미read)
 
 ## Lint 신규 등록 후보
 
 | # | 항목 | 의미 | Tier | 적용 분기 (룰 #17) | 처리 |
 |---|------|------|------|---------------------|------|
-| P2 | 도전자 AS 인덱싱 off-by-one | `applySet17SynergyBuffs:453` `ti = findIndex(activeEffect)` (0-based) vs `scaling.json` leading-0 배열 (teamwideAS/championAS 5개 `[0,...]`). raw effects 4개 [minUnits 2/3/4/5] → 2도전자 `ti=0` → `scaling[0]=0` → AS 0, 3/4/5도전자 한 칸씩 낮게 (의도 [2/3/4], 실제 [1/2/3]) | **P2** | (a) combat-start — `ti+1` 또는 scaling.json leading-0 제거. **모든 도전자 unit 공통** | sim off-by-one 버그 — Kindred-specific 아님 (도전자 trait 전반). 별도 sim fix PR. Codex PR #185 catch |
+| ✅ resolved | 도전자 AS 인덱싱 off-by-one | `applySet17SynergyBuffs:453` `ti = findIndex(activeEffect)` (0-based) vs `scaling.json` leading-0 배열 → 2도전자 `ti=0` → `scaling[0]=0` → AS 0, 3/4/5도전자 한 칸씩 낮게. **모든 도전자 unit 공통** (Kindred-specific 아님) | ~~P2~~ → ✅ | (a) scaling.json leading-0 제거 (effects 1:1 정렬) | **PR #186 수정 완료** — 도전자/전달자/구원자/불한당 4 trait leading-0 제거 + 회귀 가드 `synergy-scaling-offbyone.test.ts`. Codex PR #185 catch → #186 resolved |
 | P2 | passive 표식 평타만 (스킬 표식 미반영) | desc "기본공격+스킬이 표식" 인데 sim 은 평타 hook (`:6069`) 에서만 `_kindredMarks+1`. active multi 화살 (`ability.ts:238`) 경로에 mark 부여 없음 → 3표식 도달 속도 과소 | **P2** | (c) cast-time — active cast 후 hit target 에 `_kindredMarks+1` 추가 | active 빈도만큼 표식 누적 누락. 평타 위주라 영향 제한적. 측정 후 결정 |
 | P2 | passive mark 피해 SpellDamage flat | desc `TotalDamage`(scaleAD+scaleAP) vs sim `SpellDamage × (1+damageAmp)` flat (ad/ap scaling 없음, `:6077`). raw ADDamage/APDamage 미사용 | **P2** | (b) attack-hook — mark 피해에 ad/ap scaling 추가 (ADDamage scaleAD + APDamage scaleAP). 단 raw TotalDamage 산식 확인 필요 | scaling 누락으로 후반 under-damage 가능. raw 산식 verify 후 결정 |
 | P2 | active HexDistance(1) 도약 미구현 | 도약 reposition sim 부재 — 제자리 화살 (`ability.ts:238` 주석, 이동은 평타 AI 위임) | **P2** | (c) cast-time — dash/reposition 분기 | 1칸 도약이라 영향 작음. sim 이동 모델 단순화 의도 가능 |
@@ -173,9 +171,9 @@ generic 도전자 통합 경로 (Kindred-specific 추가 분기 없음) — sim 
 - [x] **변수 filler 판정** — SpellDamage `[0,75,115,600]` zero filler ★1=75 / ADDamage `[0,115,175,900]` zero filler ★1=115 / APDamage `[0,10,15,100]` zero filler ★1=10 / NumTargets `[3,3,3,5,5]` no-filler ★1-3=3 / MaxMarks·HexDistance·NovaRepeatTimer 상수
 - [x] **actual sim integration verify (5단계)** — active ADDamage `resolveAbilityDamage` read / passive SpellDamage `:6076` read / NOVA kindredShield `setupDrxNova:4724` → surge `:4781` read / selector damageAmp `:4884` read. **17.4 buff (0.10/4.5초) sim 하드코딩 vs raw json (0.05/5) 분리 확인** / **scaleAD/AP scaling: passive mark 는 SpellDamage flat (ad/ap 미적용) 확인 → P2**
 - [x] **cast path 3종 (PR #129 룰)** — main (multi 화살 ✅) / OOR (dash 없음 ➖) / recast (carry 없음 ➖). passive·NOVA mark/surge 별개 경로 명시
-- [x] **`traits` frontmatter 각 entry trait helper grep 전수 verify (룰 #16/#19)** — N.O.V.A. `TFT17_DRX` setupDrxNova/surge/selector ✅ ([[aatrox]] 공통) / 도전자 `TFT17_ASTrait`: AS 적용 `applySet17SynergyBuffs :458-466` ↔ Burst 트리거 `:5541` challengerIds 별개 경로 구분 + Burst (`:517` set → `:5613` endTick → `:3529` AS×1.5). **⚠️ AS 인덱싱 off-by-one 버그 검출** — `ti=findIndex` 0-based vs scaling.json leading-0 배열 → 2도전자 AS 0 (P2, Codex #185). 각 trait apiName grep + 통합 경로 본문 명시 + **scaling.json 배열 인덱싱 정합까지 verify** (단순 "값 존재 → 정합" 단정 금지 — 룰 #16 P1 2회 + Codex P2 학습)
+- [x] **`traits` frontmatter 각 entry trait helper grep 전수 verify (룰 #16/#19)** — N.O.V.A. `TFT17_DRX` setupDrxNova/surge/selector ✅ ([[aatrox]] 공통) / 도전자 `TFT17_ASTrait`: AS 적용 `applySet17SynergyBuffs :458-466` ↔ Burst 트리거 `:5541` challengerIds 별개 경로 구분 + Burst (`:517` set → `:5613` endTick → `:3529` AS×1.5). **AS 인덱싱 off-by-one 버그 검출 → PR #186 수정 완료** (scaling.json leading-0 제거 + 회귀 가드). 각 trait apiName grep + 통합 경로 본문 명시 + **scaling.json 배열 인덱싱 정합까지 verify** (단순 "값 존재 → 정합" 단정 금지 — 룰 #16 P1 2회 + Codex P2 학습)
 - [x] **본문 Lint P2 3건 + info 등록 → frontmatter `sim_active: partial` 강등** (룰 #15)
-- [x] **함수 주석 stale 확인** — `tickKindredNovaMark` 상단 주석 "5초" vs 코드 `:5229` 4.5초 → 코드 ground truth (4.5초) 기준 작성 (함수 주석 ≠ 코드, PR #184 학습 적용)
+- [x] **함수 주석 stale 확인 + 교정** — `tickKindredNovaMark` 상단 주석이 "5초" stale 이었으나 (코드 `:5231` 4.5초) **본 cleanup 에서 코드 주석 4.5초로 교정 완료** (함수 주석 ≠ 코드, PR #184 학습 적용)
 - [ ] (선택) passive 스킬 표식 / mark scaleAD·AP scaling / active 도약 sim 도입 인게임 측정
 
 ## 관련

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -5217,9 +5217,9 @@ export function simulateCombat(
     tickDrxNova(playerDrxState, tick, time);
     tickDrxNova(enemyDrxState, tick, time);
 
-    // PR7-C.5 (17.2b): Kindred N.O.V.A. 선택기 — surge 후 5초 주기로 모든 적 표식 갱신.
-    // 사용자 spec: surge (6초) → 5초 주기 (11초, 16초, ...) 로 모든 적 표식 부여.
-    // 표식은 statusEffect 'mark' (영구). 5초 주기 = 5 × TICKS_PER_SECOND.
+    // PR7-C.5 (17.2b): Kindred N.O.V.A. 선택기 — surge 후 4.5초 주기로 모든 적 표식 갱신.
+    // 사용자 spec: surge (6초) → 4.5초 주기 (10.5초, 15초, ...) 로 모든 적 표식 부여 (17.4: 5s→4.5s, PR #166).
+    // 표식은 statusEffect 'mark' (영구). 4.5초 주기 = 4.5 × TICKS_PER_SECOND (아래 periodTicks).
     const tickKindredNovaMark = (
       drxState: ReturnType<typeof setupDrxNova>,
       teamUnits: CombatUnit[],


### PR DESCRIPTION
## 요약

PR #186 (synergy scaling off-by-one sim 수정) 머지 후, `kindred.md` 의 도전자 AS off-by-one Lint P2 항목을 **✅ resolved** 로 cleanup.

## 변경

- **도전자 AS 표기**: ⚠️ off-by-one 버그 → **✅ 정합 (PR #186 수정)**. scaling.json `teamwideAS [0.1,0.15,0.2,0.3]` / `championAS [0.2,0.35,0.55,0.9]` (leading-0 제거, effects 1:1 정렬). 2도전자(ti=0)=0.1/0.2
- sim 적용 상태: 도전자 AS ✅ 활성 이동, ⚠️ P2 목록에서 off-by-one 제거
- Lint 후보 표: 도전자 off-by-one 행 → **✅ resolved (PR #186)**, 이력 추적 유지
- frontmatter / 체크리스트 갱신

## 추가 (직전 lint P1-1 반영)

- `combatLoop.ts:5220-5222` `tickKindredNovaMark` 주석 **"5초" stale → "4.5초" 교정** (코드 `:5231` `4.5 × TICKS_PER_SECOND` 와 정합, 17.4 PR #166). 위키의 "주석 5초 stale" 언급 3곳 갱신.

## 검증

- ✅ wiki-ingest-verifier 재검증 **P0/P1/P2 0 (clean)** — 도전자 off-by-one resolved 표기가 현재 scaling.json (leading-0 제거됨) 과 정합 확인
- ✅ `lint && typecheck && build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)