### PR TITLE
fix(sim): 그레이브즈 Meltthrough 인접 적 armor/MR 2배 감소 미반영 수정 (graves-armory #211)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -5434,6 +5434,7 @@ export function simulateCombat(
     }
 
     // 최신상 Meltthrough — 매 1초 graves 주변 2hex 적군 armor/MR -N (영구 누적, floor 0).
+    // raw desc: "doubled for adjacent enemies" → 인접(hexDistance===1)은 2배 감소.
     if (tick > 0 && tick % TICKS_PER_SECOND === 0) {
       for (const u of allUnits) {
         if (u.state === 'dead') continue;
@@ -5441,9 +5442,11 @@ export function simulateCombat(
         const enemyTeam = u.team === 'player' ? enemies : playerUnits;
         for (const e of enemyTeam) {
           if (e.state === 'dead') continue;
-          if (hexDistance(u.position, e.position) > 2) continue;
-          e.stats.armor = Math.max(0, e.stats.armor - u.gravesMeltthroughArmorMR);
-          e.stats.magicResist = Math.max(0, e.stats.magicResist - u.gravesMeltthroughArmorMR);
+          const dist = hexDistance(u.position, e.position);
+          if (dist > 2) continue;
+          const reduction = dist === 1 ? u.gravesMeltthroughArmorMR * 2 : u.gravesMeltthroughArmorMR;
+          e.stats.armor = Math.max(0, e.stats.armor - reduction);
+          e.stats.magicResist = Math.max(0, e.stats.magicResist - reduction);
         }
       }
     }

--- a/tests/unit/simulator/graves-meltthrough-adjacent.test.ts
+++ b/tests/unit/simulator/graves-meltthrough-adjacent.test.ts
@@ -1,0 +1,55 @@
+/**
+ * 회귀 가드 — 최신상 Meltthrough 인접 적 2배 armor/MR 감소.
+ *
+ * raw desc: "Every second, reduce the Armor of enemies within 2-hexes by 4,
+ *   doubled for adjacent enemies." → 인접(hexDistance===1) 적은 -8, 2칸 적은 -4.
+ * 버그: combatLoop.ts Meltthrough 블록이 hexDistance>2 가드만 있고 인접 2배 분기 없어
+ *   범위 내 적 균등 -4. 인접 교전(맹공 프레임) 시 실제 방어감소 절반.
+ * fix: dist===1 시 gravesMeltthroughArmorMR × 2 적용.
+ *
+ * graves-armory.md mechanic 검증 (PR #211) lint P1 발견 → sim fix.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+const apGraves = champions.find(c => c.apiName === 'TFT17_Graves')!;
+const dummyEnemy = champions.find(c => c.apiName === 'TFT17_Aatrox')!;
+
+function placed(c: RawChampion, q: number, r: number, starLevel = 2): PlacedChampion {
+  return { champion: c, starLevel, position: { q, r }, items: [] };
+}
+
+function runWith(upgrades: string[], enemies: PlacedChampion[]) {
+  const team: PlacedChampion[] = [placed(apGraves, 0, 0)];
+  return simulateCombat(team, enemies, {
+    seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    playerGravesUpgrades: upgrades,
+  });
+}
+
+describe('Meltthrough 인접 2배 (PR #211 lint P1 fix)', () => {
+  it('Meltthrough flag → armorMR reduction=4 set', () => {
+    const grav = runWith(['Meltthrough'], [placed(dummyEnemy, 1, 0)]).playerUnits[0];
+    expect(grav.gravesMeltthroughArmorMR).toBe(4);
+  });
+
+  it('인접(dist=1) 적은 armor/MR 매초 8 감소 (2배 — fix 전이면 4)', () => {
+    // graves(0,0)·인접 적(1,0) 모두 교전 거리라 고정 → 결정론적 -8/초.
+    // (2칸 적은 1초 내 graves 로 이동해 인접되므로 대조군 불안정 → 인접 -8 자체로 분기 검증.)
+    const melt = runWith(['Meltthrough'], [placed(dummyEnemy, 1, 0)]);
+    const id = melt.enemyUnits[0].id;
+    const stat = (t: number, key: 'armor' | 'magicResist') =>
+      melt.snapshots.find(s => s.tick === t)?.units[id]?.stats[key];
+    const a0 = stat(0, 'armor')!;
+    const a30 = stat(30, 'armor')!;
+    const a60 = stat(60, 'armor')!;
+    // ArmorMRReduction(4) × 2 = 8/초 영구 감소 (인접). fix 전 균등 -4 였음.
+    expect(a0 - a30).toBe(8);
+    expect(a30 - a60).toBe(8);
+    // magicResist 도 동일하게 2배 적용.
+    expect(stat(0, 'magicResist')! - stat(30, 'magicResist')!).toBe(8);
+  });
+});


### PR DESCRIPTION
## 요약

최신상(GravesTrait) 무기고 **Meltthrough(용융 관통)** 의 인접 적 2배 방어감소가 sim 에 미반영된 P1 버그 수정.

raw desc: `Every second, reduce the Armor of enemies within 2-hexes by 4, **doubled for adjacent enemies**.`

기존 sim(`combatLoop.ts` Meltthrough 블록)은 `hexDistance > 2` 가드만 두고 범위 내 적에게 **균등 −4** 적용 → 인접(`hexDistance===1`) 적의 실제 −8 대비 **방어감소 절반**. 맹공(CloseQuarters) 프레임 인접 교전 시 오차 큼.

## 변경

- `combatLoop.ts` — `dist === 1` 시 `gravesMeltthroughArmorMR × 2` 적용 분기 추가 (armor + magicResist 동일)
- `graves-meltthrough-adjacent.test.ts` — 회귀 가드. 인접 적 armor/MR **매초 −8**(2배) 결정론적 검증 (fix 전 −4)

## 검증

- ✅ 회귀 가드 통과 + negative 검증 (fix 제거 시 `expected 4 to be 8` 실패 확인)
- ✅ 전체 **921 pass / 7 skip, 회귀 0** (Meltthrough+인접 graves 시나리오만 영향, golden snapshot 무영향)
- ✅ lint 0 error / typecheck / build

## 발견 경위

`graves-armory.md` mechanic 무기고 55종 전수 검증(#211)에서 발견한 P1.

## 후속 (별도 PR)

- diff-cache 재생성 (engineSha 갱신 — 본 PR 머지 후)
- `graves-armory.md` 위키 정정: Meltthrough P1 resolved + **LaserBallistics2/3 진단 정정**. #211 은 LB2/3 미구현을 P1 으로 기재했으나, 검증 결과 LB2/3 는 게임 무기고 트리에 도달 불가능한 placeholder(lolchess 실게임 보상표 단일 tier 확인, raw 의 잘린 데이터) → sim 미구현이 정합. Frame/Backup 동류 ➖ 로 정정 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)