### PR TITLE
fix(sim): 티모(Teemo) passive 독 DOT 모델 (ingest #222 P1)

### DIFF
--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6294,6 +6294,28 @@ export function simulateCombat(
                   unit.currentHp = Math.min(unit.maxHp, unit.currentHp + healAmount);
                 }
               }
+              // === 티모: 독 DOT — poisonDamage(scaleAP magic) PoisonDuration 초 동안 중첩 (ingest #222 P1 fix) ===
+              const poisonArr = atkSc.poisonDamage as number[] | undefined;
+              const poisonDur = atkSc.poisonDuration as number | undefined;
+              if (poisonArr && poisonDur && poisonDur > 0) {
+                const poisonApMul = 1 + unit.stats.ap / 100; // scaleAP
+                const poisonRaw = starValue(poisonArr, unit.starLevel) * poisonApMul * (1 + unit.damageAmp);
+                // poison tick(:3531)은 currentHp -= value 로 mitigation 미적용 → 적용 시점에 MR mitigate 후 spread.
+                const poisonTotal = applyResistance(poisonRaw, target.stats.magicResist, unit.stats.magicPen);
+                const pTicks = Math.round(poisonDur * TICKS_PER_SECOND);
+                if (poisonTotal > 0 && pTicks > 0) {
+                  // 중첩: 같은 caster 기존 poison 잔여 합산 + duration refresh (Serpent poison 패턴 차용).
+                  const existingPoison = target.statusEffects.find(e => e.type === 'poison' && e.sourceId === unit.id);
+                  if (existingPoison) {
+                    const residualTotal = (existingPoison.value ?? 0) * existingPoison.remainingTicks;
+                    existingPoison.value = (residualTotal + poisonTotal) / pTicks;
+                    existingPoison.remainingTicks = pTicks;
+                  } else {
+                    target.statusEffects.push({ type: 'poison', sourceId: unit.id, remainingTicks: pTicks, value: poisonTotal / pTicks });
+                  }
+                  unit.totalDamageDealt += poisonTotal; // 즉시 직격(:6289)과 동일하게 dealer 에 귀속
+                }
+              }
             }
           }
 

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -3522,6 +3522,10 @@ function tickStatusEffects(
   time: number,
   logs: CombatLog[],
   tickLogs: CombatLog[],
+  allUnits: CombatUnit[],
+  playerArbiterState: { enemyDeathCount: number },
+  enemyArbiterState: { enemyDeathCount: number },
+  eventBus: EventBus,
 ): void {
   for (const effect of unit.statusEffects) {
     effect.remainingTicks--;
@@ -3529,7 +3533,19 @@ function tickStatusEffects(
       unit.currentHp -= effect.value;
     }
     if (effect.type === 'poison' && effect.value) {
+      // poison DOT — per-tick 으로 victim/dealer 피해 귀속 + lethal 시 source-aware 사망 처리
+      // (codex P1 PR #231: upfront 크레딧 시 만료 전 사망분 over-credit + 사망 미처리 → unit 계속 행동).
       unit.currentHp -= effect.value;
+      unit.totalDamageTaken += effect.value;
+      const poisonSrc = allUnits.find(u => u.id === effect.sourceId);
+      if (poisonSrc) {
+        poisonSrc.totalDamageDealt += effect.value;
+        if (unit.currentHp <= 0 && unit.state !== 'dead') {
+          const srcArb = poisonSrc.team === 'player' ? playerArbiterState : enemyArbiterState;
+          logs.push({ tick, time, type: 'death', sourceId: unit.id, message: `${unit.champion.name} 사망! (${poisonSrc.champion.name}의 중독)` });
+          markTargetDead(poisonSrc, unit, srcArb, eventBus, tick);
+        }
+      }
     }
   }
 
@@ -5652,7 +5668,7 @@ export function simulateCombat(
     for (const unit of allUnits) {
       if (unit.state === 'dead') continue;
 
-      tickStatusEffects(unit, tick, time, logs, tickLogs);
+      tickStatusEffects(unit, tick, time, logs, tickLogs, allUnits, playerArbiterState, enemyArbiterState, eventBus);
 
       // Mordekaiser proc 매 tick — 펄스 발동 / 만료 시 HealRefund / 사망 시 cancel.
       // 가드: 0 (비활성) 일 때 호출 skip → 다른 챔프 perf 손실 없음.
@@ -6313,7 +6329,8 @@ export function simulateCombat(
                   } else {
                     target.statusEffects.push({ type: 'poison', sourceId: unit.id, remainingTicks: pTicks, value: poisonTotal / pTicks });
                   }
-                  unit.totalDamageDealt += poisonTotal; // 즉시 직격(:6289)과 동일하게 dealer 에 귀속
+                  // dealer/victim 피해 귀속은 poison tick(tickStatusEffects)에서 per-tick 처리 (codex P1 PR #231 —
+                  // upfront 크레딧 제거: 만료 전 사망 시 미전달분 over-credit 방지).
                 }
               }
             }

