### PR TITLE
docs(wiki): champions gragas/leona/briar — sim fix P1 resolved 반영 (#202/#203/#204)

### DIFF
--- a/docs/wiki/champions/briar.md
+++ b/docs/wiki/champions/briar.md
@@ -11,7 +11,7 @@ traits:
 role: Fighter   # raw "ADFighter" → mapGameRole() → sim Fighter (types/index.ts includes('Fighter')). carry augment 없음
 raw_role: ADFighter
 current_patch_status: active
-sim_active: partial   # base 물고기 광분 single + 액티브 물리(ADDamage sentinel filler ★1=120/180/285 scaleAD) + 탱커 50% 추가(PercentBonusDamage) + 패시브 잃은체력 비례 AS(getEffectiveAttackSpeed scaling.json asPerMissingHpPercent+apScaling) + 태고족(Primordian) 정합. P1 패시브 AS 단위 과소 의심 (missingPct(비율 0~1) × asPerMissingHpPercent/100 → 잃은체력 50% 시 +1% AS, raw "1%당 2%" 의도 +100% 대비 ~100배 과소) / P2 config selfBuff attackSpeed 0.5(영구) raw 액티브 AS 버프 없음 — 패시브와 별도 추가/이중 / P2 APDamage[0,10,15,25] 미반영(DAMAGE_VAR_PRIORITY ADDamage 우선, desc scaleAD만) / P2 동물특공대(AnimaSquad) trait sim 전투효과 미반영(synergies/helper 없음) / P2 불한당 은신(healthThreshold stealth) 미반영
+sim_active: partial   # base 물고기 광분 single + 액티브 물리(ADDamage sentinel filler ★1=120/180/285 scaleAD) + 탱커 50% 추가(PercentBonusDamage) + 패시브 잃은체력 비례 AS(getEffectiveAttackSpeed scaling.json asPerMissingHpPercent+apScaling) + 태고족(Primordian) 정합. ✅ 패시브 AS 단위 + selfBuff #204 수정 완료 (:3530 /100 이중 변환 제거 + config selfBuff 제거 → 잃은체력 50% +100% AS raw 정합, golden 5건 갱신) / P2 APDamage[0,10,15,25] 미반영(DAMAGE_VAR_PRIORITY ADDamage 우선, desc scaleAD만) / P2 동물특공대(AnimaSquad) trait sim 전투효과 미반영(synergies/helper 없음) / P2 불한당 은신(healthThreshold stealth) 미반영
 last_verified: 2026-06-08
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Briar entry — cost 1, role ADFighter, traits [동물특공대/태고족/불한당], mana 0/40, ability '물고기 광분' variables PercentMissingHealth/ADDamage/APDamage/PercentBonusDamage/AS)"
@@ -77,9 +77,9 @@ as *= (1 + missingPct * asPerPct * apScale);
 | desc 요소 | sim 적용 | 근거 |
 |-----------|---------|------|
 | 잃은 체력 비례 AS (동적) | ✅ 동적 + scaleAP | `getEffectiveAttackSpeed` 매 공격 계산. scaling.json `asPerMissingHpPercent` [2,2,2,2.5] + `apScaling` |
-| AS 수치 단위 | ❌ **~100배 과소 의심** | `missingPct`(비율 0~1) × `asPerPct`(raw/100). 잃은체력 50% ★1: `0.5 × (2/100) = 0.01` → **+1% AS**. raw "1%당 2%" = 50% 잃으면 +100% AS (×2.0). missingPct 를 percent-point(×100) 변환 누락 의심. **Lint P1** |
+| AS 수치 단위 | ✅ **#204 수정** | `:3530` `/100` 이중 변환 제거 (scaling.json 값 [2,2,2,2.5] 가 이미 percent-point). 잃은체력 50% ★1: `0.5 × 2 = 1.0` → **+100% AS** (raw "1%당 2%" 정합). golden snapshot 5건 갱신 |
 
-> ⚠️ **패시브 AS 가 거의 무효** — 잃은체력 50% 에 +1% AS (raw 의도 +100%). 광폭화 1코 핵심 메커니즘 과소. `missingPct × 100` (pp 변환) 또는 `asPerPct` 단위 재검토 필요.
+> ✅ **패시브 AS #204 수정 완료** — `:3530` `/100` 제거로 잃은체력 50% → +100% AS (raw 정합). 광폭화 1코 핵심 정상 작동 (회귀 가드 `briar-passive-as.test.ts` + golden 5건).
 
 ### Active — 물고기 광분 (`ability.ts:190`)
 
