### PR TITLE
fix(sim): 초가스 응축 전투 중 maxHp 영구 증가 미반영 수정 (Chogath #207 발견)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6669,6 +6669,21 @@ export function simulateCombat(
                     unit.nasusBonkStack++;
                   }
                 }
+                // 초가스 응축: cast 시 maxHp 영구 증가 (처치 시 BonusHealthOnKill, 아니면 BonusHealthPerCast).
+                // desc "최대 체력 영구 BonusHealthPerCast 획득. 이 효과로 처치하면 대신 BonusHealthOnKill 획득".
+                // maxHp + currentHp 둘 다 가산 (거대화 — applyPermanentStacks chogath_hp :359 와 일관).
+                // single pattern → target 1명, cast 당 1회. Chogath ingest (PR #207) lint P1: 전투 중 영구 체력 성장 미반영 보강.
+                if (unit.champion.apiName === 'TFT17_Chogath') {
+                  const killed = t.currentHp <= 0;   // 사망 처리 블록(:6644) 과 동일 판정 — markTargetDead 후 유지
+                  const hpVar = unit.champion.ability.variables?.find(
+                    v => v.name === (killed ? 'BonusHealthOnKill' : 'BonusHealthPerCast'),
+                  );
+                  const hpGain = readVarByStar(hpVar?.value, unit.starLevel, 0);
+                  if (hpGain > 0) {
+                    unit.maxHp += hpGain;
+                    unit.currentHp += hpGain;
+                  }
+                }
               }
 
               // === PR7-A (17.2b) — 파이크 carry onKillRecast cascade ===

--- a/tests/unit/simulator/chogath-maxhp-growth.test.ts
+++ b/tests/unit/simulator/chogath-maxhp-growth.test.ts
@@ -1,0 +1,53 @@
+/**
+ * 회귀 가드 — 초가스 응축 전투 중 maxHp 영구 증가 (BonusHealthPerCast / BonusHealthOnKill).
+ *
+ * desc "최대 체력을 영구적으로 BonusHealthPerCast 획득. 이 효과로 처치하면 대신 BonusHealthOnKill 획득".
+ * 버그: 전투 중 cast/처치 시 maxHp 증가 sim 부재 (grep 0). chogath_hp(:359 applyPermanentStacks)는
+ *   라운드 간 입력만이고 전투 내 자체 증가 없음.
+ * fix: cast loop 사망 처리 직후 — 처치 시 BonusHealthOnKill, 아니면 BonusHealthPerCast → maxHp+currentHp 가산.
+ *
+ * Chogath ingest (PR #207) lint P1 발견 → sim fix.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+const chogath = champions.find(c => c.apiName === 'TFT17_Chogath')!;
+const enemy = champions.find(c => c.apiName === 'TFT17_Graves')!; // 딜러 적 — Chogath 피해받아 mana 충전 → cast
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: [] };
+}
+
+describe('초가스 응축 전투 중 maxHp 영구 증가 (PR #207 lint P1 fix)', () => {
+  it('Chogath 가 cast 발동 후 maxHp 증가 (초기 대비 커짐)', () => {
+    const team: PlacedChampion[] = [placed(chogath, 4, 3, 2)];
+    const enemyTeam: PlacedChampion[] = [placed(enemy, 4, 4, 2)];
+    const result = simulateCombat(team, enemyTeam, {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const c = result.playerUnits.find(u => u.champion.apiName === 'TFT17_Chogath')!;
+    expect(c).toBeDefined();
+    expect(result.duration).toBeGreaterThan(0);
+    // ★2 base maxHp = 700 × 1.8 = 1260 (싸움꾼 단독 비활성). 응축 cast 발동 시
+    // BonusHealthPerCast(★2=18)/OnKill(★2=40) 만큼 maxHp 영구 증가 → base 초과.
+    // fix 전(미반영)이면 maxHp == 1260 (증가 없음). 실측 1278 (cast 1회 +18).
+    expect(c.maxHp).toBeGreaterThan(1260);
+  });
+
+  it('BonusHealthPerCast / BonusHealthOnKill raw filler 정합', () => {
+    const vars = chogath.ability.variables ?? [];
+    const perCast = vars.find(v => v.name === 'BonusHealthPerCast');
+    const onKill = vars.find(v => v.name === 'BonusHealthOnKill');
+    // BonusHealthPerCast [0,12,18,33] v0=0 filler → ★1=12/★2=18/★3=33
+    expect(perCast?.value[1]).toBe(12);
+    expect(perCast?.value[2]).toBe(18);
+    expect(perCast?.value[3]).toBe(33);
+    // BonusHealthOnKill [35,30,40,70] v0(35)>v1(30) filler → ★1=30/★2=40/★3=70
+    expect(onKill?.value[1]).toBe(30);
+    expect(onKill?.value[2]).toBe(40);
+    expect(onKill?.value[3]).toBe(70);
+  });
+});


### PR DESCRIPTION
## 요약

Chogath ingest(#207)에서 발견한 **P1 sim 버그** — 응축의 전투 중 maxHp 영구 증가 미반영 수정.

## 버그

응축 desc "최대 체력을 영구적으로 `BonusHealthPerCast` 획득. 이 효과로 처치하면 대신 `BonusHealthOnKill` 획득"의 maxHp 영구 증가가 sim에 미반영 (`BonusHealthPerCast`/`BonusHealthOnKill` grep 0). `chogath_hp`(`:359` applyPermanentStacks)는 **라운드 간 입력만**이고 전투 내 자체 증가가 없어 — Chogath의 영구 체력 성장 핵심 메커니즘 누락.

## fix

cast loop 사망 처리 직후에 maxHp 증가 추가:
```ts
if (unit.champion.apiName === 'TFT17_Chogath') {
  const killed = t.currentHp <= 0;  // 사망 처리 블록과 동일 판정
  const hpVar = ...find(killed ? 'BonusHealthOnKill' : 'BonusHealthPerCast');
  const hpGain = readVarByStar(hpVar?.value, unit.starLevel, 0);
  if (hpGain > 0) { unit.maxHp += hpGain; unit.currentHp += hpGain; }
}
```
- maxHp + currentHp 둘 다 가산 (거대화 — `applyPermanentStacks` chogath_hp 일관)
- filler: OnKill `[35,30,40,70]` v0>v1 → ★1=30 / PerCast `[0,12,18,33]` v0=0 → ★1=12

## 검증

- **실측**: Chogath ★2 base maxHp 1260 → cast 1회 후 **1278** (+18 PerCast)
- 회귀 0 (Chogath 전용 apiName 분기): 전체 **919 테스트 통과**, golden 영향 없음
- 회귀 가드 `chogath-maxhp-growth.test.ts` (maxHp > base 1260 직접 검증)

> ℹ️ calibration diff-game 재생성은 머지 후 별도 chore PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)