### PR TITLE
docs(wiki): graves-armory.md — Meltthrough resolved + LaserBallistics2/3 진단 철회 (#212)

### DIFF
--- a/docs/wiki/mechanics/graves-armory.md
+++ b/docs/wiki/mechanics/graves-armory.md
@@ -5,8 +5,8 @@ api_name: TFT17_GravesTrait
 display_name_kr: 최신상 무기고
 parent_entity: "[[graves]]"
 current_patch_status: active
-sim_active: partial   # 무기고 55종 중 49종 sim 구현 (Frame 3종 + stat 가산 ~15종 + flag/hook 메커닉 ~31종). LaserBallistics2/3 HANDLERS 누락 미구현(P1) + Meltthrough 인접 2배 부분(P1). Phase 1 applyGravesFrameEffects(:2359) + Phase 2 stat map(:2440~) + Phase 3A/B/C flag setter(:2462~) + 평타/피격/처치/tick hook. 미구현 4종: FrameDefense/FrameOffense/FrameSupport(게임 내 "선택 금지" placeholder, raw 미구현) + Backup(효과 없음, 구현 불요). 부분: GravBooster2 동상(chill) raw 미정의 → 미구현(NumAttacks 3 본체는 구현). 별개: graves 평타 원뿔 투사체 passive 는 무기고 아닌 champion ability — [[graves]] P1
-last_verified: 2026-06-08
+sim_active: partial   # 무기고 raw 55 apiName = 게임 실존 49종 전부 sim 구현 (Frame 3종 + stat 가산 ~15종 + flag/hook 메커닉 ~31종) + placeholder 6종(게임 미존재, sim 미구현이 정합). Phase 1 applyGravesFrameEffects(:2359) + Phase 2 stat map(:2440~) + Phase 3A/B/C flag setter(:2462~) + 평타/피격/처치/tick hook. placeholder 6종: FrameDefense/FrameOffense/FrameSupport(게임 내 "선택 금지" placeholder, raw 미구현) + Backup(효과 없음, 구현 불요) + LaserBallistics2/3(게임 무기고 트리 미존재 — lolchess 실게임 보상표 단일 tier 확인, raw 의 잘린 tier 데이터·icon off-by-one). 부분: GravBooster2 동상(chill) raw 미정의 → 미구현(NumAttacks 3 본체는 구현). 별개: graves 평타 원뿔 투사체 passive 는 무기고 아닌 champion ability — [[graves]] P1
+last_verified: 2026-06-10
 sources:
   - "https://lolchess.gg/rewards/set17/factory-new (무기고 무기 목록 — 한글명/효과)"
   - "public/data/tft_set17_items.json (TFT17_GravesTrait_* 55종 — apiName/desc/변수)"
@@ -21,12 +21,12 @@ related:
 
 ## 요약
 
-**최신상 (`TFT17_GravesTrait`)** 전용 메커니즘. 전투에 참여한 후 무기고를 열어 **가장 강한 아군 그레이브즈 1명**에게 영구 업그레이드를 구매한다. 무기 **55종** (Frame 6종 + 능치/메커닉 49종).
+**최신상 (`TFT17_GravesTrait`)** 전용 메커니즘. 전투에 참여한 후 무기고를 열어 **가장 강한 아군 그레이브즈 1명**에게 영구 업그레이드를 구매한다. raw apiName **55종** (Frame 6종 + 비-Frame 49종) = **게임 실존 49종 구현 + placeholder 6종**(Frame 3 + Backup + LaserBallistics2/3 — 상세 아래). ⚠️ raw 분류의 "비-Frame 49" 와 "게임 실존 구현 49" 는 우연히 같은 수치이나 다른 집합(전자는 LB2/3·Backup placeholder 포함, 후자는 Frame 활성 3 포함).
 
-- sim 은 **"보유한 업그레이드"를 입력으로 받아** 가장 강한 Graves 에게 적용 (`gravesUpgrades` 배열). 51종 구현, 4종 미구현(placeholder).
+- sim 은 **"보유한 업그레이드"를 입력으로 받아** 가장 강한 Graves 에게 적용 (`gravesUpgrades` 배열). 게임 실존 49종 구현, placeholder 6종(게임 미존재 — Frame 3 + Backup + LaserBallistics2/3).
 - ⚠️ **라운드 카운터(3회마다 +1, "다음 업그레이드: ?라운드 후")는 sim 미구현 — 의도적**. 시뮬레이터는 **단일 전투** 단위라, "언제/몇 라운드마다 구매하나"는 메타게임 영역(전투 시뮬 범위 밖). [[graves]] Chogath chogath_hp 와 동일 패턴 (라운드 간 누적분만 입력).
 
-> 🎯 **무기고는 graves ingest(#193) 당시 "개요만" 검증됐으나, 이후 Phase 2/3A/3B/3C 로 대거 구현됨** (현 51/55). 본 페이지가 55종 전수 검증의 single source.
+> 🎯 **무기고는 graves ingest(#193) 당시 "개요만" 검증됐으나, 이후 Phase 2/3A/3B/3C 로 대거 구현됨** (게임 실존 49종 전부 구현 / placeholder 6). 본 페이지가 55종 전수 검증의 single source.
 
 > ⚠️ **set17 entity confirm**: `TFT17_GravesTrait` apiName + `node -e` 로 무기 55종 (`TFT17_GravesTrait_*`) 확인.
 
@@ -78,7 +78,7 @@ related:
 |------|------|:---:|
 | APRounds / 2 | 철갑탄 — 적 방어력 30/60% 무시 (`armorPen`) | ✅ |
 | **RipperBullets / 2** | **파쇄 탄환 — 평타 시 적 armor/MR −1/−2** (`gravesRipperReduce` flag+hook) | ✅ |
-| Meltthrough | 용융 관통 — 매초 2칸 내 armor/MR−4 | ⚠️ 부분 (**인접 2배 미구현** — sim 균등 −4, `:5444` hexDistance===1 분기 없음) |
+| Meltthrough | 용융 관통 — 매초 2칸 내 armor/MR−4, **인접 적 2배(−8)** | ✅ (인접 2배 `hexDistance===1` 분기 PR #212 구현) |
 
 ### ⑤ 방어 / 생존 (Phase 2/3A)
 
@@ -107,8 +107,8 @@ related:
 |------|------|:---:|
 | Buckshot / 2 / 3 | 산탄 사격 — 투사체+2/4/6, 확산+20/30/40% (`:2877` hook) | ✅ |
 | FragmentationRounds / 2 | 파편탄 — 평타 시 주변 파편 N개 | ✅ |
-| LaserBallistics | 레이저 탄도학 — 평타 관통 + 대상당 피해 감소 (LB1만) | ✅ |
-| **LaserBallistics2 / 3** | 레이저 탄도학+/++ — 관통 2/3칸 | ❌ **미구현** (HANDLERS·APPLY_ORDER 누락 — LB1만 등록) |
+| LaserBallistics | 레이저 탄도학 — 평타 관통 + 대상당 피해 감소 (Buckshot 라인 6코 단일 말단) | ✅ |
+| ~~LaserBallistics2 / 3~~ | 레이저 탄도학+/++ — 관통 2/3칸 | ➖ **게임 미존재 placeholder** (무기고 트리 미존재 — lolchess 실게임 보상표 단일 tier 확인, raw 의 잘린 tier 데이터·icon off-by-one. Frame/Backup 동류) |
 | Choke | 초크 — 투사체 분산−75% | ✅ |
 | BlastRadius / 2 / 3 | 폭발 반경 — 2차 폭발 반경+N칸 | ✅ |
 | AimAssistant | 조준 보정 — 거리 1칸당 추가 피해 | ✅ |
@@ -134,31 +134,33 @@ related:
 ✅ **활성** (49/55):
 - Frame 3종 (맹공/위력/사수=DoubleTap 25% 2회)
 - stat 가산 ~15종 (PrecisionScope/Fission/LeechingImplants/Heartseeker/Tankbuster/Coolant/APRounds/SheerMass/HeavyPlating)
-- flag+hook 메커닉 ~31종 (RipperBullets 파쇄/ReactiveArmor/EmergencyShielding/Nanomachines/Buckshot/LaserBallistics(LB1)/Frag/BlastRadius/RevUp/GravBooster/LatentExplosion/Shockwave/VoidCoefficient/Choke/AimAssistant/SympatheticDetonation 등)
+- flag+hook 메커닉 ~31종 (RipperBullets 파쇄/ReactiveArmor/EmergencyShielding/Nanomachines/Buckshot/LaserBallistics(단일 tier)/Meltthrough(인접 2배)/Frag/BlastRadius/RevUp/GravBooster/LatentExplosion/Shockwave/VoidCoefficient/Choke/AimAssistant/SympatheticDetonation 등)
+
+✅ **resolved**:
+- ~~P1 Meltthrough 인접 2배~~ → **PR #212 sim fix** (`hexDistance===1` 시 `gravesMeltthroughArmorMR × 2` = −8 분기). 회귀 가드 `graves-meltthrough-adjacent.test.ts` (인접 적 armor/MR 매초 −8)
 
 ⚠️ **미반영 / 부분** (Lint 후보):
-- **P1**: LaserBallistics2/3 미구현 — `GRAVES_STAT_UPGRADE_HANDLERS`/`APPLY_ORDER` 에 LB1만 등록, LB2/3 누락 → 관통 효과 0 (LB1 동시 미보유 시)
-- **P1**: Meltthrough 인접 2배 미구현 — sim 균등 −4 (`:5444` hexDistance===1 분기 없음). 인접 교전 시 실제 −8 대비 절반
 - **P2**: GravBooster2 동상(chill) — raw 미정의, NumAttacks 3 본체만 구현
 - ➖ FrameDefense/FrameOffense/FrameSupport — 게임 내 선택 금지 placeholder (sim 미구현이 정합, raw 자체 미구현)
 - ➖ Backup — 효과 없음 (구현 불요)
+- ➖ **LaserBallistics2/3** — 게임 무기고 트리 미존재 placeholder (lolchess 실게임 보상표 단일 tier 확인 — #211 의 "P1 HANDLERS 누락 미구현" 진단 **철회**, raw 의 잘린 tier 데이터·icon off-by-one). Frame/Backup 동류 = sim 미구현이 정합
 - ➖ **라운드 카운터** (3회마다 +1, "다음 업그레이드: N라운드 후") — 메타게임, 단일 전투 시뮬 범위 밖 (의도적 미구현, Lint 아님)
 
 ## Lint 신규 등록 후보
 
 | # | 항목 | 의미 | Tier | 적용 분기 (룰 #17) | 처리 |
 |---|------|------|------|---------------------|------|
-| P1 | LaserBallistics2/3 미구현 | `GRAVES_STAT_UPGRADE_HANDLERS`/`APPLY_ORDER` 에 LB1만 등록, LB2(관통 2칸·감소 50%)/LB3(관통 3칸·감소 40%) 누락 → 선택 시 `gravesLaserPenetrationHexes`=0 → 관통 미발동 | **P1** | (c) flag setter handler 추가 (LB1 패턴 동형, 값만 tier별) + `APPLY_ORDER` 등록 | LB2/3 선택 시 sim 효과 0. fix 단순 (handler 2개 추가) |
-| P1 | Meltthrough 인접 2배 미반영 | desc "인접한 적에게 두 배". sim `:5444` hexDistance>2 가드로 2칸 내 균등 −4, hexDistance===1 시 2배(−8) 분기 없음 | **P1** | per-target — hexDistance===1 시 `2 × gravesMeltthroughArmorMR` | 인접 교전 시 방어감소 절반. 맹공(CloseQuarters) 조합 오차 큼 |
+| ➖ 철회 | ~~LaserBallistics2/3 미구현~~ | #211 은 `HANDLERS`/`APPLY_ORDER` 누락을 P1 으로 기재했으나, **LB2/3 는 게임 무기고 트리 미존재 placeholder** (lolchess 실게임 보상표 단일 tier 확인, raw 의 잘린 tier 데이터·icon off-by-one) | ~~P1~~ | 해당 없음 (게임 미존재) | **진단 철회** — sim 미구현이 정합. Frame/Backup 동류. 교훈: tiered weapon raw apiName 존재 ≠ 게임 도달 가능 (트리 도달성 확인 필수) |
+| ✅ resolved | ~~Meltthrough 인접 2배 미반영~~ | desc "doubled for adjacent enemies". sim `:5444` hexDistance>2 가드로 2칸 내 균등 −4, hexDistance===1 시 2배(−8) 분기 없었음 | ~~P1~~ | per-target — hexDistance===1 시 `2 × gravesMeltthroughArmorMR` | **PR #212 fix 완료** (−8 분기 + 회귀 가드 + diff-cache #213) |
 | P2 | GravBooster2 동상(chill) 미반영 | desc "처치 관여 시 돌진+AS". GravBooster2 NumAttacks 3 본체 구현, lolchess UI 의 "동상" 부가효과는 raw 미정의 → 미구현 | **P2** | 해당 없음 (raw 미정의) | raw 에 chill 변수 없어 추정 불가. patch raw 확인 후 |
 | info | 라운드 카운터 미구현 | 무기고 구매 타이밍(3회마다 라운드+1)은 메타게임 진행 로직 | info | 해당 없음 (전투 시뮬 범위 밖) | 단일 전투 시뮬 설계상 정상 — 구매 결과(`gravesUpgrades`)만 입력 |
 
-> 📌 **무기고 49/55 sim 구현 — Frame 3종 + stat 가산 + flag/hook 메커닉**. `partial` 사유는 LaserBallistics2/3 미구현(P1) + Meltthrough 인접 2배(P1) + GravBooster2 동상(P2) + 게임 placeholder 3종(raw 미구현 정합) + Backup(효과없음). **실질 메커닉은 대부분 구현**. 라운드 카운터는 의도적 범위 밖.
+> 📌 **무기고 게임 실존 49종 전부 sim 구현 — Frame 3종 + stat 가산 + flag/hook 메커닉** (raw 55 apiName = 49 구현 + placeholder 6). `partial` 사유는 GravBooster2 동상(P2) + 게임 placeholder 6종(Frame 3 + Backup + LaserBallistics2/3, raw 미구현·미존재 정합) + graves 평타 passive 별개([[graves]] P1). **Meltthrough 인접 2배는 PR #212 resolved**. 라운드 카운터는 의도적 범위 밖.
 
 ## Lint 체크리스트
 
 - [x] **set17 entity 소속 0단계** — `node -e` 로 `TFT17_GravesTrait_*` 55종 확인 (apiName/한글명/desc)
-- [x] entity-wide grep `GravesTrait` + 55종 suffix sim hit 측정 — base suffix hit 51 이나 **tier별 핸들러 전수 확인 필수**(LaserBallistics hit 는 LB1만, LB2/3 는 `HANDLERS` 누락 — hit 측정이 tier 구분 못 함). 실구현 49종 / 미구현 6종(Backup, Frame placeholder 3, LaserBallistics2/3)
+- [x] entity-wide grep `GravesTrait` + 55종 suffix sim hit 측정 — base suffix hit 51 이나 **tier별 핸들러 전수 확인 필수**(LaserBallistics hit 는 단일 tier 만 — hit 측정이 tier 구분 못 함). 실구현 49종 / placeholder 6종(Backup, Frame placeholder 3, **LaserBallistics2/3 게임 트리 미존재**). ⚠️ 교훈: raw 에 tier apiName(LB2/3) 존재해도 **게임 무기고 트리 도달 가능 여부**는 별도 확인 — lolchess 실게임 보상표 / 트리 다이어그램 대조 (raw 에 잘린 tier 데이터 잔존 가능)
 - [x] **함수 컨텍스트 read (2단계)** — Phase 1 `applyGravesFrameEffects` (`:2359`) + Phase 2 stat map (`:2440-2460`, PrecisionScope/Fission/Heartseeker/APRounds/SheerMass/LeechingImplants/HeavyPlating 직접 가산) + Phase 3A/B/C flag setter (`:2462-2575`, RipperBullets/Buckshot/RevUp/GravBooster/Meltthrough/VoidCoefficient/Choke 등)
 - [x] **flag → hook 작동 verify** — `gravesBuckshotProjectiles` (`:2877` 소비) / `gravesLatentStored` (`:2898/2950/2998`) / `gravesRipperReduce` (`:2428` 주석 + 평타 hook) 실제 효과 발동 확인 (flag set 만이 아닌 hook 소비)
 - [x] **변수 값 정합** — PrecisionScope AD+12/24/36%·range+1/2/3 / Heartseeker crit+10/25/40% / APRounds armorPen 30/60% / RipperBullets armor/MR−1/−2 / RevUp AS+8/15% max80/150% / Buckshot 투사체+2/4/6 — raw items.json effects 대조


### PR DESCRIPTION
## 요약

graves 무기고 전수 검증(#211)에서 기재한 P1 2건을 sim fix 작업 중 정정.

## 변경

### ① Meltthrough 인접 2배 P1 → ✅ resolved
PR #212 sim fix (`hexDistance===1` 시 armor/MR ×2 = −8). 표/Lint 후보/partial 사유 갱신.

### ② LaserBallistics2/3 "미구현 P1" → ➖ 진단 철회
검증 결과 LB2/3 는 **게임 무기고 트리 미존재 placeholder**:
- `factoryNewTree.ts`: LaserBallistics 가 Buckshot 라인 **6코 단일 말단**(LB2/3 노드 부재). 다른 tiered 무기는 모두 변종 노드 존재 — LaserBallistics만 단일
- lolchess 실게임 보상표: 단일 tier 확인 (LB+/++ 없음)
- raw json: LB2/3 effects 정의되어 있으나 name "+/++" + icon off-by-one = 잘린 tier 데이터
- → Frame/Backup 동류. **sim 미구현이 정합**. handler 추가는 게임에 없는 노드를 만드는 오류였을 것

### 숫자 정합
raw 55 = 게임 실존 49 구현 + placeholder 6(Frame 3 + Backup + LB2/3). 기존 "49 + 미구현 4" 에서 LB2/3 2개 붕 뜨던 산식 교정.

## 검증

`wiki-ingest-verifier` dispatch — **P0 0 / P1 0**. Meltthrough(`combatLoop.ts:5447` dist===1 분기) + LB2/3(factoryNewTree.ts 노드 부재) 코드 ground truth verify 완료. P2 wording 1건 본 PR 반영.

## 교훈

raw tier apiName 존재 ≠ 게임 트리 도달 가능 — tiered weapon 은 트리 도달성 별도 확인(lolchess 보상표/트리 대조). 체크리스트에 기재.

🤖 Generated with [Claude Code](https://claude.com/claude-code)