### PR TITLE
test(sim): 자야 lethal opening auto bounce 회귀 가드 (codex P2 PR #219)

### DIFF
--- a/tests/unit/simulator/xayah-bounce-passive.test.ts
+++ b/tests/unit/simulator/xayah-bounce-passive.test.ts
@@ -28,6 +28,18 @@ function xayahDamage(enemyPositions: Array<[number, number]>): { total: number; 
   return { total: x.totalDamageDealt, enemiesHit };
 }
 
+// lethal 시나리오용 1-HP 더미 — raw hp 만 1 로 덮어쓴 클론 (★1 = base 스케일 ×1 → maxHp≈1).
+// 카탈로그 raw 객체 변형 금지 위해 structuredClone (데이터 보존 규칙).
+const dummyBase: RawChampion = (() => {
+  const c = structuredClone(tank);
+  c.stats.hp = 1;
+  return c;
+})();
+
+function dummy(q: number, r: number): PlacedChampion {
+  return { champion: dummyBase, starLevel: 1, position: { q, r }, items: [] };
+}
+
 describe('자야 깃털 bounce 패시브', () => {
   it('bounce 가 primary 외 다른 적도 적중 — ★2 numBounce=2 → 3명 전원 피해', () => {
     // numEnemies(★2)=3, numBounce=2 → primary 1 + bounce 2 = 3명 모두 피해.
@@ -41,5 +53,22 @@ describe('자야 깃털 bounce 패시브', () => {
     // 적 1명이면 bounce 대상 없음 → primary 데미지만 (enemiesHit=1).
     const single = xayahDamage([[6, 3]]);
     expect(single.enemiesHit).toBe(1);
+  });
+
+  // codex P2 (PR #219) 회귀 가드: 평타가 primary 를 죽이면 사망 처리가 target.state='dead'
+  // 로 만들어, 과거엔 outer 가드가 bounce 까지 skip → 마무리 평타가 단일 타겟처럼 동작했다.
+  // bounce 는 다른 적을 치므로 primary 사망(lethal auto) 시에도 발동해야 한다.
+  it('lethal opening auto — primary 가 base auto 로 죽어도 같은 tick 에 bounce 2명 발동', () => {
+    // 3명 모두 1-HP 더미: 어느 적이 primary 든 base auto 로 즉사하고, bounce(★2 numBounce=2)
+    // 가 나머지 2명을 같은 tick 에 처치. 버그(lethal 시 bounce skip) 면 그 tick bounce 사망=0.
+    const r = simulateCombat([placed(xayah, 0, 0)], [dummy(6, 2), dummy(6, 3), dummy(6, 4)], {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const deaths = r.logs.filter(l => l.type === 'death');
+    expect(deaths.length).toBeGreaterThan(0);
+    // 첫 사망 tick = primary 가 base auto 로 죽는 시점 (bounce 대상은 이 평타로만 죽음).
+    const t0 = Math.min(...deaths.map(d => d.tick));
+    const bounceDeathsAtT0 = deaths.filter(d => d.tick === t0 && d.message.includes('bounce')).length;
+    expect(bounceDeathsAtT0).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## 배경
PR #219 에서 codex P2 finding 을 수정했다: **평타가 primary 를 죽이면** 사망 처리가 `target.state='dead'` 로 만들어, 과거 outer 가드가 bounce 까지 skip → 마무리 평타가 단일 타겟처럼 동작 (under-damage). `5b23cd5` 에서 bounce 를 primary 생사와 분리해 해결.

codex 가 "회귀 테스트를 새 PR 로 올렸다"(commit `52f4aee`)고 보고했으나 **실제로는 commit/PR/브랜치 모두 push 되지 않음** (codex 샌드박스 내에서만 생성 후 휘발). 즉 머지된 P2 수정이 테스트로 잠겨있지 않은 상태 → 본 PR 로 가드 추가.

## 테스트 설계
- 적 **3명 모두 1-HP 더미** (raw hp=1 클론, ★1 = base 스케일). 어느 적이 primary 든 base auto 로 즉사.
- bounce(★2 `numBounce=2`)가 나머지 2명을 **같은 tick** 에 처치.
- assert: **첫 사망 tick 의 bounce 사망 수 >= 2**.

## red/green 검증
- 버그 재현(bounce 에 `target.state !== 'dead'` 가드 재주입) 시 → `bounceDeathsAtT0 = 0` → **fail** 확인.
- 수정 상태 → 2 → **pass**. (단순 "피해 입음" assert 는 primary 사망 후 재타겟 평타로도 충족돼 버그를 못 잡으므로 same-tick 사망으로 판별.)

## 게이트
`pnpm lint` (exit 0) / `pnpm typecheck` / `pnpm test` / `pnpm build` 모두 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)