@@ -97,9 +97,9 @@ TFT17_Briar: { pattern: 'single', selfBuff: { attackSpeed: 0.5, duration: 999 } 
 | 단일 대상 물리 피해 (`ADDamage`) | ✅ ★별 + scaleAD | `DAMAGE_VAR_PRIORITY` 'ADDamage' 매칭 (`:392`). sentinel filler → ★1=120/★2=180/★3=285. detectScaling 물리 → 'ad' |
 | 탱커 시 +50% (`PercentBonusDamage`) | ✅ | `:6590` `if Briar && t.role === 'Tank' → baseDmg *= (1 + 0.5)` |
 | `APDamage` ([0,10,15,25]) | ❌ **미반영** | `DAMAGE_VAR_PRIORITY` 에서 'ADDamage' 가 'APDamage' 보다 우선 → ADDamage 만 선택. APDamage 는 별도 추가 마법 피해 변수이나 ADDamage 에 가려 미선택 (AS·apScaling 과 무관). **Lint P2** |
-| config `selfBuff: attackSpeed 0.5` (duration 999) | ⚠️ **raw 근거 없음 + 매 cast 누적** | `:7081` `unit.stats.attackSpeed *= (1+0.5)` — raw 액티브는 **물리 피해만** (AS 버프 없음). `duration` 필드는 코드 미참조 (`config.selfBuff.duration` grep 0) → 만료 없이 **매 cast 마다 ×1.5 영구 누적** (mana 0/40, 전투당 복수 cast → 기하급수). 패시브 AS 는 getEffectiveAttackSpeed 별도 처리 → 이중. **Lint P2** |
+| config `selfBuff` → **제거** (#204) | ✅ **#204 수정** | config 에서 `selfBuff` 제거 — raw 액티브는 물리 피해만(AS 버프 없음) + `duration` 미참조 매 cast ×1.5 누적 버그였음. 패시브 AS 는 getEffectiveAttackSpeed 전담 |
 
-> config `selfBuff attackSpeed 0.5` 는 [[graves]] 와 같은 set16 Briar 광폭화(selfBuff AS+AD) 패턴 잔재 추정 — TFT17 raw 액티브엔 AS 버프 없음. 패시브 AS 과소(P1)와 별개로 cast 시 영구 +50% AS over-application.
+> config `selfBuff` 는 [[graves]] 와 같은 set16 Briar 광폭화 패턴 잔재였고, TFT17 raw 액티브엔 AS 버프 없음 → **#204 에서 제거** (패시브 AS 단위 fix 와 함께 AS 정합 완성).
 
 ### 3 trait — 동물특공대 / 태고족 / 불한당
 
@@ -113,7 +113,7 @@ TFT17_Briar: { pattern: 'single', selfBuff: { attackSpeed: 0.5, duration: 999 } 
 
 | cast path | Briar 처리 | 근거 |
 |-----------|------------|------|
-| **main pipeline** | ✅ single 물리 피해 + selfBuff AS + 탱커 50% | `ability.ts:190` / `:6590` |
+| **main pipeline** | ✅ single 물리 피해 + 탱커 50% | `ability.ts:190` / `:6590` |
 | **OOR (out-of-range dash)** | ➖ dash 없음 (single non-dash) | config dash 미지정 |
 | **recast (onKill)** | ➖ 없음 — carry augment 없음 | — |
 
@@ -124,13 +124,12 @@ TFT17_Briar: { pattern: 'single', selfBuff: { attackSpeed: 0.5, duration: 999 } 
 ✅ **활성**:
 - stats 17.4 정합 (hp 650, armor/MR 35, AD 35, AS 0.75, range 1, mana 0/40)
 - role Fighter (`mapGameRole('ADFighter')`)
-- 패시브 잃은체력 비례 AS (getEffectiveAttackSpeed 동적, scaling.json + apScaling) — 단 단위 과소(P1)
+- 패시브 잃은체력 비례 AS (getEffectiveAttackSpeed 동적, scaling.json + apScaling) — **#204 단위 fix** (잃은체력 50% → +100% AS, raw 정합)
 - 액티브 물리 피해 (ADDamage sentinel filler ★1=120/★2=180/★3=285 scaleAD) + 탱커 50% 추가
 - 태고족 (Primordian) trait
 
 ⚠️ **부정확 / 미반영** (Lint 후보):
-- **P1**: 패시브 AS 단위 ~100배 과소 의심 — missingPct(비율) × asPerPct(raw/100), 잃은체력 50% 시 +1% AS (raw 의도 +100%)
-- **P2**: config selfBuff attackSpeed 0.5 (영구) raw 액티브 AS 버프 없음 — 패시브와 별도 추가/이중
+- ✅ **#204 수정 완료**: 패시브 AS 단위 (`:3530` /100 제거) + config selfBuff 제거 — 잃은체력 50% → +100% AS (raw 정합), golden 5건 갱신
 - **P2**: APDamage 미반영 (DAMAGE_VAR_PRIORITY ADDamage 우선)
 - **P2**: 동물특공대 trait 전투 효과 미반영 (synergies/helper 없음)
 - **P2**: 불한당 은신(healthThreshold stealth) 미반영
@@ -139,12 +138,11 @@ TFT17_Briar: { pattern: 'single', selfBuff: { attackSpeed: 0.5, duration: 999 } 
 
 | # | 항목 | 의미 | Tier | 적용 분기 (룰 #17) | 처리 |
 |---|------|------|------|---------------------|------|
-| P1 | 패시브 AS 단위 ~100배 과소 (lint 확정) | `getEffectiveAttackSpeed` (`:3530`) `missingPct(0~1) × (asPerMissingHpPercent/100)`. scaling.json 값 [2,2,2,2.5] 는 이미 percent-point("2%") 인데 `/100` 재변환 → **이중 변환 버그**. 잃은체력 50% → +1% AS (raw 의도 +100%) | **P1** | runtime — `:3530` 의 `/ 100` 제거 (scaling.json 값 percent-point 그대로). selfBuff 0.5(P2) 와 묶어 fix → AS 정합 완성 | 광폭화 핵심 AS 무력화. fix 전 패치노트/실측 cross-check |
-| P2 | selfBuff 0.5 raw 근거 없음 | config `selfBuff attackSpeed 0.5` (영구) — raw 액티브 AS 버프 없음 (물리 피해만). 패시브 AS 와 별도 cast 시 +50% AS | **P2** | config — Briar config 에서 selfBuff 제거 (패시브가 AS 담당) | cast 시 과대 AS. set16 잔재 추정 |
+| ✅ #204 | 패시브 AS 단위 + selfBuff → **수정 완료** | `:3530` `/100` 이중 변환 제거 (scaling.json 값 percent-point 그대로) + config selfBuff 제거. 잃은체력 50% → +100% AS (raw "1%당 2%" 정합) | ~~P1+P2~~ resolved | runtime+config | 회귀 가드 `briar-passive-as.test.ts` + golden snapshot 5건 |
 | P2 | APDamage 미반영 | ADDamage 만 DAMAGE_VAR_PRIORITY 선택. APDamage [0,10,15,25] 미참조 (desc scaleAD 만) | **P2** | cast-time — ModifiedDamage 에 APDamage 합산 여부 raw 확인 후 | minor (desc scaleAD 주력) |
 | P2 | 동물특공대 trait 미반영 | AnimaSquad 전투 효과 sim 0 (synergies/helper 없음) | **P2** | trait — 동물특공대 synergy 효과 구현 | trait 차원 별도 (다수 동물특공대 champion 공통) |
 
-> 📌 **액티브 물리(ADDamage)+탱커 50% + 태고족 trait 는 sim 정합**. `partial` 사유는 패시브 AS 단위 과소(P1) + selfBuff 이중·APDamage·동물특공대·불한당 은신 등 P2.
+> 📌 **패시브 AS(#204)+액티브 물리(ADDamage)+탱커 50% + 태고족 trait 는 sim 정합**. `partial` 잔존 사유는 APDamage·동물특공대·불한당 은신 (전부 P2) — 패시브 AS P1 + selfBuff 는 #204 해소.
 
 ## Lint 체크리스트
 
@@ -155,11 +153,12 @@ TFT17_Briar: { pattern: 'single', selfBuff: { attackSpeed: 0.5, duration: 999 } 
 - [x] **raw role `ADFighter` → mapGameRole → Fighter** — `includes('Fighter')`. carry augment 없음
 - [x] **함수 컨텍스트 read (2단계)** — `getEffectiveAttackSpeed` briarSc 블록 (`:3527`, missingPct × asPerPct × apScale) + scaling.json Briar (asPerMissingHpPercent [2,2,2,2.5] apScaling) + selfBuff 처리 (`:7077`) + 탱커 50% (`:6590`) + DAMAGE_VAR_PRIORITY (`:392`)
 - [x] **변수 filler 판정** — ADDamage [3.3,120,180,285] sentinel(v1/v0=36>5) filler → ★1=120/★2=180/★3=285 / APDamage [0,10,15,25] v0=0 filler / PercentMissingHealth/PercentBonusDamage 상수 / AS [2,2,2,2.5] no-filler (v0===v1)
-- [x] **actual sim integration verify (5단계)** — **패시브 AS 단위: missingPct(비율) × asPerPct(raw/100) → 잃은체력 50% +1% AS, raw +100% 대비 과소 P1** / ADDamage DAMAGE_VAR_PRIORITY 선택 (APDamage 미반영 P2) / 탱커 50% `:6590` 확인 / **config selfBuff 0.5 raw 액티브 AS 버프 없음 — 이중 P2**
-- [x] **cast path 3종 (PR #129 룰)** — main (single 물리 + selfBuff + 탱커 50% ✅) / OOR (dash 없음 ➖) / recast (carry 없음 ➖). 패시브 AS·trait 별개
+- [x] **actual sim integration verify (5단계)** — **패시브 AS 단위: missingPct × asPerPct (scaling.json percent-point 그대로, `:3530` /100 제거) — #204 fix ✅** / ADDamage DAMAGE_VAR_PRIORITY 선택 (APDamage 미반영 P2) / 탱커 50% `:6590` 확인 / **config selfBuff 제거 — #204 fix ✅**
+- [x] **cast path 3종 (PR #129 룰)** — main (single 물리 + 탱커 50% ✅, selfBuff 제거 #204) / OOR (dash 없음 ➖) / recast (carry 없음 ➖). 패시브 AS·trait 별개
 - [x] **`traits` frontmatter 각 entry trait helper grep 전수 verify (룰 #16/#19)** — 태고족 `TFT17_Primordian` `applyPrimordianEffects` (`:2166`) ✅ / 불한당 `TFT17_AssassinTrait` scaling.json synergies adap ✅ 은신 ❌ (P2) / 동물특공대 `TFT17_AnimaSquad` combatLoop+synergies 0 → 미반영 (P2)
 - [x] **본문 Lint P1 1건 + P2 4건 등록 → frontmatter `sim_active: partial`** (P1 sim 부정확 → 룰 #15)
-- [ ] (선택) 패시브 AS 단위(P1) / selfBuff 제거 / APDamage / 동물특공대 trait sim 도입
+- [x] **패시브 AS 단위(P1) + selfBuff 제거 → #204 수정 완료**
+- [ ] (선택) APDamage / 동물특공대 trait sim 도입
 
 ## 관련
 

--- a/docs/wiki/champions/gragas.md
+++ b/docs/wiki/champions/gragas.md
@@ -11,7 +11,7 @@ role: Tank   # raw "APTank" → mapGameRole() → sim Tank (types/index.ts inclu
 raw_role: APTank
 current_patch_status: active
 carry_augment: TFT17_Augment_GragasCarry   # 자폭 — abilityOverride aoe_circle selfDamage (conditional)
-sim_active: partial   # base 화학적 분노 aoe_circle Damage(★별 200/300/450 scaleAP) + 싸움꾼(Brawler) maxHp + 초능력(PsyOps) + carry augment(GragasCarry 자폭 selfDamage+baseDamageHpFrac+hexReduction+tankBonus 전부) 정합. P1 base heal 완전 미반영 (HEALING 변수 healVar find 후보['Heal'/'APHeal'/'PercentMaximumHealthHealing'/'HealthDrain']와 이름 미스매치 — Reksai #195 APHealing 동형이나 main heal 자체 누락) + HealingPercentHealth(maxHp 8.5%) 미반영 / P2 CCDuration 2초 냉각(ASSlow 30%)→stun 0.5 근사(CC 종류·시간 불일치) / P2 ASSlow 공속감소 미반영(stun 대체)
+sim_active: partial   # base 화학적 분노 aoe_circle Damage(★별 200/300/450 scaleAP) + 싸움꾼(Brawler) maxHp + 초능력(PsyOps) + carry augment(GragasCarry 자폭 selfDamage+baseDamageHpFrac+hexReduction+tankBonus 전부) 정합. ✅ base heal #202 수정 완료 (find 후보 'HEALING' 추가 + HealingPercentHealth maxHp 8.5% 별도 합산) / P2 CCDuration 2초 냉각(ASSlow 30%)→stun 0.5 근사(CC 종류·시간 불일치) / P2 ASSlow 공속감소 미반영(stun 대체)
 last_verified: 2026-06-08
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Gragas entry — cost 2, role APTank, traits [초능력/싸움꾼], mana 30/80, ability '화학적 분노' variables DURATION/HEALING/Damage/CCDuration/HealingPercentHealth/ASSlow)"
@@ -20,7 +20,7 @@ sources:
   - "src/types/index.ts (mapGameRole — 'APTank' includes 'Tank' → Tank)"
   - "src/lib/simulator/systems/ability.ts:211 (TFT17_Gragas: { pattern: 'aoe_circle', radius: 1, heal: true, stun: 0.5 })"
   - "src/lib/simulator/systems/ability.ts:379 (detectScaling — desc scaleAP → 'ap') / :442 (getAbilityDamage — Damage ★별 + ap scaling)"
-  - "src/lib/simulator/engine/combatLoop.ts:7028-7064 (config.heal — healVar find ['Heal'/'APHeal'/'PercentMaximumHealthHealing'/'HealthDrain'], Gragas 'HEALING' 미매칭 → heal 누락)"
+  - "src/lib/simulator/engine/combatLoop.ts:7028-7082 (config.heal — healVar find 후보에 'HEALING' 포함 + HealingPercentHealth 별도 합산 — #202 fix 완료)"
   - "src/lib/simulator/engine/combatLoop.ts:2020 (applyBrawlerEffects 싸움꾼 maxHp, Gragas 7명 중) / :2234 (applyPsyOpsRadiantSwap 초능력) / :6353-6390 (GragasCarry 자폭 selfDamage 공식)"
 related:
   - "[[role-passive]]"
@@ -40,7 +40,7 @@ related:
 - **base ability "화학적 분노"**: `DURATION`(2)초 체력 `ModifiedHeal`(scaleHealth scaleAP) 회복 → 대상+인접 적 `Damage`(scaleAP) 마법 피해 + `CCDuration`(2)초 `ASSlow`(30%) 냉각.
 - **carry augment "자폭"**: 반경 3칸 자폭 (maxHp 20% 희생 + maxHp 10% + AP, 1칸당 45% 감소, 탱커 +60%).
 
-> 🎯 **Gragas 는 회복 + 광역 냉각 2코 탱커** (초능력/싸움꾼). carry augment 시 자폭 nuke 로 변환. base Damage·싸움꾼·carry 자폭은 sim 정합하나 **base heal 이 변수명 미스매치로 완전 미반영 (P1)** — [[reksai]] #195 와 동형.
+> 🎯 **Gragas 는 회복 + 광역 냉각 2코 탱커** (초능력/싸움꾼). carry augment 시 자폭 nuke 로 변환. base Damage·heal(#202)·싸움꾼·carry 자폭 sim 정합. base heal 은 변수명 미스매치를 **#202 로 해소** ([[reksai]] #195 APHealing 패턴).
 
 > ⚠️ **set17 entity confirm**: `TFT17_Gragas` apiName 으로 소속 확인 (cost 2, traits 초능력/싸움꾼, role APTank). 한글명 list 만으로 후보 선정 금지 (룰 #149 P2 학습).
 
@@ -78,12 +78,12 @@ TFT17_Gragas: { pattern: 'aoe_circle', radius: 1, heal: true, stun: 0.5 }
 | desc 요소 | sim 적용 | 근거 |
 |-----------|---------|------|
 | 대상+인접 마법 피해 (`Damage`) | ✅ ★별 + scaleAP | `findDamageVariable` → `Damage` (filler → ★1=200/★2=300/★3=450). `detectScaling` desc `scaleAP` → `'ap'` → `getAbilityDamage` `× (1+ap/100)` (`:379`/`:442`). aoe_circle radius 1 = 대상+인접 각각 full |
-| 체력 회복 (`HEALING` flat 415~630, scaleHealth+scaleAP) | ❌ **완전 미반영** | `config.heal: true` 이나 `healVar` find 후보 `['Heal','APHeal','PercentMaximumHealthHealing','HealthDrain']` (`:7032`) 에 **`HEALING` 없음** → find 실패 → heal 0. [[reksai]] #195 (APHealing 미스매치) 동형이나 **main heal var 자체 누락** (더 심각). **Lint P1** |
-| 회복 maxHp 비례 (`HealingPercentHealth` 8.5%) | ❌ **미반영** | find 후보 `PercentMaximumHealthHealing` ≠ raw `HealingPercentHealth`. heal 누락에 포함. **Lint P1** |
+| 체력 회복 (`HEALING` flat 415~630, scaleHealth+scaleAP) | ✅ **#202 수정** | `config.heal` find 후보에 `HEALING` 추가 (`:7032`) → `HEALING × (1+ap/100)` 합산. [[reksai]] #195 APHealing 패턴 |
+| 회복 maxHp 비례 (`HealingPercentHealth` 8.5%) | ✅ **#202 수정** | `HealingPercentHealth` 별도 read → `maxHp × 0.085` 합산 (if healVar 블록 내, HEALING 가진 Gragas만 진입) |
 | 냉각 (`CCDuration` 2초, `ASSlow` 30% 공속감소) | ⚠️ **stun 0.5 근사** | sim `stun: 0.5` 고정. raw 는 ASSlow 30%(공속 감소)를 CCDuration 2초간 → sim 은 기절(완전 행동불가) 0.5초로 대체. **CC 종류(냉각≠기절) + 시간(2초→0.5초) 모두 불일치**. **Lint P2** |
 | 공속 감소 효과 (`ASSlow` 30%) | ❌ 미반영 | stun 0.5 대체 (위 P2 에 포함) — ASSlow 정확 적용 시 별도 |
 
-> ⚠️ **base heal 미반영이 핵심 gap** — 2코 탱커 생존 핵심기(HEALING 415~630 + maxHp 8.5%)가 변수명 미스매치로 완전 누락. heal find 후보 확장(`HEALING`/`HealingPercentHealth` 추가) 시 해소.
+> ✅ **base heal #202 수정 완료** — heal find 후보에 `HEALING` 추가 + `HealingPercentHealth` 별도 합산. 2코 탱커 생존 핵심기 정합 (회귀 가드 `gragas-heal.test.ts`).
 
 ### Conditional — 자폭 (carry augment `TFT17_Augment_GragasCarry`, `carryAugments.ts:258`)
 
@@ -132,7 +132,7 @@ abilityData: { damage: [280,420,630], healthCost: 0.20, hexReduction: 0.45,
 - **싸움꾼** maxHp 증폭 + **초능력** PsyOps item
 
 ⚠️ **부정확 / 미반영** (Lint 후보):
-- **P1**: base heal 완전 미반영 — `HEALING` 변수가 healVar find 후보와 이름 미스매치 (+ `HealingPercentHealth` maxHp 8.5% 미반영). 2코 탱커 생존 핵심기 누락
+- ✅ **#202 수정 완료**: base heal (HEALING + HealingPercentHealth maxHp 8.5%) — find 후보 확장 + 별도 합산
 - **P2**: CCDuration 2초 냉각(ASSlow 30%) → stun 0.5 근사 (CC 종류 + 시간 불일치)
 - **P2**: ASSlow 공속감소 미반영 (stun 대체)
 
@@ -140,10 +140,10 @@ abilityData: { damage: [280,420,630], healthCost: 0.20, hexReduction: 0.45,
 
 | # | 항목 | 의미 | Tier | 적용 분기 (룰 #17) | 처리 |
 |---|------|------|------|---------------------|------|
-| P1 | base heal 완전 미반영 | `config.heal: true` 이나 healVar find 후보 `['Heal','APHeal','PercentMaximumHealthHealing','HealthDrain']` 에 raw `HEALING` 없음 → find 실패. + `HealingPercentHealth`(maxHp 8.5%) 미반영. [[reksai]] #195 (APHealing) 동형이나 main heal 자체 누락 | **P1** | cast-time — healVar find 후보에 `HEALING` 추가 + `HealingPercentHealth`(maxHp%) 합산 (Reksai APHealing 패턴). heal find 후보 확장 별도 과제와 연결 | 2코 탱커 생존 핵심기. 회귀 가드 동반 |
+| ✅ #202 | base heal 미반영 → **수정 완료** | healVar find 후보에 `HEALING` 추가 + `HealingPercentHealth`(maxHp 8.5%) 별도 합산 (Reksai APHealing 패턴) | ~~P1~~ resolved | cast-time — `:7032` 적용 | 회귀 가드 `gragas-heal.test.ts`. IvernMinion 등 heal find 일반화는 별도 과제 |
 | P2 | 냉각→stun 근사 (CC 종류·시간) | sim `stun: 0.5` vs raw ASSlow 30% 공속감소 CCDuration 2초. 기절(완전 행동불가)≠냉각(공속 감소) + 0.5초≠2초 | **P2** | config — ASSlow 30% slow status 를 CCDuration 2초 적용 (stun 대체) | CC 종류·시간 부정확. stun 이 더 강한 CC 라 과대평가 가능 |
 
-> 📌 **base Damage(scaleAP)+냉각 근사 + carry 자폭 전체 + 싸움꾼/초능력 trait 는 sim 정합**. `partial` 사유는 base heal 완전 미반영(P1) + 냉각 근사(P2). carry augment 자폭은 selfDamage 분기로 완전 반영.
+> 📌 **base Damage+heal(#202)+carry 자폭+싸움꾼/초능력 trait 는 sim 정합**. `partial` 잔존 사유는 냉각→stun 근사(P2)뿐 — base heal P1 은 #202 로 해소.
 
 ## Lint 체크리스트
 

--- a/docs/wiki/champions/leona.md
+++ b/docs/wiki/champions/leona.md
@@ -11,7 +11,7 @@ role: Tank   # raw "APTank" → mapGameRole() → sim Tank (types/index.ts inclu
 raw_role: APTank
 current_patch_status: active
 carry_augment: TFT17_Augment_LeonaCarry   # 방패 여전사 — abilityOverride line dash (conditional)
-sim_active: partial   # base 여명의 방패 single + Damage(★별 100/150/225 flat) + stun + selfBuff durability 0.3(ShieldAmount 근사) + 선봉대 전투시작 shield + 중재자 arbiter law 정합. carry augment(LeonaCarry) line dash + firstHitOnlyStun + stunDuration[1.0,1.25,1.5]★별 + secondaryDamage[200,300,480] 정합. P1 carry baseDamageHpFrac 0.24(첫 적중 maxHp 24%) 미반영(selfDamage 분기 전용, applyCarryDamageModifiers 누락) / P2 carry abilityData.shield[200,240,280] 미반영(mordekaiser만 처리) / P2 base stun 1.5 하드코딩 vs raw StunDuration ★1=1.75/★2=1.75/★3=2(★별 무시·과소) / P2 base ShieldAmount flat(420~620)→durability 0.3 근사 / P2 DefenseToDamageRatio(scaleArmor/MR) 미반영(grep 0) / P2 선봉대 HealthThreshold+Durability 미구현(후속 PR, Illaoi #184 동형)
+sim_active: partial   # base 여명의 방패 single + Damage(★별 100/150/225 flat) + stun + selfBuff durability 0.3(ShieldAmount 근사) + 선봉대 전투시작 shield + 중재자 arbiter law 정합. carry augment(LeonaCarry) line dash + firstHitOnlyStun + stunDuration[1.0,1.25,1.5]★별 + secondaryDamage[200,300,480] 정합. ✅ carry baseDamageHpFrac 0.24(첫 적중 maxHp 24%) #203 수정 완료(applyCarryDamageModifiers primary 가산) / P2 carry abilityData.shield[200,240,280] 미반영(mordekaiser만 처리) / P2 base stun 1.5 하드코딩 vs raw StunDuration ★1=1.75/★2=1.75/★3=2(★별 무시·과소) / P2 base ShieldAmount flat(420~620)→durability 0.3 근사 / P2 DefenseToDamageRatio(scaleArmor/MR) 미반영(grep 0) / P2 선봉대 HealthThreshold+Durability 미구현(후속 PR, Illaoi #184 동형)
 last_verified: 2026-06-08
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Leona entry — cost 1, role APTank, traits [중재자/선봉대], mana 50/110, ability '여명의 방패' variables ShieldAmount/Damage/StunDuration/DefenseToDamageRatio/ShieldDuration)"
@@ -20,7 +20,7 @@ sources:
   - "src/types/index.ts (mapGameRole — 'APTank' includes 'Tank' → Tank)"
   - "src/lib/simulator/systems/ability.ts:200 (TFT17_Leona: { pattern: 'single', stun: 1.5, selfBuff: { durability: 0.3, duration: 4 } })"
   - "src/lib/simulator/systems/ability.ts:400 (findDamageVariable — default 'Damage' 매칭) / :442 (getAbilityDamage — filler + ap/ad scaling만)"
-  - "src/lib/simulator/engine/combatLoop.ts:1315 (applyCarryDamageModifiers — secondaryDamage :1337, baseDamageHpFrac 분기 없음) / :1921 (applyVanguardEffects 선봉대 shield)"
+  - "src/lib/simulator/engine/combatLoop.ts:1315 (applyCarryDamageModifiers — secondaryDamage :1337, baseDamageHpFrac primary 가산 :1349 [#203 fix, hexReduction==undefined 가드]) / :1921 (applyVanguardEffects 선봉대 shield)"
   - "src/lib/simulator/engine/combatLoop.ts:6995/7002/7370/7416 (LeonaCarry stunDuration ★별 + firstHitOnlyStun main+OOR) / :6695 (secondaryDamage recast) / :6387 (baseDamageHpFrac 자폭 전용) / :2340 (abilityData.shield mordekaiser 전용)"
 related:
   - "[[role-passive]]"
@@ -40,7 +40,7 @@ related:
 - **base ability "여명의 방패"**: `ShieldDuration`(4)초 `ShieldAmount`(scaleAP) 보호막 + 현재 대상 강타 `Damage`(scaleArmor scaleMR) 마법 피해 + `StunDuration`초 기절.
 - **carry augment "방패 여전사"**: line 돌진 → 첫 적중 AD + 24% 최대체력 + 기절, 추가 대상 secondary 피해.
 
-> 🎯 **Leona 는 보호막 + 기절 1코 탱커** (선봉대/중재자). base 는 단일 강타 + 자버프 보호막, carry augment 시 line 돌진 광역 CC carry 로 변환. base/carry 모두 sim 반영하나 carry baseDamageHpFrac(maxHp 24%)·shield + base stun ★별·DefenseToDamageRatio 등 P1/P2 gap.
+> 🎯 **Leona 는 보호막 + 기절 1코 탱커** (선봉대/중재자). base 는 단일 강타 + 자버프 보호막, carry augment 시 line 돌진 광역 CC carry 로 변환. base/carry 모두 sim 반영. carry baseDamageHpFrac(maxHp 24%)은 #203 해소, 잔존 P2 = carry shield·base stun ★별·DefenseToDamageRatio 등 P1/P2 gap.
 
 > ⚠️ **set17 entity confirm**: `TFT17_Leona` apiName 으로 소속 확인 (cost 1, traits 중재자/선봉대, role APTank). 한글명 list 만으로 후보 선정 금지 (룰 #149 P2 학습).
 
@@ -101,7 +101,7 @@ abilityData: { damage: [90,135,225], shield: [200,240,280], shieldDuration: 2,
 | 기절 시간 (`stunDuration` [1.0,1.25,1.5]) | ✅ ★별 | `:6995` main pipeline + `:7416` OOR — starLevel별 정확 적용 (이전 fixed 1.0 회귀 해소) |
 | 추가 대상 secondary 피해 (`secondaryDamage` [200,300,480]) | ✅ | `applyCarryDamageModifiers` `:1337` (`!isPrimaryTarget`) + recast `:6695` |
 | primary damage (`damage` [90,135,225]) | ✅ | abilityData.damage cast |
-| **첫 적중 maxHp 24% (`baseDamageHpFrac` 0.24)** | ❌ **미반영** | `baseDamageHpFrac` 처리는 `:6387` (그라가스 자폭 `selfDamage`+`hexReduction` 가드) 전용. `applyCarryDamageModifiers` (`:1315`) 6종 modifier 에 baseDamageHpFrac 분기 없음 (주석 `:1306` "selfDamage special path 라 helper 무관"). LeonaCarry 첫 적중 maxHp 가산 누락. **Lint P1** |
+| **첫 적중 maxHp 24% (`baseDamageHpFrac` 0.24)** | ✅ **#203 수정** | `applyCarryDamageModifiers` (`:1336`) 에 primary target `maxHp × baseDamageHpFrac` 가산 추가 (`hexReduction === undefined` 가드 — 자폭형 GragasCarry 는 selfDamage continue 로 미진입). 회귀 가드 `leona-basedamagehpfrac.test.ts` |
 | 보호막 (`shield` [200,240,280], `shieldDuration` 2) | ❌ **미반영** | abilityOverride 에 selfBuff 없음 → base durability 도 소거. `abilityData.shield` 처리는 `:2340` `mordekaiserCarryShield` 전용. LeonaCarry shield 미참조. **Lint P2** |
 
 > carry augment 는 [[feedback_selected_single_carry]] — `findSelectedCarryAugment` 가 selected 1명만 carryCfg 반환. secondaryDamage/stunDuration 은 selected 카피만 적용 (비-carry 회귀 방지).
@@ -133,7 +133,7 @@ abilityData: { damage: [90,135,225], shield: [200,240,280], shieldDuration: 2,
 - **선봉대** 전투 시작 shield + **중재자** arbiter law
 
 ⚠️ **부정확 / 미반영** (Lint 후보):
-- **P1**: carry `baseDamageHpFrac` 0.24 (첫 적중 maxHp 24%) 미반영 — selfDamage 분기 전용, applyCarryDamageModifiers 누락
+- ✅ **#203 수정 완료**: carry `baseDamageHpFrac` 0.24 (첫 적중 maxHp 24%) — applyCarryDamageModifiers primary 가산 (hexReduction 없는 carry 한정)
 - **P2**: carry `abilityData.shield` [200,240,280] 미반영 — mordekaiser 만 처리
 - **P2**: base stun 1.5 하드코딩 vs raw StunDuration ★1=1.75/★2=1.75/★3=2 (★별 무시 + 과소)
 - **P2**: base ShieldAmount flat(420~620) → durability 0.3 근사
@@ -144,13 +144,13 @@ abilityData: { damage: [90,135,225], shield: [200,240,280], shieldDuration: 2,
 
 | # | 항목 | 의미 | Tier | 적용 분기 (룰 #17) | 처리 |
 |---|------|------|------|---------------------|------|
-| P1 | carry baseDamageHpFrac 미반영 | LeonaCarry 첫 적중 "AD + 24% 최대체력". `baseDamageHpFrac` 처리는 `:6387` 자폭(selfDamage) 전용 → line carry 미적용. applyCarryDamageModifiers 6 modifier 에 분기 없음 | **P1** | cast-time — primary target(첫 적중)에 `maxHp × baseDamageHpFrac` 가산 (applyCarryDamageModifiers 또는 line cast primary 분기) | carry primary 핵심 데미지 누락. 회귀 가드 동반 |
+| ✅ #203 | carry baseDamageHpFrac 미반영 → **수정 완료** | `applyCarryDamageModifiers`(`:1336`)에 primary `maxHp × baseDamageHpFrac` 가산 (hexReduction 없는 carry 한정 — GragasCarry 자폭 selfDamage continue 로 미진입) | ~~P1~~ resolved | cast-time 적용 | 회귀 가드 `leona-basedamagehpfrac.test.ts` |
 | P2 | carry abilityData.shield 미반영 | LeonaCarry shield [200,240,280]/2초. abilityOverride selfBuff 없음 + abilityData.shield 는 `:2340` mordekaiser 전용 → carry Leona shield 전무 | **P2** | cast-time — carry cast 시 abilityData.shield[★] 보호막 부여 | carry 방어 효과 누락 |
 | P2 | base stun ★별 무시 + 과소 | sim `stun: 1.5` 고정 vs raw StunDuration ★1=1.75/★2=1.75/★3=2. CC 0.25~0.5초 과소 + ★별 무시 | **P2** | config stun 을 raw StunDuration readVarByStar 로 전환 | base 강타 CC 과소. 의도적 근사 가능성(패치노트 확인) |
 | P2 | DefenseToDamageRatio 미반영 | desc Damage `(scaleArmor scaleMR)` → 방어 비례 추가. `getAbilityDamage` ap/ad scaling 만, grep 0 | **P2** | cast-time — Damage 에 (armor+MR)×DefenseToDamageRatio 가산 | base 강타 피해 과소 (탱빌드 시 큼) |
 | P2 | 선봉대 HealthThreshold/Durability 미구현 | `applyVanguardEffects` 전투시작 shield 만. HealthThreshold(50%) 추가 shield + Durability 미구현 | **P2** | tick — HealthThreshold 발동 감시 + 보호막 활성 중 Durability 가산 | trait 차원 후속 PR (Illaoi #184 동형) |
 
-> 📌 **base Damage(★별)+stun+durability shield + carry line+firstHitOnlyStun+stunDuration★별+secondaryDamage + 선봉대 shield + 중재자 law 는 sim 정합**. `partial` 사유는 carry baseDamageHpFrac(P1)·shield + base stun ★별·ShieldAmount·DefenseToDamageRatio + 선봉대 부분구현 등.
+> 📌 **base Damage+stun+durability shield + carry line+firstHitOnlyStun+stunDuration★별+secondaryDamage+baseDamageHpFrac(#203) + 선봉대 shield + 중재자 law 는 sim 정합**. `partial` 잔존 사유는 carry shield + base stun ★별·ShieldAmount·DefenseToDamageRatio + 선봉대 부분구현 (전부 P2) — baseDamageHpFrac P1 은 #203 해소.
 
 ## Lint 체크리스트
 


### PR DESCRIPTION
## 요약

sim fix P1 3건(#202/#203/#204) 머지 후, 해당 champion 페이지의 P1 lint 항목을 **resolved**로 갱신. 위키 정확성 동기화.

| 페이지 | P1 → resolved | sim_active |
|--------|--------------|-----------|
| gragas.md | base heal (HEALING+HealingPercentHealth) → **#202** | partial (P2 냉각 stun 근사 잔존) |
| leona.md | carry baseDamageHpFrac (maxHp 24%) → **#203** | partial (P2 carry shield·base stun·DefenseToDamageRatio·선봉대 잔존) |
| briar.md | 패시브 AS 단위 + selfBuff → **#204** | partial (P2 APDamage·동물특공대·불한당 은신 잔존) |

## wiki-ingest-verifier 결과

| Tier | 건수 | 처리 |
|------|------|------|
| P0 | 0 | — (3건 resolved 주장 모두 코드 일치 확인) |
| P1 | 0 | — |
| P2 | 3 | sources/체크리스트의 fix-전 stale 표기 (page-internal 모순) 전부 fix |

각 페이지 frontmatter ↔ 본문 ↔ Lint 표 정합 확인. P1만 resolved, P2 미반영은 유지(sim_active partial 적절). docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)