### PR TITLE
docs(wiki): maokai.md passive maxHp Lint P1 → resolved cleanup (PR #190 반영)

### DIFF
--- a/docs/wiki/champions/maokai.md
+++ b/docs/wiki/champions/maokai.md
@@ -10,7 +10,7 @@ traits:
 role: Tank   # raw "APTank" → mapGameRole() → sim Tank (types/index.ts:41 includes('Tank')). carry augment 없음 → role 변환 분기 없음
 raw_role: APTank
 current_patch_status: active
-sim_active: partial   # active X덩굴 aoe_circle Damage(scaleAP magic ★1=100/100/150) + stun 1.5 + N.O.V.A.(DRX) surge heal(maokaiHealPct 0.12)/selector 광역 stun[1.5,1.5,1.75] + 싸움꾼(applyBrawlerEffects maxHp) 정합. P1 passive maxHp +50%(PassiveRatio 0.5) 미반영 (grep 0 — 탱커 핵심 패시브 부재) / P2 NOVA 타격 기본공격 추가 물리(NovaHealthDamage 0.08 scaleHealth) 미반영 (selector stun 만) / info active stun starLevel ★4/5(1.75/2) 미반영 (config 고정 1.5, 3코 ★1-3=1.5 동일 무관)
+sim_active: partial   # active X덩굴 aoe_circle Damage(scaleAP magic ★1=100/100/150) + stun 1.5 + N.O.V.A.(DRX) surge heal(maokaiHealPct 0.12)/selector 광역 stun + 싸움꾼(applyBrawlerEffects maxHp) + passive maxHp +50%(applyMaokaiPassive PR #190) 정합. P2 selector stun ★3=1.75 vs raw NovaStunDuration ★3=1.5 off-by-one (코드가 raw ★4 값을 ★3에) / P2 NOVA 타격 기본공격 추가 물리(NovaHealthDamage 0.08 scaleHealth) 미반영 / info active stun starLevel ★4/5(1.75/2) 미반영 (config 고정 1.5, 3코 ★1-3=1.5 동일 무관)
 last_verified: 2026-06-05
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Maokai entry — cost 3, role APTank, traits [N.O.V.A./싸움꾼], ability '교차의 마수' variables PassiveRatio/Damage/StunDuration/NovaStunDuration/NovaHealthDamage)"
@@ -19,8 +19,8 @@ sources:
   - "src/lib/simulator/systems/mana.ts:23 (Tank manaPerAttack 5 / manaPerSecond 0 / manaFromDamage true)"
   - "src/lib/simulator/systems/ability.ts:225 (TFT17_Maokai: { pattern: 'aoe_circle', radius: 2, stun: 1.5 })"
   - "src/lib/simulator/systems/ability.ts:371-375 (detectDamageType — desc '마법 피해' → magic) / :390 DAMAGE_VAR_PRIORITY first 'Damage' (Maokai Damage var 선택)"
-  - "src/lib/simulator/engine/combatLoop.ts:4770-4774 (N.O.V.A. surge — hasMaokai → 모든 아군 maxHp × maokaiHealPct(Heal 0.12) × (1+healAmp) 회복)"
-  - "src/lib/simulator/engine/combatLoop.ts:4796-4816 (Maokai selector — surge 시 모든 적 광역 stun [1.5,1.5,1.75] starLevel별)"
+  - "src/lib/simulator/engine/combatLoop.ts:4794-4799 (N.O.V.A. surge — hasMaokai → 모든 아군 maxHp × maokaiHealPct(Heal 0.12) × (1+healAmp) 회복)"
+  - "src/lib/simulator/engine/combatLoop.ts:4819-4835 (Maokai selector — surge 시 모든 적 광역 stun [1.5,1.5,1.75] starLevel별)"
   - "src/lib/simulator/engine/combatLoop.ts:2011-2022 (applyBrawlerEffects — 싸움꾼 maxHp × multiplier, unitHasTrait '싸움꾼')"
 related:
   - "[[role-passive]]"
@@ -70,7 +70,7 @@ raw desc: "모든 요소로부터 최대 체력을 `@PassiveRatio*100@`%(50%) �
 
 | 요소 | sim 적용 | 근거 |
 |------|---------|------|
