### PR TITLE
docs(wiki): champions/chogath.md — sim fix P1 resolved 반영 (#208)

### DIFF
--- a/docs/wiki/champions/chogath.md
+++ b/docs/wiki/champions/chogath.md
@@ -10,7 +10,7 @@ traits:
 role: Tank   # raw "APTank" → mapGameRole() → sim Tank (types/index.ts includes('Tank')). carry augment 없음
 raw_role: APTank
 current_patch_status: active
-sim_active: partial   # base 응축 single + TotalDamage(BonusDamage no-filler ★1=140/210/290 scaleAP + 대상 maxHp 8% `:6585`) + chogath_hp permanentStacks 전투시작 영구체력(`:359`) + 암흑의 별(DarkStar)/싸움꾼(Brawler) 정합. P1 전투 중 cast당 maxHp 증가(BonusHealthPerCast 12/18/33) + 처치 시(BonusHealthOnKill 30/40/70) 미반영 (grep 0 — chogath_hp 는 라운드간 입력만, 전투 내 자체 증가 없음) / P2 HP tier 진화(HPToTier2 1000/Tier3 2000) 미반영(grep 0) / info config.heal:true 무의미(healVar find 후보에 Chogath heal 변수 없음 — maxHp 영구 증가는 currentHp heal 과 별개)
+sim_active: partial   # base 응축 single + TotalDamage(BonusDamage no-filler ★1=140/210/290 scaleAP + 대상 maxHp 8% `:6585`) + chogath_hp permanentStacks 전투시작 영구체력(`:359`) + 암흑의 별(DarkStar)/싸움꾼(Brawler) 정합. ✅ 전투 중 cast당 maxHp 증가(BonusHealthPerCast 12/18/33) + 처치 시(BonusHealthOnKill 30/40/70) #208 수정 완료(cast loop 사망 처리 직후 maxHp+currentHp 가산) / P2 HP tier 진화(HPToTier2 1000/Tier3 2000) 미반영(grep 0) / info config.heal:true 무의미(healVar find 후보에 Chogath heal 변수 없음 — maxHp 영구 증가는 currentHp heal 과 별개)
 last_verified: 2026-06-08
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Chogath entry — cost 1, role APTank, traits [암흑의 별/싸움꾼], mana 30/70, ability '응축' variables PercentMaximumHealthDamage/BonusDamage/BonusHealthOnKill/HPToTier2/HPToTier3/BonusHealthPerCast)"
@@ -36,7 +36,7 @@ related:
 - **role**: `mapGameRole('APTank')` → sim **Tank** ([[role-passive]] — 공격당 5 / 초당 0 / 피격 ✅).
 - **base ability "응축"**: 사거리 내 체력 가장 낮은 적에 `TotalDamage`(scaleHealth scaleAP — 대상 최대체력 8% + `BonusDamage`) 마법 피해 + 최대 체력 영구 `BonusHealthPerCast` 획득. 처치 시 대신 `BonusHealthOnKill` 획득.
 
