### PR TITLE
fix(sim): 마오카이 passive maxHp +50% (PassiveRatio) 미반영 수정

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -2034,6 +2034,26 @@ function applyBrawlerEffects(activeTraits: ActiveTrait[], units: CombatUnit[]): 
 }
 
 /**
+ * 마오카이 (TFT17_Maokai) passive "교차의 마수" — 모든 요소로부터 maxHp +PassiveRatio(50%).
+ *
+ * raw: PassiveRatio=0.5 (전 star 동일). desc "모든 요소로부터 최대 체력을 50% 더" →
+ * item/trait(싸움꾼 등) maxHp 적용 후 최종 ×1.5. Astronaut(flat) + Brawler(×) 이후,
+ * Stargazer(Huntress) maxHp 기준 mark 선택 전에 적용 (호출 순서 — combat-start).
+ * Note: maxHp 증폭 시 currentHp 비례 (전투 시작 풀체). applyBrawlerEffects 와 동일 패턴 (round 없음).
+ */
+function applyMaokaiPassive(units: CombatUnit[]): void {
+  for (const u of units) {
+    if (u.champion.apiName !== 'TFT17_Maokai') continue;
+    const ratio = readVarByStar(
+      u.champion.ability.variables?.find(v => v.name === 'PassiveRatio')?.value, u.starLevel, 0.5
+    );
+    if (ratio <= 0) continue;
+    u.maxHp *= (1 + ratio);
+    u.currentHp *= (1 + ratio);
+  }
+}
+
+/**
  * 암흑의 별 (DarkStar) — tier 별 효과:
  *
  * Spec (TFT17_DarkStar) 17.2 raw (모든 tier 동일 변수):
@@ -4603,6 +4623,10 @@ export function simulateCombat(
   // 정령족+싸움꾼 동시 보유 챔프 없어 corner case 영향 없음.
   applyBrawlerEffects(playerActiveTraits, playerUnits);
   applyBrawlerEffects(enemyActiveTraits, enemies);
+  // 마오카이 passive maxHp +50% — 모든 요소(item/Astronaut/Brawler 등) 적용 후 ×1.5.
+  // Stargazer(Huntress) maxHp 상위 N명 mark 선택 전에 적용해야 정확 (Brawler 와 동일 이유).
+  applyMaokaiPassive(playerUnits);
+  applyMaokaiPassive(enemies);
   applyStargazerEffects(playerActiveTraits, playerUnits, enemies, options.playerStargazerConstellation, true);
   applyStargazerEffects(enemyActiveTraits, enemies, playerUnits, options.enemyStargazerConstellation, false);
   applyMorganaDarklight(playerActiveTraits, playerUnits);

--- a/tests/unit/simulator/maokai-passive-maxhp.test.ts
+++ b/tests/unit/simulator/maokai-passive-maxhp.test.ts
@@ -1,0 +1,57 @@
+/**
+ * 회귀 가드 — 마오카이 passive maxHp +50% (PassiveRatio 0.5).
+ *
+ * desc "모든 요소로부터 최대 체력을 50% 더 얻습니다" — applyMaokaiPassive 가 combat-start 에
+ * maxHp × 1.5 적용 (Brawler/Astronaut maxHp 이후, Stargazer mark 선택 전).
+ *
+ * 버그: PassiveRatio sim 미반영 (grep 0) 이던 것을 applyMaokaiPassive 로 구현.
+ * Maokai ingest (PR #189) lint P1 발견.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+
+function findChamp(apiName: string): RawChampion | undefined {
+  return champions.find(c => c.apiName === apiName);
+}
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 1): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: [] };
+}
+
+describe('마오카이 passive maxHp +50% (PR #189 lint P1 fix)', () => {
+  it('Maokai ★1 단독 (싸움꾼 비활성) maxHp = base hp × 1.5', () => {
+    const maokai = findChamp('TFT17_Maokai');
+    const enemy = findChamp('TFT17_Aatrox'); // 임의 적 (싸움꾼 아님)
+    if (!maokai || !enemy) return;
+    const baseHp = maokai.stats.hp; // raw 1100 (★1 base)
+    const team: PlacedChampion[] = [placed(maokai, 0, 0, 1)];
+    const enemyTeam: PlacedChampion[] = [placed(enemy, 6, 3, 1)];
+    const result = simulateCombat(team, enemyTeam, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const m = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Maokai');
+    expect(m).toBeDefined();
+    // 단독이라 싸움꾼(minUnits 2)/teamwideBonus 비활성 → passive ×1.5 만 적용
+    expect(m!.maxHp).toBeCloseTo(baseHp * 1.5, 0);
+  });
+
+  it('Maokai 가 아닌 챔프는 passive maxHp 증폭 없음 (회귀 가드)', () => {
+    const aatrox = findChamp('TFT17_Aatrox');
+    const enemy = findChamp('TFT17_Maokai');
+    if (!aatrox || !enemy) return;
+    const baseHp = aatrox.stats.hp;
+    const team: PlacedChampion[] = [placed(aatrox, 0, 0, 1)];
+    const enemyTeam: PlacedChampion[] = [placed(enemy, 6, 3, 1)];
+    const result = simulateCombat(team, enemyTeam, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const a = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Aatrox');
+    expect(a).toBeDefined();
+    // Aatrox 단독, 요새/NOVA 단독 비활성 → maxHp = base (passive 증폭 없음)
+    expect(a!.maxHp).toBeCloseTo(baseHp, 0);
+  });
+});


### PR DESCRIPTION
## 배경

champion 위키 ingest (Maokai PR #189) lint 에서 발견한 **실제 sim 버그** — Maokai 탱커 핵심 패시브가 sim 에 전혀 없었음.

## 원인

Maokai passive "교차의 마수": desc "모든 요소로부터 최대 체력을 50% 더 얻습니다" (`PassiveRatio` 0.5).
`grep -rn "PassiveRatio" src/` → **0 hit**. maxHp 1.5배 생존 패시브 sim 부재 → Maokai 생존력 과소.

## 수정

- `applyMaokaiPassive` helper 추가 — combat-start 에 Maokai unit `maxHp/currentHp × (1 + PassiveRatio)`.
- **호출 순서**: Astronaut(flat) + Brawler(×) 이후, Stargazer(Huntress) maxHp 기준 mark 선택 **전** (applyBrawlerEffects 와 동일 이유 — "모든 요소" 적용 후 ×1.5). `round` 없음 (Brawler 패턴 일관).

## 검증

- ✅ **회귀 가드 테스트 추가** (`maokai-passive-maxhp.test.ts`) — Maokai ★1 단독 `maxHp = base × 1.5` / 타 챔프 미영향 (passive grep 0 이던 것을 검증)
- ✅ `pnpm lint && typecheck && build && test` 전부 통과 (909 passed, +2)

Maokai ingest PR #189 lint **P1** 발견. 위키 `maokai.md` 에 P1 로 등록됐던 항목 sim 해소.

> 잔여: Maokai selector stun ★3 off-by-one (P2) 는 별도 — 의도(NOVA stun 강화) 가능성 있어 패치노트 확인 후 결정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)