-| maxHp +50% (PassiveRatio 0.5) | ❌ **미반영** | `PassiveRatio` repo-wide grep **0 hit**. maxHp 증폭 passive sim 부재 — Maokai 탱커 핵심 패시브 (체력 1.5배) 미적용. **Lint P1** (큰 생존 효과) |
+| maxHp +50% (PassiveRatio 0.5) | ✅ **적용 (PR #190)** | `applyMaokaiPassive` (`combatLoop.ts:2044`) — combat-start 에 Maokai unit `maxHp/currentHp × (1 + PassiveRatio)`. "모든 요소로부터" → item/Astronaut(flat)/Brawler(×) 적용 후 ×1.5 (호출 `:4628`, Stargazer mark 선택 전). 회귀 가드 `maokai-passive-maxhp.test.ts`. **PR #190 전엔 grep 0 미반영 (Lint P1) → 해소** |
 
 ### Active — 교차의 마수 (`ability.ts:225`)
 
@@ -95,8 +95,8 @@ NOVA 공통 surge (TeamAttackDelay 6초, setupDrxNova/tickDrxNova, autoAssignNov
 
 | 효과 | sim 적용 | 근거 |
 |------|---------|------|
-| **surge teamwide heal** | ✅ | `hasMaokai && maokaiHealPct > 0` → 모든 아군 `maxHp × maokaiHealPct(DRX Heal 0.12) × (1+healAmp)` 회복 (`:4770-4774`) |
-| **selector 광역 stun** | ⚠️ **코드 ★3 불일치** | `maokaiSelector` (aatroxNovaStrikeSelector) → surge 시 모든 적 `stun` `maokaiStunArr [1.5,1.5,1.75]` (`:4802`, starLevel별). ★1/★2=1.5 정합. ⚠️ **코드 ★3=1.75 vs raw `NovaStunDuration` ★3=1.5 불일치** (코드가 raw ★4 값 1.75 를 ★3 에 사용 — 잠재 off-by-one, 3코 ★3 시 0.25초 과다). **Lint P2** |
+| **surge teamwide heal** | ✅ | `hasMaokai && maokaiHealPct > 0` → 모든 아군 `maxHp × maokaiHealPct(DRX Heal 0.12) × (1+healAmp)` 회복 (`:4794-4799`) |
+| **selector 광역 stun** | ⚠️ **코드 ★3 불일치** | `maokaiSelector` (aatroxNovaStrikeSelector) → surge 시 모든 적 `stun` `maokaiStunArr [1.5,1.5,1.75]` (`:4826`, starLevel별). ★1/★2=1.5 정합. ⚠️ **코드 ★3=1.75 vs raw `NovaStunDuration` ★3=1.5 불일치** (코드가 raw ★4 값 1.75 를 ★3 에 사용 — 잠재 off-by-one, 3코 ★3 시 0.25초 과다). **Lint P2** |
 | **NOVA 타격 기본공격 추가 물리** (`NovaHealthDamage` 0.08 scaleHealth) | ❌ **미반영** | `NovaHealthDamage` repo-wide grep **0 hit**. desc "전투 끝까지 기본 공격이 ModifiedNovaDamage(scaleHealth) 추가 물리" — selector 시 기본공격 강화 sim 부재 (광역 stun 만 반영). **Lint P2** |
 
 ### 싸움꾼 (Brawler) trait
@@ -111,7 +111,7 @@ NOVA 공통 surge (TeamAttackDelay 6초, setupDrxNova/tickDrxNova, autoAssignNov
 | **OOR (out-of-range dash)** | ✅ stun config 동일 (`config.stun` 1.5 고정 — starLevel 비대칭 없음, Leona Lint #9 회귀 무관). Maokai range 1 melee 라 OOR dash 가능하나 stun 값 동일 | cast loop OOR 분기 |
 | **recast (onKill)** | ➖ 없음 — carry augment 전용. Maokai carry augment 없음 | — |
 
-> **NOVA surge/selector** (`:4770`/`:4796`) 와 **passive maxHp** (미반영) 는 cast pipeline 과 별개 (surge 시점 / 전투 시작). 싸움꾼 maxHp 도 combat-start.
+> **NOVA surge/selector** (`:4794`/`:4819`) 와 **passive maxHp** (`applyMaokaiPassive` PR #190) 는 cast pipeline 과 별개 (surge 시점 / 전투 시작). 싸움꾼 maxHp 도 combat-start.
 
 ## sim 적용 상태 — `partial`
 
@@ -121,9 +121,9 @@ NOVA 공통 surge (TeamAttackDelay 6초, setupDrxNova/tickDrxNova, autoAssignNov
 - active X덩굴 aoe_circle radius 2 + Damage(scaleAP magic, ★1=100/★2=100/★3=150) + stun 1.5 (★1-3 정합)
 - **N.O.V.A. (DRX)**: surge teamwide heal (maokaiHealPct 0.12) + selector 광역 stun [1.5,1.5,1.75]
 - **싸움꾼 (Brawler)** maxHp 증폭 (`applyBrawlerEffects`)
+- **passive maxHp +50%** (`PassiveRatio` 0.5) — `applyMaokaiPassive` combat-start ×1.5 (**PR #190 수정**)
 
 ⚠️ **부정확 / 미반영** (Lint 후보):
-- **P1**: passive maxHp +50% (`PassiveRatio` 0.5) 미반영 — grep 0, 탱커 핵심 생존 패시브 (체력 1.5배) 부재
 - **P2**: selector 광역 stun `maokaiStunArr` 코드 ★3=1.75 vs raw `NovaStunDuration` ★3=1.5 불일치 (코드가 raw ★4 값을 ★3 에 사용 — 잠재 off-by-one, 3코 ★3 selector stun 0.25초 과다)
 - **P2**: NOVA 타격 기본공격 추가 물리 (`NovaHealthDamage` 0.08 scaleHealth) 미반영 — selector stun 만, 기본공격 강화 부재
 - (info): active stun starLevel ★4/5 (1.75/2) 미반영 — config 고정 1.5, 3코 ★1-3=1.5 동일이라 실전 무관
@@ -132,12 +132,12 @@ NOVA 공통 surge (TeamAttackDelay 6초, setupDrxNova/tickDrxNova, autoAssignNov
 
 | # | 항목 | 의미 | Tier | 적용 분기 (룰 #17) | 처리 |
 |---|------|------|------|---------------------|------|
-| P1 | passive maxHp +50% 미반영 | desc "모든 요소 최대 체력 +50%" — `PassiveRatio` 0.5 grep 0. Maokai 탱커 핵심 패시브 (maxHp 1.5배) sim 부재 → 생존력 과소 | **P1** | (a) combat-start — createCombatUnit/calculateStats 에 PassiveRatio maxHp 증폭 적용 (싸움꾼 multiplier 와 유사 위치) | maxHp 1.5배는 큰 효과 (탱커 핵심). 우선 fix 권장 |
-| P2 | selector stun ★3 코드/raw 불일치 | `maokaiStunArr [1.5,1.5,1.75]` (`:4802`) ★3=1.75 vs raw `NovaStunDuration` ★3=1.5. 코드가 raw ★4 값(1.75)을 ★3 에 사용 — 잠재 off-by-one (3코 ★3 selector stun 0.25초 과다) | **P2** | (a) surge-time — `maokaiStunArr` 를 raw `NovaStunDuration` read 로 전환 (★3=1.5 정합). 또는 의도 확인 | ★1/★2=1.5 정합. ★3 만 0.25초 차이. 의도(NOVA stun 강화) 가능성 — 인게임/패치노트 확인 후 결정 |
+| ✅ resolved | passive maxHp +50% 미반영 | desc "모든 요소 최대 체력 +50%" — `PassiveRatio` 0.5 grep 0 이던 것 (maxHp 1.5배 탱커 핵심 패시브 부재) | ~~P1~~ → ✅ | (a) combat-start — `applyMaokaiPassive` maxHp ×(1+PassiveRatio) | **PR #190 수정 완료** (`applyMaokaiPassive` `:2044`, 호출 `:4628` Brawler 이후/Stargazer mark 전 + 회귀 가드 `maokai-passive-maxhp.test.ts`). Codex Maokai #189 P1 |
+| P2 | selector stun ★3 코드/raw 불일치 | `maokaiStunArr [1.5,1.5,1.75]` (`:4826`) ★3=1.75 vs raw `NovaStunDuration` ★3=1.5. 코드가 raw ★4 값(1.75)을 ★3 에 사용 — 잠재 off-by-one (3코 ★3 selector stun 0.25초 과다) | **P2** | (a) surge-time — `maokaiStunArr` 를 raw `NovaStunDuration` read 로 전환 (★3=1.5 정합). 또는 의도 확인 | ★1/★2=1.5 정합. ★3 만 0.25초 차이. 의도(NOVA stun 강화) 가능성 — 인게임/패치노트 확인 후 결정 |
 | P2 | NOVA 타격 기본공격 추가 물리 미반영 | desc "전투 끝까지 기본공격 NovaHealthDamage(0.08 scaleHealth) 추가 물리" — selector 시 기본공격 강화. grep 0 | **P2** | (b) attack-hook — selector Maokai 평타에 maxHp × 0.08 추가 물리 (akali 단검 burn 패턴 유사) | selector 시점만. 광역 stun 은 반영됨. 기본공격 강화만 gap |
 | info | active stun starLevel ★4/5 미반영 | sim `config.stun` 고정 1.5 vs raw StunDuration ★4=1.75/★5=2. 단 3코 ★1-3=1.5 동일 | info | cast-time — starLevel별 stun (Leona Lint #9 패턴) | 3코 ★3까지 1.5 동일이라 실전 무관. 명시만 |
 
-> 📌 **active X덩굴 + N.O.V.A. surge heal/selector stun + 싸움꾼 maxHp 는 sim 정합**. `partial` 핵심 사유는 **passive maxHp +50% 미반영 (P1, 탱커 생존 핵심)**. NOVA 공통은 [[aatrox]] 와 동일 코드 path.
+> 📌 **active X덩굴 + N.O.V.A. surge heal/selector stun + 싸움꾼 maxHp + passive maxHp +50%(PR #190) 는 sim 정합**. `partial` 잔여 사유는 P2 (selector stun ★3 off-by-one / NOVA 타격 기본공격 추가 미반영). NOVA 공통은 [[aatrox]] 와 동일 코드 path.
 
 ## Lint 체크리스트
 
@@ -145,14 +145,14 @@ NOVA 공통 surge (TeamAttackDelay 6초, setupDrxNova/tickDrxNova, autoAssignNov
 - [x] entity-wide grep `Maokai` + `마오카이` + `maokai` — sim site (active config / NOVA surge heal·selector stun / 싸움꾼 / passive·NovaHealthDamage grep 0)
 - [x] raw stats 17.4 정합 (hp 1100 / armor·MR 40 / AD 60 / AS 0.6 / mana 30·100 / range 1)
 - [x] **raw role `APTank` → mapGameRole → Tank** — `includes('Tank')` (`types/index.ts:41`). carry augment 없음
-- [x] **함수 컨텍스트 read (2단계)** — surge heal (`:4770-4774`) + Maokai selector stun (`:4796-4816`) + `applyBrawlerEffects` (`:2011-2022`) 전체 read. passive/NovaHealthDamage 는 grep 0 확인
+- [x] **함수 컨텍스트 read (2단계)** — surge heal (`:4794-4799`) + Maokai selector stun (`:4819-4835`) + `applyBrawlerEffects` (`:2011-2022`) 전체 read. passive/NovaHealthDamage 는 grep 0 확인
 - [x] **변수 filler 판정** — Damage `[100,100,150,225,300]` no-filler (v0=v1=100) → ★1=100/★2=100/★3=150 / StunDuration `[1.5,1.5,1.5,1.75,2]` ★1-3=1.5 / PassiveRatio·NovaHealthDamage 상수
-- [x] **actual sim integration verify (5단계)** — active Damage 'Damage' auto-detect read 확인 / **`PassiveRatio` grep 0 → maxHp passive 미반영 (P1)** / **`NovaHealthDamage` grep 0 → NOVA 기본공격 추가 미반영 (P2)** / surge heal maokaiHealPct(`:4725` Heal) read. 효과 주장 전 read site 검증
+- [x] **actual sim integration verify (5단계)** — active Damage 'Damage' auto-detect read 확인 / **`PassiveRatio` → `applyMaokaiPassive` (`:2044`) read (PR #190 수정, 이전 grep 0 P1 해소)** / **`NovaHealthDamage` grep 0 → NOVA 기본공격 추가 미반영 (P2)** / surge heal maokaiHealPct(`:4725` Heal) read. 효과 주장 전 read site 검증
 - [x] **cast path 3종 (PR #129 룰)** — main (aoe_circle stun ✅) / OOR (config.stun 1.5 고정 동일 ✅) / recast (carry 없음 ➖). stun starLevel 비대칭 없음 (1.5 고정)
 - [x] **`traits` frontmatter 각 entry trait helper grep 전수 verify (룰 #16/#19)** — N.O.V.A. `TFT17_DRX` surge heal/selector stun ✅ ([[aatrox]] 공통) / 싸움꾼 `TFT17_HPTank` `applyBrawlerEffects` (`:2011-2022`, `unitHasTrait '싸움꾼'` :2021 `apiName === 'TFT17_HPTank'`) maxHp 증폭 ✅. 싸움꾼은 scaling.json synergies 아닌 별도 helper (PR #186 off-by-one 무관)
 - [x] **재발 패턴 적용** — ① role canonical APTank→Tank ② Damage scaleAP magic (scaleArmor 아님) / **NovaHealthDamage scaleHealth 미반영 P2** ③ spell crit: Maokai active magic 은 cast loop crit 분기 가능 (운명술사/Akali Precision 시), 자체 부여 없음 ④ 함수 본문 read (surge/selector/brawler) + passive/Nova grep 0 ⑤ trait 경로 (싸움꾼 별도 helper)
-- [x] **본문 Lint P1 1건 + P2 1건 등록 → frontmatter `sim_active: partial` 강등** (룰 #15)
-- [ ] (선택) passive maxHp +50% / NovaHealthDamage 기본공격 추가 sim 도입 (P1 우선)
+- [x] **본문 Lint 등록 → frontmatter `sim_active: partial` 강등** (룰 #15) — P1 passive maxHp 는 PR #190 수정 완료 (✅ resolved), 잔여 P2 (selector stun off-by-one / NovaHealthDamage)
+- [ ] (선택) NovaHealthDamage 기본공격 추가 / selector stun ★3 off-by-one sim 도입 (P2)
 
 ## 관련
 


### PR DESCRIPTION
## 요약

PR #190 (Maokai passive maxHp +50% sim 수정) 머지 후, `maokai.md` 의 passive maxHp Lint P1 을 **✅ resolved** 로 cleanup.

## 변경

- **Passive 섹션**: ❌ 미반영 → **✅ 적용 (PR #190)**. `applyMaokaiPassive` (`:2044`, 호출 `:4628` Brawler 이후/Stargazer mark 전), 회귀 가드 `maokai-passive-maxhp.test.ts`
- sim 적용 상태: passive maxHp ✅ 활성 이동, ⚠️ P1 제거
- Lint 후보 표: passive maxHp P1 → **✅ resolved** (이력 유지)
- frontmatter/체크리스트/요약 박스 갱신 (+ frontmatter 누락됐던 selector stun P2 정합)

## 추가 (line drift 정정)

PR #190 코드 삽입(`applyMaokaiPassive` ~20줄)으로 그 아래 line 이 밀려, maokai.md 의 인용 정정:
- surge heal `:4770` → `:4794` / selector stun `:4796` → `:4819` / maokaiStunArr `:4802` → `:4826`

## 검증

- ✅ wiki-ingest-verifier 재검증 — passive maxHp resolved 표기가 현재 코드(`applyMaokaiPassive :2044`, 호출 `:4628`)와 정합. line drift 본 커밋에서 정정.

> 잔여 P2: selector stun ★3 off-by-one (의도 가능성, 패치노트 확인 후 결정) / NovaHealthDamage 기본공격 추가 물리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)