### PR TITLE
chore(calibration): diff 회귀 캐시 재생성 — Meltthrough fix 반영 (engineSha c8decde)

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-06-08T03:21:45.339Z",
+  "computedAt": "2026-06-10T01:49:15.623Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "8527125ab95b1c8b2f795439248518fbada177db",
+  "engineSha": "c8decdeb8cc07949b6e79996590cc8c8f70959ef",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-06-08T03:21:46.920Z",
+  "computedAt": "2026-06-10T01:49:17.355Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "8527125ab95b1c8b2f795439248518fbada177db",
+  "engineSha": "c8decdeb8cc07949b6e79996590cc8c8f70959ef",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [


### PR DESCRIPTION
## 요약

PR #212 (Meltthrough 인접 2배 sim fix) 머지 후 diff 회귀 캐시 engineSha 통일.

## 변경

- `diff-game-20260423-001.json` / `diff-game-20260424-001.json` — `engineSha` `8527125`(#209) → `c8decde`(#212), `computedAt` 갱신
- **rounds 데이터 불변** — 두 게임에 Meltthrough graves 인접 시나리오 없어 회귀 결과 무영향

## 재생성 방법

`DIFF_GAME_ID=<gid> npx vitest run tests/calibration/compute-diff-cache.test.ts` (각 게임)

🤖 Generated with [Claude Code](https://claude.com/claude-code)