### PR TITLE
fix(sim): 진(Jhin) active damageVar APDamage→ADDamage (ingest #227 P0)

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-06-12T04:29:26.552Z",
+  "computedAt": "2026-06-12T09:05:10.322Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "3f2215bb76d14fb482711e0b53769204d5c4b09e",
+  "engineSha": "18f282fe20064f1c3de3257076a437a6434c7fa7",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-06-12T04:29:28.044Z",
+  "computedAt": "2026-06-12T09:05:11.762Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "3f2215bb76d14fb482711e0b53769204d5c4b09e",
+  "engineSha": "18f282fe20064f1c3de3257076a437a6434c7fa7",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [
@@ -2903,13 +2903,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 8933,
-          "simMean": 12839.500426149458,
-          "simMedian": 12954.836210388607,
+          "simMean": 12464.892199155618,
+          "simMedian": 12583.965273792242,
           "simRange": [
-            11979.01410208561,
-            13905.908098688056
+            11477.344938512617,
+            13405.477034142255
           ],
-          "diffPct": 0.4373111414026036
+          "diffPct": 0.3953758198987594
         },
         {
           "hex": {
@@ -2933,13 +2933,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 1981,
-          "simMean": 2930.3933903023208,
-          "simMedian": 2995.2172382943077,
+          "simMean": 3668.3520195914984,
+          "simMedian": 3615.1350453047576,
           "simRange": [
-            2326.6726951682385,
-            3276.2513844699124
+            3291.123066051929,
+            4310.729854056226
           ],
-          "diffPct": 0.4792495660284305
+          "diffPct": 0.8517678039331138
         },
         {
           "hex": {
@@ -2948,13 +2948,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 1439,
-          "simMean": 62.29083391807708,
-          "simMedian": 62.025887000538944,
+          "simMean": 64.91403781356446,
+          "simMedian": 67.61376284008372,
           "simRange": [
-            50.620970686742105,
-            73.99735415566599
+            50.983983938306835,
+            82.14468782118601
           ],
-          "diffPct": -0.9567124156232959
+          "diffPct": -0.9548894803241387
         },
         {
           "hex": {
@@ -2963,13 +2963,13 @@
           },
           "championId": "TFT17_Rammus",
           "actual": 1235,
-          "simMean": 96.06726942704661,
-          "simMedian": 102.46118457558939,
+          "simMean": 117.92711332067749,
+          "simMedian": 112.80547536349638,
           "simRange": [
-            46.41966820299467,
-            154.53070705464293
+            49.24872889609595,
+            172.33681190025294
           ],
-          "diffPct": -0.9222127373060351
+          "diffPct": -0.9045124588496538
         }
       ],
       "survivors": [
@@ -3104,13 +3104,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 10628,
-          "simMean": 12191.454658861208,
-          "simMedian": 12283.583937289448,
+          "simMean": 11648.642520274147,
+          "simMedian": 11716.031218406402,
           "simRange": [
-            11215.40297738382,
-            12660.605901653138
+            10879.644248778353,
+            12161.292700010388
           ],
-          "diffPct": 0.14710713764219122
+          "diffPct": 0.09603335719553506
         },
         {
           "hex": {
@@ -3119,13 +3119,13 @@
           },
           "championId": "TFT17_Jhin",
           "actual": 5725,
-          "simMean": 2688.693674314224,
-          "simMedian": 2651.096870053954,
+          "simMean": 3259.7729321849156,
+          "simMedian": 3288.1940071195318,
           "simRange": [
-            2585.989888551261,
-            3033.0247271247413
+            3111.106945163604,
+            3455.3960475555355
           ],
-          "diffPct": -0.5303591835258997
+          "diffPct": -0.4306073480899711
         },
         {
           "hex": {
@@ -3134,13 +3134,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 2263,
-          "simMean": 2557.7833912986166,
-          "simMedian": 2537.5737554924654,
+          "simMean": 2329.9336538471725,
+          "simMedian": 2362.470630178228,
           "simRange": [
-            2269.977554848385,
-            2815.0468585377453
+            2007.2067391496737,
+            2564.321719726091
           ],
-          "diffPct": 0.13026221444923403
+          "diffPct": 0.029577398960306027
         },
         {
           "hex": {
@@ -3149,13 +3149,13 @@
           },
           "championId": "TFT17_Nunu",
           "actual": 1626,
-          "simMean": 192.38395316909697,
+          "simMean": 178.09853082163454,
           "simMedian": 186.711864453936,
           "simRange": [
-            0,
-            297.4498908300575
+            108.77697663477234,
+            223.32203177257162
           ],
-          "diffPct": -0.8816826856278617
+          "diffPct": -0.890468308227777
         },
         {
           "hex": {
@@ -3164,13 +3164,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 1353,
-          "simMean": 57.669654395687004,
-          "simMedian": 62.54327583027815,
+          "simMean": 55.76073104986405,
+          "simMedian": 57.01556733117525,
           "simRange": [
-            44.98106213956392,
-            64.88666527351475
+            37.00689836366129,
+            73.59375359058988
           ],
-          "diffPct": -0.9573764564702978
+          "diffPct": -0.9587873384701671
         }
       ],
       "survivors": [
@@ -3184,9 +3184,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 90.62968742678335,
+          "simMeanHp": 90.06266442176543,
           "aliveMismatch": true,
-          "hpDiffPoints": 90.62968742678335
+          "hpDiffPoints": 90.06266442176543
         },
         {
           "hex": {
@@ -3198,9 +3198,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 20.848481227172904,
+          "simMeanHp": 23.560453063641738,
           "aliveMismatch": true,
-          "hpDiffPoints": 20.848481227172904
+          "hpDiffPoints": 23.560453063641738
         },
         {
           "hex": {
@@ -3226,9 +3226,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 79.52172491173533,
+          "simMeanHp": 79.73293200893083,
           "aliveMismatch": true,
-          "hpDiffPoints": 79.52172491173533
+          "hpDiffPoints": 79.73293200893083
         },
         {
           "hex": {
@@ -3240,9 +3240,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 84.19404762539834,
+          "simMeanHp": 84.9293650629383,
           "aliveMismatch": true,
-          "hpDiffPoints": 84.19404762539834
+          "hpDiffPoints": 84.9293650629383
         },
         {
           "hex": {
@@ -3268,9 +3268,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 67.44372198504564,
+          "simMeanHp": 68.54823818499781,
           "aliveMismatch": true,
-          "hpDiffPoints": 67.44372198504564
+          "hpDiffPoints": 68.54823818499781
         },
         {
           "hex": {
@@ -3282,9 +3282,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 93.76698098135275,
+          "simMeanHp": 92.66745611719918,
           "aliveMismatch": true,
-          "hpDiffPoints": 93.76698098135275
+          "hpDiffPoints": 92.66745611719918
         },
         {
           "hex": {
@@ -3296,9 +3296,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 93.53870967186748,
+          "simMeanHp": 93.33870967633783,
           "aliveMismatch": true,
-          "hpDiffPoints": 93.53870967186748
+          "hpDiffPoints": 93.33870967633783
         }
       ],
       "warnings": []
@@ -3319,7 +3319,7 @@
     "pvpRoundCount": 21,
     "winnerMatchRate": 0.7142857142857143,
     "weakSignalRoundCount": 0,
-    "avgPlayerDamageErrorPct": -0.36026495037147205,
+    "avgPlayerDamageErrorPct": -0.3568375353112704,
     "avgSurvivorHpErrorPts": 0.32955537642893223
   }
 }

--- a/src/lib/simulator/systems/ability.ts
+++ b/src/lib/simulator/systems/ability.ts
@@ -250,7 +250,7 @@ export const CHAMPION_ABILITY_PATTERNS: Record<string, AbilityConfig> = {
   // === 5코스트 ===
   TFT17_Bard:        { pattern: 'aoe_circle', radius: 1, dot: { duration: 4 } },  // 비행접시 4초 DOT + 주변 분배
   TFT17_Fiora:       { pattern: 'single', dash: 'to_target', heal: true },  // 급소 돌진 + 회복
-  TFT17_Jhin:        { pattern: 'multi', maxTargets: 3, debuff: { armorReduction: 15, duration: 4 }, hitCount: 4, damageVar: 'APDamage' },  // 잔상 손 4개 × 4회 사격 APDamage
+  TFT17_Jhin:        { pattern: 'multi', maxTargets: 3, debuff: { armorReduction: 15, duration: 4 }, hitCount: 4, damageVar: 'ADDamage' },  // 잔상 손 4개 × 4회 사격 — TotalDamage scaleAD = ADDamage (raw <physicalDamage>). APDamage 는 미미한 부차 변수 (ingest #227 P0 fix)
   TFT17_Blitzcrank:  { pattern: 'aoe_circle', radius: 3, stun: 1.5, stunTargets: 1, damageVar: 'ExplosionDamage' },  // 띄움 1명 + 폭발 3칸
   TFT17_Sona:        { pattern: 'multi', maxTargets: 3, secondaryDamageVar: 'SlamDamage' },  // 파편 DebrisDamage + 5회째 SlamDamage 폭발 + 기절
   TFT17_Vex:         { pattern: 'aoe_circle', radius: 1, damageVar: 'ShadowHandMagicDamage', hitCount: 3 },  // 강화 타격 3회

--- a/tests/unit/simulator/jhin-active-addamage.test.ts
+++ b/tests/unit/simulator/jhin-active-addamage.test.ts
@@ -1,0 +1,43 @@
+/**
+ * 회귀 가드 — 진(Jhin) active '우주 활극' 이 ADDamage(주력 scaleAD) 로 피해.
+ *
+ * 버그 (ingest PR #227 발견, P0): `ability.ts` Jhin config 가 `damageVar: 'APDamage'`
+ * [0,4,6,44] (미미) 를 써서 raw 주력 `ADDamage` [0,41,62,644] (desc <physicalDamage>
+ * TotalDamage scaleAD) 대비 ~10배 under. 동형 multi Kindred(:238)/Xayah(:247)는 ADDamage.
+ * fix: damageVar 'APDamage' → 'ADDamage'.
+ *
+ * ★2 기준: APDamage=6 → cast hit ~5 / ADDamage=62 → cast hit ~50+ (threshold 30 으로 분리).
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+const jhin = champions.find(c => c.apiName === 'TFT17_Jhin')!;
+const tank = champions.find(c => c.apiName === 'TFT17_Shen')!;
+
+function placed(c: RawChampion, q: number, r: number): PlacedChampion {
+  return { champion: c, starLevel: 2, position: { q, r }, items: [] };
+}
+
+describe('진 active 우주 활극 — ADDamage 피해 (P0 회귀 가드)', () => {
+  it('cast 직격이 ADDamage scaleAD 기반 (APDamage 미미값 아님)', () => {
+    const r = simulateCombat([placed(jhin, 0, 0)], [placed(tank, 6, 3), placed(tank, 6, 2), placed(tank, 6, 4)], {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const j = r.playerUnits.find(u => u.champion.apiName === 'TFT17_Jhin')!;
+    // active cast 로그 (우주 활극 시전) 의 per-hit 피해 추출
+    const castHits = r.logs
+      .filter(l => l.type === 'ability' && l.sourceId === j.id && l.message.includes('우주 활극'))
+      .map(l => {
+        const m = l.message.match(/(\d+) 물리 피해/);
+        return m ? Number(m[1]) : 0;
+      });
+    expect(castHits.length).toBeGreaterThan(0);
+    const maxHit = Math.max(...castHits);
+    // ADDamage ★2=62 (mitigated ~44+) vs APDamage ★2=6 (~5). threshold 30 으로 분리.
+    // 버그(APDamage) 시 maxHit ~5 → fail. fix(ADDamage) 시 ~44+ → pass.
+    expect(maxHit).toBeGreaterThan(30);
+  });
+});


### PR DESCRIPTION
## 배경
champion ingest PR #227 (jhin.md) 에서 wiki-ingest-verifier 가 **P0 확정**: Jhin active '우주 활극' 이 `damageVar: 'APDamage'` [0,4,6,44] (미미) 를 써서 raw 주력 `ADDamage` [0,41,62,644] (desc `<physicalDamage>@TotalDamage@(scaleAD)`) 대비 **~10배 under**. 동형 multi pattern Kindred(`:238`)/Xayah(`:247`)는 `ADDamage` 사용 + `detectScaling('APDamage')→'ap'` 오적용.

## 수정
`src/lib/simulator/systems/ability.ts:253` — `damageVar: 'APDamage'` → `'ADDamage'` (1-line). `detectScaling` 도 자동으로 'ad' 정정.

## 검증
- **회귀 가드** `tests/unit/simulator/jhin-active-addamage.test.ts`: Jhin ★2 cast 직격 maxHit > 30 (ADDamage ★2=62 mitigated ~50 / APDamage ★2=6 ~5). **red(6) → green** 확인.
- 전체 **948 pass** / `pnpm lint`(exit 0)·`typecheck`·`build` 통과 — 회귀 0.
- **diff-cache 재생성** (engineSha `18f282f`): game-424 Jhin `simMean 2688.7 → 3259.8` (+21%, actual 5725 근접), avgDmgErr **-36.0% → -35.7%** 개선. game-423 (Jhin 부재) 불변.

## 후속
- 위키 `jhin.md` P0 → resolved 갱신 (별도 PR, wiki-ingest-verifier dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)