### PR TITLE
fix(sim): 브라이어 패시브 AS 단위(~100배 과소) + config selfBuff 이중 수정 (Briar #201 발견)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -3534,7 +3534,10 @@ function getEffectiveAttackSpeed(unit: CombatUnit): number {
   const briarSc = unit.champion.apiName === 'TFT17_Briar' ? getChampionScaling('TFT17_Briar') : null;
   if (briarSc) {
     const missingPct = 1 - (unit.currentHp / unit.maxHp);
-    const asPerPct = starValue(briarSc.asPerMissingHpPercent as number[] | undefined, unit.starLevel) / 100;
+    // scaling.json asPerMissingHpPercent [2,2,2,2.5] 는 이미 "missing 비율당 AS 배수" 단위.
+    // (잃은체력 50% × 2 = +100% AS, raw "1%당 2%" 정합). 기존 `/100` 은 이중 변환 버그(~100배 과소).
+    // Briar ingest (PR #201) lint P1 fix.
+    const asPerPct = starValue(briarSc.asPerMissingHpPercent as number[] | undefined, unit.starLevel);
     const apScale = briarSc.apScaling ? (1 + unit.stats.ap / 100) : 1;
     as *= (1 + missingPct * asPerPct * apScale);
   }

--- a/src/lib/simulator/systems/ability.ts
+++ b/src/lib/simulator/systems/ability.ts
@@ -187,7 +187,7 @@ export const CHAMPION_ABILITY_PATTERNS: Record<string, AbilityConfig> = {
   // =====================================================
 
   // === 1코스트 ===
-  TFT17_Briar:       { pattern: 'single', selfBuff: { attackSpeed: 0.5, duration: 999 } },  // 잃은 체력당 AS + 단일 물리
+  TFT17_Briar:       { pattern: 'single' },  // 단일 물리. 패시브 잃은체력 비례 AS 는 getEffectiveAttackSpeed, 탱커 50% 는 :6590 (selfBuff 0.5 제거 — raw 액티브 AS 버프 없음, duration 미참조 매 cast 누적 버그)
   TFT17_Poppy:       { pattern: 'self_buff' },  // 보호막 + 2칸 내 아군 방어력+마법저항 — combatLoop applyPoppyShieldAndResists 헬퍼에서 처리 (Shield/ShieldDuration/Resists 변수 + AP scaling + 만료)
   TFT17_Veigar:      { pattern: 'aoe_circle', radius: 1, secondaryDamageVar: 'MiniDamage' },  // 정령유성 Damage + 미니유성 MiniDamage
   TFT17_Aatrox:      { pattern: 'single', heal: true },  // 회복 + 단일 물리

--- a/tests/golden/__snapshots__/golden.test.ts.snap
+++ b/tests/golden/__snapshots__/golden.test.ts.snap
@@ -48,35 +48,35 @@ exports[`golden — anomaly (role-based) > Anomaly: Aurora(Caster) vs Rammus 1`]
 
 exports[`golden — anomaly (role-based) > Anomaly: Briar(Fighter) vs Illaoi 1`] = `
 {
-  "duration": 10.1,
+  "duration": 16.3,
   "logCounts": {
-    "ability": 3,
-    "attack": 19,
+    "ability": 6,
+    "attack": 27,
     "death": 1,
     "move": 6,
   },
   "scenarioName": "Anomaly: Briar(Fighter) vs Illaoi",
   "seed": 7,
-  "snapshotCount": 305,
+  "snapshotCount": 491,
   "units": [
     {
       "alive": true,
-      "attackCount": 13,
-      "castCount": 3,
+      "attackCount": 16,
+      "castCount": 4,
       "championApi": "TFT17_Briar",
-      "finalHp": 925.81,
+      "finalHp": 539.81,
       "id": "player-0",
       "killCount": 1,
       "maxHp": 1170,
       "starLevel": 2,
       "team": "player",
-      "totalDamageDealt": 2019.72,
-      "totalDamageTaken": 480,
+      "totalDamageDealt": 2310.72,
+      "totalDamageTaken": 900.93,
     },
     {
       "alive": false,
-      "attackCount": 6,
-      "castCount": 0,
+      "attackCount": 11,
+      "castCount": 1,
       "championApi": "TFT17_Illaoi",
       "finalHp": 0,
       "id": "enemy-0",
@@ -84,8 +84,8 @@ exports[`golden — anomaly (role-based) > Anomaly: Briar(Fighter) vs Illaoi 1`]
       "maxHp": 1980,
       "starLevel": 2,
       "team": "enemy",
-      "totalDamageDealt": 480,
-      "totalDamageTaken": 2019.72,
+      "totalDamageDealt": 900.93,
+      "totalDamageTaken": 2310.72,
     },
   ],
   "winner": "player",
@@ -232,7 +232,7 @@ exports[`golden — anomaly specialist (star orbit) > Anomaly: Gnar(Specialist) 
 
 exports[`golden — basic > 1v1 Briar mirror (대칭) 1`] = `
 {
-  "duration": 11.1,
+  "duration": 16.3,
   "logCounts": {
     "ability": 6,
     "attack": 31,
@@ -241,7 +241,7 @@ exports[`golden — basic > 1v1 Briar mirror (대칭) 1`] = `
   },
   "scenarioName": "1v1 Briar mirror (대칭)",
   "seed": 42,
-  "snapshotCount": 335,
+  "snapshotCount": 491,
   "units": [
     {
       "alive": true,
@@ -278,47 +278,47 @@ exports[`golden — basic > 1v1 Briar mirror (대칭) 1`] = `
 
 exports[`golden — basic > 1v1 Jinx+IE vs Briar (단일 스탯 아이템) 1`] = `
 {
-  "duration": 10.1333,
+  "duration": 10.9,
   "logCounts": {
     "ability": 3,
-    "attack": 20,
+    "attack": 19,
     "death": 1,
     "move": 6,
   },
   "scenarioName": "1v1 Jinx+IE vs Briar (단일 스탯 아이템)",
   "seed": 42,
-  "snapshotCount": 306,
+  "snapshotCount": 329,
   "units": [
     {
-      "alive": false,
-      "attackCount": 8,
+      "alive": true,
+      "attackCount": 9,
       "castCount": 1,
       "championApi": "TFT17_Jinx",
-      "finalHp": 0,
+      "finalHp": 144,
       "id": "player-0",
-      "killCount": 0,
+      "killCount": 1,
       "maxHp": 990,
       "starLevel": 2,
       "team": "player",
-      "totalDamageDealt": 1154.43,
-      "totalDamageTaken": 993,
+      "totalDamageDealt": 1293.03,
+      "totalDamageTaken": 846,
     },
     {
-      "alive": true,
-      "attackCount": 12,
-      "castCount": 3,
+      "alive": false,
+      "attackCount": 10,
+      "castCount": 2,
       "championApi": "TFT17_Briar",
-      "finalHp": 134.73,
+      "finalHp": 0,
       "id": "enemy-0",
-      "killCount": 1,
+      "killCount": 0,
       "maxHp": 1170,
       "starLevel": 2,
       "team": "enemy",
-      "totalDamageDealt": 993,
-      "totalDamageTaken": 1154.43,
+      "totalDamageDealt": 846,
+      "totalDamageTaken": 1293.03,
     },
   ],
-  "winner": "enemy",
+  "winner": "player",
 }
 `;
 
@@ -490,35 +490,35 @@ exports[`golden — combined items > Aurora+Rabadon vs Rammus 1`] = `
 
 exports[`golden — combined items > Belveth+Deathblade vs Briar 1`] = `
 {
-  "duration": 10.9,
+  "duration": 9.8,
   "logCounts": {
-    "ability": 4,
-    "attack": 25,
+    "ability": 3,
+    "attack": 18,
     "death": 1,
     "move": 6,
   },
   "scenarioName": "Belveth+Deathblade vs Briar",
   "seed": 42,
-  "snapshotCount": 329,
+  "snapshotCount": 296,
   "units": [
     {
       "alive": true,
-      "attackCount": 10,
-      "castCount": 2,
+      "attackCount": 9,
+      "castCount": 1,
       "championApi": "TFT17_Belveth",
-      "finalHp": 378.92,
+      "finalHp": 820.44,
       "id": "player-0",
       "killCount": 1,
       "maxHp": 1350,
       "starLevel": 2,
       "team": "player",
-      "totalDamageDealt": 1417.94,
-      "totalDamageTaken": 1128.41,
+      "totalDamageDealt": 1311.1,
+      "totalDamageTaken": 674.07,
     },
     {
       "alive": false,
-      "attackCount": 15,
-      "castCount": 3,
+      "attackCount": 9,
+      "castCount": 2,
       "championApi": "TFT17_Briar",
       "finalHp": 0,
       "id": "enemy-0",
@@ -526,8 +526,8 @@ exports[`golden — combined items > Belveth+Deathblade vs Briar 1`] = `
       "maxHp": 1170,
       "starLevel": 2,
       "team": "enemy",
-      "totalDamageDealt": 1128.41,
-      "totalDamageTaken": 1417.94,
+      "totalDamageDealt": 674.07,
+      "totalDamageTaken": 1311.1,
     },
   ],
   "winner": "player",
@@ -536,7 +536,7 @@ exports[`golden — combined items > Belveth+Deathblade vs Briar 1`] = `
 
 exports[`golden — combined items > Briar+Titans vs Jinx 1`] = `
 {
-  "duration": 4.2333,
+  "duration": 4.4667,
   "logCounts": {
     "ability": 2,
     "attack": 14,
@@ -545,7 +545,7 @@ exports[`golden — combined items > Briar+Titans vs Jinx 1`] = `
   },
   "scenarioName": "Briar+Titans vs Jinx",
   "seed": 101,
-  "snapshotCount": 129,
+  "snapshotCount": 136,
   "units": [
     {
       "alive": true,

--- a/tests/unit/simulator/briar-passive-as.test.ts
+++ b/tests/unit/simulator/briar-passive-as.test.ts
@@ -1,0 +1,45 @@
+/**
+ * 회귀 가드 — 브라이어 패시브 잃은 체력 비례 AS 단위 fix.
+ *
+ * desc "기본 지속 효과: 잃은 체력 1%당 AS 2%(★3 2.5%)".
+ * 버그 ①: getEffectiveAttackSpeed 에서 `missingPct(비율 0~1) × (asPerMissingHpPercent/100)` →
+ *   잃은체력 50% 시 +1% AS (raw 의도 +100%, ~100배 과소). scaling.json 값은 이미 percent-point 단위.
+ * 버그 ②: config selfBuff attackSpeed 0.5 (duration 999) — raw 액티브 AS 버프 없음 + duration 미참조 매 cast 누적.
+ * fix: `/100` 제거 (asPerMissingHpPercent 그대로) + config selfBuff 제거.
+ *
+ * Briar ingest (PR #201) lint P1 발견 → sim fix.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { CHAMPION_ABILITY_PATTERNS } from '@/lib/simulator/systems/ability';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+const briar = champions.find(c => c.apiName === 'TFT17_Briar')!;
+const enemy = champions.find(c => c.apiName === 'TFT17_Graves')!;
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: [] };
+}
+
+describe('브라이어 패시브 AS 단위 fix (PR #201 lint P1)', () => {
+  it('config selfBuff 제거 (패시브 AS 는 getEffectiveAttackSpeed 전담)', () => {
+    expect(CHAMPION_ABILITY_PATTERNS['TFT17_Briar']?.selfBuff).toBeUndefined();
+    expect(CHAMPION_ABILITY_PATTERNS['TFT17_Briar']?.pattern).toBe('single');
+  });
+
+  // fix 단위: getEffectiveAttackSpeed 에서 missingPct(0.5) × asPerMissingHpPercent(2) = 1.0 → AS ×2.0
+  //   (+100%, raw "잃은체력 50% × 2%" 정합). 기존 `/100` 이중 변환 버그(~100배 과소) 제거.
+  //   AS fix 의 전투 결과 회귀 가드는 golden snapshot (Briar 5 시나리오) 가 담당.
+
+  it('Briar 가 피해받아 광폭화 후 정상 종료 + 데미지 발생 (잃은체력 비례 AS)', () => {
+    const result = simulateCombat([placed(briar, 0, 0, 2)], [placed(enemy, 6, 3, 2)], {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const b = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Briar')!;
+    expect(b).toBeDefined();
+    expect(b.totalDamageDealt).toBeGreaterThan(0);
+    expect(result.duration).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 요약

Briar ingest(#201)에서 lint subagent가 확정한 **P1 sim 버그** 2건 수정. sim fix P1 3건 중 ③ (리스크 최대).

## 버그

**① 패시브 AS 단위 ~100배 과소** (`combatLoop.ts:3530`)
`getEffectiveAttackSpeed`에서 `missingPct(비율 0~1) × (asPerMissingHpPercent/100)`. scaling.json 값 `[2,2,2,2.5]`는 이미 percent-point("1%당 2%")인데 `/100`을 또 적용 → 잃은 체력 50%에 **+1% AS**(raw 의도 +100%). 광폭화 핵심 무력화.

| 잃은 체력 | 버그(현재) | fix 후 | raw 의도 |
|----------|-----------|--------|---------|
| 50% | +1% | **+100%** | +100% |
| 100% | +2% | **+200%** | +200% |

**② config selfBuff 이중** (`ability.ts:190`)
`selfBuff attackSpeed 0.5 (duration 999)` — raw 액티브는 물리 피해만(AS 버프 없음) + `duration` 미참조 → 매 cast `×1.5` 영구 누적.

## fix

- `combatLoop.ts:3530`: `/ 100` 제거 (asPerMissingHpPercent 그대로 — percent-point 단위)
- `ability.ts:190`: config `selfBuff` 제거 (패시브 AS는 getEffectiveAttackSpeed 전담)

## 회귀 안전성

- **golden snapshot 5건 갱신** — Briar 포함 시나리오(basic/combined/anomaly). AS 정상 작동으로 전투 결과 변화 (totalDamageTaken↑). **Briar 없는 51개 시나리오 불변 = 회귀 격리 확인**
- 전체 **917 테스트 통과**, 회귀 가드 `briar-passive-as.test.ts`

> ℹ️ calibration diff-game 재생성은 sim fix 3건(#202/#203/이 PR) 완료 후 일괄 (별도 chore PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)