--- a/tests/unit/simulator/teemo-poison-dot.test.ts
+++ b/tests/unit/simulator/teemo-poison-dot.test.ts
@@ -1,0 +1,42 @@
+/**
+ * 회귀 가드 — 티모(Teemo) passive 독 DOT (ingest PR #222 발견, P1).
+ *
+ * 버그: onAttack extraDamage 핸들러가 즉시 추가 마법(hitDamage) 만 적용하고,
+ * 독 DOT (scaling.json poisonDamage scaleAP, poisonDuration 6초, 중첩) 은 미반영.
+ * Teemo 핵심 지속 피해 누락 → 1코 AP carry under-damage.
+ * fix: onAttack 핸들러에 poison statusEffect 적용 (MR mitigate 후 poisonDuration 초 spread, 중첩).
+ *
+ * scaling 로드 + hitDamage 만이면 totalDamageDealt ~268. 독 DOT(poisonDamage ★2 6초 중첩) 추가 시 ~650.
+ * (scaling 미로드 시 base auto 만 ~105 — calibration 경로는 scaling 미로드라 onAttack 자체 미발동)
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { setScalingData, type ScalingData } from '@/lib/simulator/systems/ability';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import scalingJson from '../../../public/data/tft_set17_scaling.json';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+
+// onAttack scaling (poison) 은 scaling.json 필요 — calibration 경로(loadServerCatalogs)는 미로드.
+beforeAll(() => {
+  setScalingData(scalingJson as unknown as ScalingData);
+});
+const teemo = champions.find(c => c.apiName === 'TFT17_Teemo')!;
+const tank = champions.find(c => c.apiName === 'TFT17_Shen')!; // 고HP 생존 → 독 누적
+
+function placed(c: RawChampion, q: number, r: number): PlacedChampion {
+  return { champion: c, starLevel: 2, position: { q, r }, items: [] };
+}
+
+describe('티모 독 DOT passive (P1 회귀 가드)', () => {
+  it('평타 시 독 DOT(poisonDamage) 누적 — hitDamage 단독 대비 대폭 증가', () => {
+    const r = simulateCombat([placed(teemo, 0, 0)], [placed(tank, 6, 3)], {
+      seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5,
+    });
+    const t = r.playerUnits.find(u => u.champion.apiName === 'TFT17_Teemo')!;
+    // hitDamage 단독(scaling 로드)이면 ~268. 독 DOT 추가 시 poisonDamage 6초 중첩으로 ~650.
+    // 버그(독 미반영) 시 ~268 → fail. fix(독 DOT) 시 ~650 > 400 → pass. (threshold 400 으로 분리)
+    expect(t.totalDamageDealt).toBeGreaterThan(400);
+  });
+});


### PR DESCRIPTION
## 배경
champion ingest PR #222 (teemo.md) 발견 P1: Teemo passive 독 DOT (`scaling.json poisonDamage` scaleAP, `poisonDuration` 6초, 중첩) 미반영 — onAttack `extraDamage` 핸들러가 즉시 추가 마법(`hitDamage`)만 적용. Teemo 핵심 지속 피해 누락 → 1코 AP carry under-damage.

## 수정
`combatLoop.ts:6297` onAttack 핸들러에 poison statusEffect 적용 분기 추가:
- `poisonDamage`(scaleAP, `1+ap/100`) → **MR mitigate** (poison tick `:3531` 은 `currentHp -= value` 로 mitigation 미적용 → 적용 시점에 mitigate 후 spread) → `poisonDuration` 초 spread
- **중첩**: 같은 caster 기존 poison 잔여 합산 + duration refresh (Serpent poison `:5009` 패턴 차용)
- dealer `totalDamageDealt` 귀속 (즉시 직격 `:6289` 동형)

## 검증
- **회귀 가드** `teemo-poison-dot.test.ts`: scaling 로드 후 Teemo totalDamageDealt — hitDamage-only **268** → poison **650** (threshold 400 으로 분리). poison off → 268<400 fail / on → 650 pass.
- 전체 **949 pass** / `pnpm lint`(0)·`typecheck`·`build` 통과 — 회귀 0.

## ⚠️ diff-cache 미regen (중요)
**calibration 경로(`computeGameDiff`→`loadServerCatalogs`→`runN`)가 scaling.json 을 로드하지 않습니다** (`setScalingData` 미호출). → `getChampionScaling` null → Teemo onAttack(hitDamage·poison) 자체가 calibration 에서 미발동. 실측: 새 코드로 diff-cache 재생성해도 game-423 Teemo rows **변화 0** (engineSha만 변경). 본 fix 는 **production(`useGameData` `loadScalingData`)** 에서만 발효.

> 🚨 **별도 인프라 이슈 발견**: calibration 이 scaling.json 미로드 → onAttack/onKill/passive(asToAd) + **synergy 전반** 이 diff 계산에서 미반영. systemic under-damage(-39%) 기여 가능성 — 별도 조사 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)