-> 🎯 **Chogath 는 영구 체력 성장 1코 탱커** (암흑의 별/싸움꾼). 매 cast·처치마다 maxHp 영구 증가가 핵심이나 **sim 은 전투 중 증가를 미반영 (P1)** — 라운드 간 누적분(chogath_hp)만 전투 시작에 반영. TotalDamage(대상 maxHp 8% + BonusDamage)·trait 는 정합.
+> 🎯 **Chogath 는 영구 체력 성장 1코 탱커** (암흑의 별/싸움꾼). 매 cast·처치마다 maxHp 영구 증가가 핵심 — **#208 로 전투 중 증가 반영** (라운드 간 누적분 chogath_hp 전투 시작 + 전투 중 cast/처치 증가). TotalDamage(대상 maxHp 8% + BonusDamage)·trait 도 정합.
 
 > ⚠️ **set17 entity confirm**: `TFT17_Chogath` apiName 으로 소속 확인 (cost 1, traits 암흑의 별/싸움꾼, role APTank). 한글명 list 만으로 후보 선정 금지 (룰 #149 P2 학습).
 
@@ -80,8 +80,8 @@ if (unit.champion.apiName === 'TFT17_Chogath') {
 | 체력 가장 낮은 적 타겟 | ✅ | `pattern: 'single'` (lowest-hp 타게팅) |
 | `BonusDamage` (고정, scaleAP) | ✅ ★별 + scaleAP | `damageVar: 'BonusDamage'` no-filler → ★1=140/★2=210/★3=290. detectScaling desc `scaleAP` → 'ap' (`getAbilityDamage`) |
 | 대상 최대체력 8% (`PercentMaximumHealthDamage`, scaleHealth) | ✅ | `:6585` `baseDmg += t.maxHp × 0.08`. TotalDamage = BonusDamage + 대상 maxHp 8% |
-| **cast당 maxHp 영구 증가 (`BonusHealthPerCast` 12/18/33)** | ❌ **미반영** | `BonusHealthPerCast` repo-wide grep **0 hit**. cast 시 maxHp 증가 sim 부재. **Lint P1** |
-| **처치 시 maxHp 영구 증가 (`BonusHealthOnKill` filler ★1=30/★2=40/★3=70)** | ❌ **미반영** | `BonusHealthOnKill` grep **0 hit**. 처치 시 maxHp 증가 sim 부재. **Lint P1** |
+| **cast당 maxHp 영구 증가 (`BonusHealthPerCast` 12/18/33)** | ✅ **#208 수정** | cast loop 사망 처리 직후(`:6671`) — 미처치(`currentHp>0`) 시 `BonusHealthPerCast` → maxHp+currentHp 가산. 실측 ★2 +18 |
+| **처치 시 maxHp 영구 증가 (`BonusHealthOnKill` filler ★1=30/★2=40/★3=70)** | ✅ **#208 수정** | 처치(`currentHp<=0`) 시 `BonusHealthOnKill` (PerCast 대신) 가산 |
 | HP tier 진화 (`HPToTier2` 1000 / `HPToTier3` 2000) | ❌ **미반영** | `HPToTier2`/`HPToTier3` grep **0 hit**. 체력 임계 진화 sim 부재. **Lint P2** |
 | config `heal: true` | ➖ **무의미** | healVar find 후보 `['Heal','APHeal','PercentMaximumHealthHealing','HealthDrain','HEALING']` 에 Chogath heal 변수 없음 → find 실패 → heal 0. Chogath 의 "체력 획득"은 currentHp heal 이 아닌 **maxHp 영구 증가** (별개 메커니즘). **info** |
 
@@ -101,7 +101,7 @@ function applyPermanentStacks(unit, placed) {
 |------|---------|------|
 | 누적 영구 체력 → 전투 시작 maxHp 반영 | ✅ **라운드 간 입력만** | `:359` `placed.permanentStacks`(chogath_hp) 를 전투 시작 시 maxHp/currentHp 가산. types `chogath_hp` UI 표시 (`:327`) |
 
-> ⚠️ **전투 시작 시 누적분만 반영** — `permanentStacks` 는 외부(라운드 간) 입력값. **전투 시뮬 중 cast/처치로 chogath_hp 가 자체 증가하지 않음** (BonusHealthPerCast/OnKill grep 0). 단일 전투 내 영구 체력 성장이 핵심인 Chogath 의 P1 gap.
+> ✅ **#208 로 전투 중 증가 반영** — `permanentStacks`(chogath_hp)는 라운드 간 입력값(전투 시작 반영), **전투 시뮬 중 cast/처치 maxHp 증가는 cast loop(`:6671` 직후)에서 별도 처리** (#208). 회귀 가드 `chogath-maxhp-growth.test.ts`.
 
 ### 암흑의 별 (`TFT17_DarkStar`) / 싸움꾼 (`TFT17_HPTank`) trait
 
@@ -130,7 +130,7 @@ function applyPermanentStacks(unit, placed) {
 - **암흑의 별 (DarkStar)** + **싸움꾼 (Brawler)** trait
 
 ⚠️ **부정확 / 미반영** (Lint 후보):
-- **P1**: 전투 중 cast당 maxHp 증가 (`BonusHealthPerCast` 12/18/33) + 처치 시 (`BonusHealthOnKill` 30/40/70) 미반영 — grep 0, chogath_hp 라운드간 입력만
+- ✅ **#208 수정 완료**: 전투 중 cast당 maxHp 증가 (`BonusHealthPerCast`) + 처치 시 (`BonusHealthOnKill`) — cast loop 사망 처리 직후 maxHp+currentHp 가산
 - **P2**: HP tier 진화 (`HPToTier2` 1000 / `HPToTier3` 2000) 미반영 — grep 0
 - ℹ️ info: config `heal: true` 무의미 (healVar find 실패, maxHp 영구 증가는 heal 과 별개)
 
@@ -138,10 +138,10 @@ function applyPermanentStacks(unit, placed) {
 
 | # | 항목 | 의미 | Tier | 적용 분기 (룰 #17) | 처리 |
 |---|------|------|------|---------------------|------|
-| P1 | 전투 중 maxHp 영구 증가 미반영 | 응축 cast 시 `BonusHealthPerCast`(12/18/33) + 처치 시 `BonusHealthOnKill`(30/40/70) maxHp 영구 증가. grep 0 — chogath_hp(`:359`)는 라운드 간 입력만, 전투 내 자체 증가 없음 | **P1** | cast-time + onKill — cast/처치 시 `unit.maxHp += BonusHealthPerCast/OnKill[★]` (chogath_hp 누적). 처치는 markTargetDead 직후 (Nasus bonusPerKill 패턴) | 영구 체력 성장 핵심. 단일 전투 내 생존 영향. 회귀 가드 동반 |
+| ✅ #208 | 전투 중 maxHp 영구 증가 → **수정 완료** | cast loop 사망 처리 직후(`:6671`) — 처치(`currentHp<=0`) 시 `BonusHealthOnKill` 아니면 `BonusHealthPerCast` → maxHp+currentHp 가산 | ~~P1~~ resolved | cast-time + onKill | 회귀 가드 `chogath-maxhp-growth.test.ts`, diff-cache #209 |
 | P2 | HP tier 진화 미반영 | `HPToTier2`(1000)/`HPToTier3`(2000) 체력 임계 도달 시 진화(크기/스탯). grep 0 | **P2** | tick — maxHp 임계 도달 감시 + tier 효과 | 시각/스탯 효과. raw 의미 측정 후 |
 
-> 📌 **TotalDamage(BonusDamage scaleAP + 대상 maxHp 8%) + chogath_hp 전투시작 반영 + 암흑의 별/싸움꾼 trait 는 sim 정합**. `partial` 사유는 전투 중 maxHp 증가 미반영(P1) + HP tier(P2). config.heal 은 무의미(info).
+> 📌 **TotalDamage + chogath_hp + 전투 중 maxHp 증가(#208) + 암흑의 별/싸움꾼 trait 는 sim 정합**. `partial` 잔존 사유는 HP tier 진화(P2)뿐 — maxHp 증가 P1 은 #208 해소. config.heal 무의미(info).
 
 ## Lint 체크리스트
 
@@ -152,11 +152,12 @@ function applyPermanentStacks(unit, placed) {
 - [x] **raw role `APTank` → mapGameRole → Tank** — `includes('Tank')`. carry augment 없음
 - [x] **함수 컨텍스트 read (2단계)** — Chogath 특수처리 (`:6585`, baseDmg += t.maxHp × PercentMaximumHealthDamage) + `applyPermanentStacks` (`:353-368`, chogath_hp → maxHp/currentHp) + `applyDarkStarEffects` (`:2083`) + `applyBrawlerEffects` (`:2027`)
 - [x] **변수 filler 판정** — BonusDamage [140,210,290] no-filler(v0<v1) ★1=140/★2=210/★3=290 / BonusHealthOnKill [35,30,40,70] v0>v1 filler ★1=30/★2=40/★3=70 / BonusHealthPerCast [0,12,18,33] v0=0 filler ★1=12/★2=18/★3=33 / PercentMaximumHealthDamage·HPToTier2/3 상수
-- [x] **actual sim integration verify (5단계)** — TotalDamage: BonusDamage(`damageVar`) + 대상 maxHp 8%(`:6585`) read 확인 / **`BonusHealthPerCast`/`BonusHealthOnKill` grep 0 → 전투 중 maxHp 증가 미반영 P1** / **`HPToTier2`/`HPToTier3` grep 0 → tier 진화 미반영 P2** / chogath_hp permanentStacks(`:359`) 전투 시작 반영 확인 / **config.heal healVar find 후보에 Chogath heal 변수 없음 → 무의미 info**
+- [x] **actual sim integration verify (5단계)** — TotalDamage: BonusDamage(`damageVar`) + 대상 maxHp 8%(`:6585`) read 확인 / **`BonusHealthPerCast`/`BonusHealthOnKill` → cast loop 사망 처리 직후 maxHp 증가 #208 fix ✅** / **`HPToTier2`/`HPToTier3` grep 0 → tier 진화 미반영 P2** / chogath_hp permanentStacks(`:359`) 전투 시작 반영 확인 / **config.heal healVar find 후보에 Chogath heal 변수 없음 → 무의미 info**
 - [x] **cast path 3종 (PR #129 룰)** — main (single lowest-hp TotalDamage ✅) / OOR (dash 없음 ➖) / recast (carry 없음 ➖). chogath_hp·trait 별개
 - [x] **`traits` frontmatter 각 entry trait helper grep 전수 verify (룰 #16/#19)** — 암흑의 별 `TFT17_DarkStar` `applyDarkStarEffects` (`:2083`) ✅ (Chogath 6명 중) / 싸움꾼 `TFT17_HPTank` `applyBrawlerEffects` (`:2027`) ✅ (Chogath 7명 중)
 - [x] **본문 Lint P1 1건 + P2 1건 등록 → frontmatter `sim_active: partial`** (P1 sim 미반영 → 룰 #15)
-- [ ] (선택) 전투 중 maxHp 증가(P1) / HP tier 진화(P2) sim 도입
+- [x] **전투 중 maxHp 증가(P1) → #208 수정 완료**
+- [ ] (선택) HP tier 진화(P2) sim 도입
 
 ## 관련
 


### PR DESCRIPTION
## 요약

Chogath maxHp fix(#208) 머지 후 chogath.md의 P1 lint 항목을 **resolved**로 갱신. 위키 정확성 동기화 (gragas/leona/briar #206과 동일 패턴).

| P1 → resolved | sim_active |
|--------------|-----------|
| 전투 중 maxHp 영구 증가(BonusHealthPerCast/OnKill) → **#208** | partial (P2 HP tier 진화 잔존) |

## wiki-ingest-verifier 결과

| Tier | 건수 | 처리 |
|------|------|------|
| P0 | 0 | — |
| P1 | 0 | — (#208 코드 완전 정합 확인) |
| P2 | 0 | informational (HP tier P2 표기 정합) |

`#208 수정 완료` 주장이 `combatLoop.ts:6672-6686` 코드와 정합. frontmatter ↔ 본문 ↔ Lint 표 일관. P1만 resolved, P2 HP tier 미반영 유지(partial 적절). docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)