### PR TITLE
fix(sim): 그라가스 base heal (HEALING + HealingPercentHealth) 미반영 수정 (Gragas #201 발견)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -7029,7 +7029,7 @@ export function simulateCombat(
               // PR98: Illaoi 의 HealthDrain (drain × NumEnemies) 도 self-heal 로 인식.
               // Illaoi ability '영혼의 시험': 가까운 NumEnemies 명에게서 HealthDrain 흡수.
               // 단순화 — 실제 메커닉은 3s 동안 drain over time, sim 은 cast 순간 lump-sum heal.
-              const healVar = unit.champion.ability.variables.find(v => v.name === 'Heal' || v.name === 'APHeal' || v.name === 'PercentMaximumHealthHealing' || v.name === 'HealthDrain');
+              const healVar = unit.champion.ability.variables.find(v => v.name === 'Heal' || v.name === 'APHeal' || v.name === 'PercentMaximumHealthHealing' || v.name === 'HealthDrain' || v.name === 'HEALING');
               if (healVar) {
                 const starIdx = Math.min(unit.starLevel, healVar.value.length - 1);
                 const healVal = healVar.value[starIdx] ?? healVar.value[0] ?? 0;
@@ -7055,6 +7055,15 @@ export function simulateCombat(
                   const apSi = Math.min(unit.starLevel, apHealingVar.value.length - 1);
                   const apHealVal = (apHealingVar.value[apSi] ?? apHealingVar.value[0] ?? 0) as number;
                   healAmount += Math.round(apHealVal * (1 + unit.stats.ap / 100));
+                }
+                // Gragas (TFT17_Gragas) 'HealingPercentHealth' scaleHealth heal 합산 — desc ModifiedHeal = scaleHealth + scaleAP.
+                // healVar find 후보에 'HealingPercentHealth' 없어 (raw 'HealingPercentHealth' vs find 'PercentMaximumHealthHealing' 이름 미스매치)
+                // maxHp% heal 누락되던 것 보강. HEALING(main flat+scaleAP) 과 합산. Gragas ingest (PR #201) lint P1.
+                const pctHealthHealVar = unit.champion.ability.variables.find(v => v.name === 'HealingPercentHealth');
+                if (pctHealthHealVar) {
+                  const pSi = Math.min(unit.starLevel, pctHealthHealVar.value.length - 1);
+                  const pVal = (pctHealthHealVar.value[pSi] ?? pctHealthHealVar.value[0] ?? 0) as number;
+                  healAmount += Math.round(unit.maxHp * pVal);
                 }
                 if (healAmount > 0) {
                   // healAmp 곱셈 적용 — ability self-heal 도 회복량 증폭 효과 대상.

--- a/tests/unit/simulator/gragas-heal.test.ts
+++ b/tests/unit/simulator/gragas-heal.test.ts
@@ -1,0 +1,51 @@
+/**
+ * 회귀 가드 — 그라가스 base heal (HEALING + HealingPercentHealth) 합산.
+ *
+ * desc "화학적 분노" ModifiedHeal = scaleHealth(HealingPercentHealth maxHp 8.5%) + scaleAP(HEALING flat+AP).
+ * 버그: config.heal find 후보가 'Heal'/'APHeal'/'PercentMaximumHealthHealing'/'HealthDrain' 인데
+ *   raw 변수명은 'HEALING' (이름 미스매치) → main heal 자체 누락 (+ HealingPercentHealth maxHp% 도 누락).
+ * fix: find 후보에 'HEALING' 추가 + HealingPercentHealth 별도 read 합산.
+ *
+ * Gragas ingest (PR #201) lint P1 발견 → sim fix.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+
+function findChamp(apiName: string): RawChampion | undefined {
+  return champions.find(c => c.apiName === apiName);
+}
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 1): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: [] };
+}
+
+describe('그라가스 base heal (HEALING + HealingPercentHealth) 합산 (PR #201 lint P1 fix)', () => {
+  it('Gragas 가 스킬 시전 후 정상 종료 (heal find HEALING 매칭 — 크래시 없음)', () => {
+    const gragas = findChamp('TFT17_Gragas');
+    const enemy = findChamp('TFT17_Graves'); // 딜러 적 (Gragas 피해받아 mana 충전 → cast)
+    if (!gragas || !enemy) return;
+    const team: PlacedChampion[] = [placed(gragas, 4, 3, 2)];
+    const enemyTeam: PlacedChampion[] = [placed(enemy, 4, 4, 1)];
+    const result = simulateCombat(team, enemyTeam, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const g = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Gragas');
+    expect(g).toBeDefined();
+    expect(result.duration).toBeGreaterThan(0);
+  });
+
+  it('HEALING raw 값 정합 (filler ★1=415/★2=470/★3=630) + HealingPercentHealth (0.085)', () => {
+    const gragas = findChamp('TFT17_Gragas')!;
+    const vars = gragas.ability.variables ?? [];
+    const healing = vars.find(v => v.name === 'HEALING');
+    const pctHeal = vars.find(v => v.name === 'HealingPercentHealth');
+    expect(healing?.value[1]).toBe(415);  // [0,415,470,630] filler → ★1=value[1]=415
+    expect(healing?.value[2]).toBe(470);
+    expect(healing?.value[3]).toBe(630);
+    expect(pctHeal?.value[0]).toBeCloseTo(0.085, 3);
+  });
+});


### PR DESCRIPTION
## 요약

Gragas ingest(#201)에서 발견한 **P1 sim 버그** — base heal 완전 미반영 수정. sim fix P1 3건 중 ①.

## 버그

`combatLoop.ts:7032` `config.heal` 블록의 healVar find 후보가 `['Heal','APHeal','PercentMaximumHealthHealing','HealthDrain']`인데, Gragas raw heal 변수명은 **`HEALING`**(전부 대문자)이라 이름 미스매치 → `if (healVar)` 진입 실패 → **회복 전체 누락**. `HealingPercentHealth`(maxHp 8.5%)도 후보 밖.

(Reksai #195 APHealing 미스매치와 동형이나, Reksai는 base heal은 됐고 보조만 누락이었던 반면 Gragas는 **main heal 자체 누락**으로 더 심각)

## fix

- find 후보에 `'HEALING'` 추가
- `HealingPercentHealth` 별도 read 합산 (APHealing 패턴 차용)
- `ModifiedHeal = HEALING × (1+ap/100) + maxHp × HealingPercentHealth` (desc `scaleHealth scaleAP`)

## 회귀 안전성

- `HealingPercentHealth` read는 `if (healVar)` 블록 **내부** → `HEALING` 가진 Gragas만 진입
- IvernMinion도 `HealingPercentHealth` 보유하나 `HEALING` 없음 → healVar find 여전히 실패 → **미영향** 확인
- 전체 **913 테스트 통과** (회귀 0), 회귀 가드 `gragas-heal.test.ts` 추가

> ℹ️ calibration diff-game 회귀 캐시는 sim fix 3건 완료 후 일괄 재생성 예정 (별도 chore PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)