### PR TITLE
fix(sim): 잭스(Jax) 「별의 반격」 armor+MR 비례 마법 피해 모델 (under-damage)

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-06-15T05:04:38.271Z",
+  "computedAt": "2026-06-15T05:41:26.469Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "26cd77cd447e34d9e24df3aed61ee3767922903d",
+  "engineSha": "3bcc078c85c489c720aca19bf6743f4b39a7d4e2",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [
@@ -466,13 +466,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 1339,
-          "simMean": 1140.2282232796604,
-          "simMedian": 1042.2384927780004,
+          "simMean": 1076.7624264930605,
+          "simMedian": 1062.6380717603133,
           "simRange": [
-            813.6143427607674,
-            2223.251552992014
+            814.8842935784875,
+            1669.9572804869417
           ],
-          "diffPct": -0.14844792884267335
+          "diffPct": -0.1958458353300519
         },
         {
           "hex": {
@@ -481,13 +481,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 592,
-          "simMean": 521.2647492742703,
-          "simMedian": 465.11839097760185,
+          "simMean": 509.28925593617487,
+          "simMedian": 471.8014848882984,
           "simRange": [
-            404.7473340366191,
-            829.934511777796
+            450.68638729105703,
+            601.8353717701212
           ],
-          "diffPct": -0.11948522082048929
+          "diffPct": -0.1397140947024073
         },
         {
           "hex": {
@@ -496,13 +496,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 924,
-          "simMean": 1491.309000145817,
-          "simMedian": 1517.4759892434981,
+          "simMean": 1473.071060514146,
+          "simMedian": 1501.6241633342747,
           "simRange": [
             1162.2244289532377,
-            1628.3834706325604
+            1602.1763700579083
           ],
-          "diffPct": 0.6139707793785898
+          "diffPct": 0.5942327494741839
         },
         {
           "hex": {
@@ -531,9 +531,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.6,
-          "simMeanHp": 22.258273403287053,
+          "simMeanHp": 25.00654981554472,
           "aliveMismatch": true,
-          "hpDiffPoints": 22.258273403287053
+          "hpDiffPoints": 25.00654981554472
         },
         {
           "hex": {
@@ -544,10 +544,10 @@
           "team": "player",
           "actualAlive": true,
           "actualHp": 20,
-          "simAliveRate": 0.9,
-          "simMeanHp": 43.917624688865686,
+          "simAliveRate": 1,
+          "simMeanHp": 47.16430666453736,
           "aliveMismatch": false,
-          "hpDiffPoints": 23.917624688865686
+          "hpDiffPoints": 27.164306664537357
         },
         {
           "hex": {
@@ -624,13 +624,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 1671,
-          "simMean": 751.9725614828019,
-          "simMedian": 732.7857250250274,
+          "simMean": 823.6763205370177,
+          "simMedian": 857.6987739214408,
           "simRange": [
-            608.4248661771389,
-            874.1687594195375
+            607.7556496294579,
+            955.0540427583219
           ],
-          "diffPct": -0.5499864982149599
+          "diffPct": -0.5070758105703066
         },
         {
           "hex": {
@@ -639,13 +639,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 1102,
-          "simMean": 1813.5474240414253,
-          "simMedian": 1818.3851195998022,
+          "simMean": 1743.8214586866284,
+          "simMedian": 1738.966967894326,
           "simRange": [
-            1639.9949192054432,
-            1938.4971721257464
+            1616.6067366511916,
+            1872.8305794996286
           ],
-          "diffPct": 0.6456873176419468
+          "diffPct": 0.5824151167755248
         },
         {
           "hex": {
@@ -654,13 +654,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 632,
-          "simMean": 568.861751267293,
+          "simMean": 559.1550847742744,
           "simMedian": 551.3824539045493,
           "simRange": [
             511.78947324423405,
-            697.1649059609886
+            619.8035029972332
           ],
-          "diffPct": -0.099902292298587
+          "diffPct": -0.11526094181285691
         },
         {
           "hex": {
@@ -669,13 +669,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 200,
-          "simMean": 560.8262765269176,
-          "simMedian": 572.4521691109823,
+          "simMean": 561.4434737525891,
+          "simMedian": 575.2592536152465,
           "simRange": [
             461.2173876736474,
-            620.0141680056154
+            616.7922644723632
           ],
-          "diffPct": 1.804131382634588
+          "diffPct": 1.8072173687629454
         }
       ],
       "survivors": [
@@ -702,10 +702,10 @@
           "team": "player",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.4,
-          "simMeanHp": 20.57359812970158,
-          "aliveMismatch": false,
-          "hpDiffPoints": 20.57359812970158
+          "simAliveRate": 0.7,
+          "simMeanHp": 16.150506726076106,
+          "aliveMismatch": true,
+          "hpDiffPoints": 16.150506726076106
         },
         {
           "hex": {
@@ -731,9 +731,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 36.129209417040656,
+          "simMeanHp": 35.57425494820543,
           "aliveMismatch": true,
-          "hpDiffPoints": 36.129209417040656
+          "hpDiffPoints": 35.57425494820543
         },
         {
           "hex": {
@@ -855,13 +855,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 835,
-          "simMean": 601.1837027120571,
-          "simMedian": 607.7191759539221,
+          "simMean": 856.6857088120212,
+          "simMedian": 833.3797315344889,
           "simRange": [
-            423.3112046793938,
-            737.9868497390237
+            537.7445355967523,
+            1054.4048746678402
           ],
-          "diffPct": -0.2800195177101113
+          "diffPct": 0.025970908756911586
         }
       ],
       "opponentDamage": [
@@ -1037,9 +1037,9 @@
           "actualAlive": true,
           "actualHp": 65,
           "simAliveRate": 1,
-          "simMeanHp": 80.80948520817903,
+          "simMeanHp": 72.48706114146205,
           "aliveMismatch": false,
-          "hpDiffPoints": 15.809485208179026
+          "hpDiffPoints": 7.48706114146205
         },
         {
           "hex": {
@@ -1051,9 +1051,9 @@
           "actualAlive": true,
           "actualHp": 8,
           "simAliveRate": 1,
-          "simMeanHp": 64.98013138236443,
+          "simMeanHp": 55.631003039443,
           "aliveMismatch": false,
-          "hpDiffPoints": 56.98013138236443
+          "hpDiffPoints": 47.631003039443
         },
         {
           "hex": {
@@ -1065,9 +1065,9 @@
           "actualAlive": true,
           "actualHp": 40,
           "simAliveRate": 1,
-          "simMeanHp": 35.32248911317431,
+          "simMeanHp": 29.121668226026816,
           "aliveMismatch": false,
-          "hpDiffPoints": -4.6775108868256865
+          "hpDiffPoints": -10.878331773973184
         }
       ],
       "warnings": [
@@ -1942,13 +1942,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 6242,
-          "simMean": 4516.2532011081885,
+          "simMean": 4501.710891853725,
           "simMedian": 4578.038074877815,
           "simRange": [
             2914.4733365915054,
-            5097.439717486728
+            5017.433392303931
           ],
-          "diffPct": -0.27647337374107844
+          "diffPct": -0.2788031253037928
         },
         {
           "hex": {
@@ -1957,13 +1957,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 2130,
-          "simMean": 1342.5998659979473,
-          "simMedian": 1215.4162871183908,
+          "simMean": 1351.2621634472562,
+          "simMedian": 1241.3632611156486,
           "simRange": [
             637.2182128999324,
             2200.215304314594
           ],
-          "diffPct": -0.3696714244141093
+          "diffPct": -0.3656046180998797
         },
         {
           "hex": {
@@ -1972,13 +1972,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 944,
-          "simMean": 736.4872438120502,
-          "simMedian": 715.6311756736673,
+          "simMean": 903.5696596379164,
+          "simMedian": 944.128080673144,
           "simRange": [
-            687.6569061626427,
-            887.7630414091411
+            723.9139649874332,
+            1068.986470896965
           ],
-          "diffPct": -0.21982283494486204
+          "diffPct": -0.04282875038356313
         },
         {
           "hex": {
@@ -2064,9 +2064,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 97.7223723485132,
+          "simMeanHp": 97.44386244141657,
           "aliveMismatch": true,
-          "hpDiffPoints": 97.7223723485132
+          "hpDiffPoints": 97.44386244141657
         },
         {
           "hex": {
@@ -2078,9 +2078,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 93.42132943779674,
+          "simMeanHp": 86.24184238296353,
           "aliveMismatch": true,
-          "hpDiffPoints": 93.42132943779674
+          "hpDiffPoints": 86.24184238296353
         },
         {
           "hex": {
@@ -2091,10 +2091,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.2,
-          "simMeanHp": 4.640496169503702,
+          "simAliveRate": 0,
+          "simMeanHp": 0,
           "aliveMismatch": false,
-          "hpDiffPoints": 4.640496169503702
+          "hpDiffPoints": 0
         },
         {
           "hex": {
@@ -2120,9 +2120,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.1,
-          "simMeanHp": 27.385804000199194,
+          "simMeanHp": 17.928964563100937,
           "aliveMismatch": false,
-          "hpDiffPoints": 27.385804000199194
+          "hpDiffPoints": 17.928964563100937
         },
         {
           "hex": {
@@ -2157,13 +2157,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 5564,
-          "simMean": 6212.745138106791,
+          "simMean": 6244.3242156124015,
           "simMedian": 6024.343468541345,
           "simRange": [
-            5495.414199815639,
-            7131.141047730384
+            5389.68585219609,
+            7180.309343732593
           ],
-          "diffPct": 0.11659689757490857
+          "diffPct": 0.12227250460323535
         },
         {
           "hex": {
@@ -2172,13 +2172,13 @@
           },
           "championId": "TFT17_Caitlyn",
           "actual": 1482,
-          "simMean": 890.2377767493299,
-          "simMedian": 1026.4183869714611,
+          "simMean": 873.2728282053749,
+          "simMedian": 895.0156718266952,
           "simRange": [
             200.27586206896555,
-            1385.0582800822506
+            1401.6073400000423
           ],
-          "diffPct": -0.39929974578317823
+          "diffPct": -0.41074707948355266
         },
         {
           "hex": {
@@ -2187,13 +2187,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 1342,
-          "simMean": 1268.3000233017729,
-          "simMedian": 1296.6854596659646,
+          "simMean": 1222.494018624789,
+          "simMedian": 1228.2390733060474,
           "simRange": [
             826.9234595770029,
-            1620.6408217774765
+            1631.1139121130172
           ],
-          "diffPct": -0.05491801542341814
+          "diffPct": -0.08905065676245225
         },
         {
           "hex": {
@@ -2202,13 +2202,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 1464,
-          "simMean": 585.9457208379479,
-          "simMedian": 539.9192629814675,
+          "simMean": 728.2303739937689,
+          "simMedian": 737.1030067613249,
           "simRange": [
             233.08637815754545,
-            1038.7519488703977
+            1287.1863331750349
           ],
-          "diffPct": -0.5997638518866476
+          "diffPct": -0.5025748811517972
         },
         {
           "hex": {
@@ -2217,13 +2217,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 382,
-          "simMean": 509.4192019604933,
-          "simMedian": 510.0030130286082,
+          "simMean": 500.37847798398843,
+          "simMedian": 475.8811420758933,
           "simRange": [
             306.50249774354955,
             726.0262987719577
           ],
-          "diffPct": 0.3335581203154275
+          "diffPct": 0.3098913036230064
         },
         {
           "hex": {
@@ -2232,13 +2232,13 @@
           },
           "championId": "TFT17_Milio",
           "actual": 1069,
-          "simMean": 2025.9667299343023,
-          "simMedian": 2001.2336569604236,
+          "simMean": 2008.2893686141608,
+          "simMedian": 1974.111485030909,
           "simRange": [
-            1600.6572126437009,
-            2558.362542696511
+            1524.7151325343461,
+            2548.391534798646
           ],
-          "diffPct": 0.8951980635493941
+          "diffPct": 0.8786617105838735
         }
       ],
       "opponentDamage": [
@@ -2264,13 +2264,13 @@
           },
           "championId": "TFT17_Veigar",
           "actual": 2565,
-          "simMean": 953.1480393855403,
+          "simMean": 889.9544380312185,
           "simMedian": 758.8930594784701,
           "simRange": [
             646.6060589698982,
-            1860.1171807873516
+            1228.181167244135
           ],
-          "diffPct": -0.6284023238263
+          "diffPct": -0.6530392054459186
         },
         {
           "hex": {
@@ -2329,9 +2329,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 39.35962200221664,
+          "simMeanHp": 40.8779254992133,
           "aliveMismatch": true,
-          "hpDiffPoints": 39.35962200221664
+          "hpDiffPoints": 40.8779254992133
         },
         {
           "hex": {
@@ -2343,9 +2343,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.9,
-          "simMeanHp": 25.211523126768913,
+          "simMeanHp": 25.763965607341,
           "aliveMismatch": true,
-          "hpDiffPoints": 25.211523126768913
+          "hpDiffPoints": 25.763965607341
         },
         {
           "hex": {
@@ -2778,13 +2778,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 6971,
-          "simMean": 6472.158164113903,
-          "simMedian": 6454.782359755243,
+          "simMean": 6439.551505420039,
+          "simMedian": 6410.98259885403,
           "simRange": [
-            6311.371509133052,
-            6739.496194230831
+            6229.854862398392,
+            6657.97954749617
           ],
-          "diffPct": -0.07155958053164499
+          "diffPct": -0.07623705272987538
         },
         {
           "hex": {
@@ -2808,13 +2808,13 @@
           },
           "championId": "TFT17_Milio",
           "actual": 2053,
-          "simMean": 2447.1715272416086,
-          "simMedian": 2452.7436537580315,
+          "simMean": 2443.9970151634725,
+          "simMedian": 2449.8833077656823,
           "simRange": [
             2286.597056922207,
             2651.721548856508
           ],
-          "diffPct": 0.19199782135489946
+          "diffPct": 0.19045154172599732
         },
         {
           "hex": {
@@ -2823,13 +2823,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 1497,
-          "simMean": 944.1668898146061,
+          "simMean": 943.7534772920587,
           "simMedian": 960.652547313309,
           "simRange": [
             663.7116072601777,
             1234.2145997514913
           ],
-          "diffPct": -0.3692939947798223
+          "diffPct": -0.36957015544952654
         },
         {
           "hex": {
@@ -2838,13 +2838,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 813,
-          "simMean": 771.4655789110838,
-          "simMedian": 776.8344086259066,
+          "simMean": 830.1642698061116,
+          "simMedian": 864.3488397742967,
           "simRange": [
             585.5990558513623,
-            868.486428626695
+            1062.758188671811
           ],
-          "diffPct": -0.051087848817855164
+          "diffPct": 0.02111226298414715
         },
         {
           "hex": {
@@ -2873,9 +2873,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 69.24950570746947,
+          "simMeanHp": 69.38195950290809,
           "aliveMismatch": true,
-          "hpDiffPoints": 69.24950570746947
+          "hpDiffPoints": 69.38195950290809
         },
         {
           "hex": {
@@ -2887,9 +2887,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 55.575793673793,
+          "simMeanHp": 55.59128177023945,
           "aliveMismatch": true,
-          "hpDiffPoints": 55.575793673793
+          "hpDiffPoints": 55.59128177023945
         },
         {
           "hex": {
@@ -2929,9 +2929,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.9,
-          "simMeanHp": 20.223893559490335,
+          "simMeanHp": 20.24141542168774,
           "aliveMismatch": true,
-          "hpDiffPoints": 20.223893559490335
+          "hpDiffPoints": 20.24141542168774
         },
         {
           "hex": {
@@ -3606,13 +3606,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 10653,
-          "simMean": 6274.3580529265255,
-          "simMedian": 6677.0510359793425,
+          "simMean": 6202.4248154387715,
+          "simMedian": 6273.564201732295,
           "simRange": [
             4717.93695993069,
-            7029.779484804016
+            7735.280269161957
           ],
-          "diffPct": -0.41102430743203555
+          "diffPct": -0.4177766999494254
         },
         {
           "hex": {
@@ -3636,13 +3636,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 2853,
-          "simMean": 491.4752113958301,
-          "simMedian": 496.77627271113886,
+          "simMean": 492.02974544130194,
+          "simMedian": 511.33226159994854,
           "simRange": [
             439.73799044644494,
             526.6491691751354
           ],
-          "diffPct": -0.8277338901521801
+          "diffPct": -0.8275395214015765
         },
         {
           "hex": {
@@ -3651,13 +3651,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 1703,
-          "simMean": 982.9976881174637,
-          "simMedian": 1002.2873816682335,
+          "simMean": 1918.827580435801,
+          "simMedian": 2319.9441636833853,
           "simRange": [
             581.0038610038611,
-            1239.9611125405402
+            2743.1053470724664
           ],
-          "diffPct": -0.4227846810819356
+          "diffPct": 0.12673375245789847
         },
         {
           "hex": {
@@ -3698,13 +3698,13 @@
           },
           "championId": "TFT17_Vex",
           "actual": 5808,
-          "simMean": 9165.795115555942,
-          "simMedian": 9083.417865583582,
+          "simMean": 9152.692152324813,
+          "simMedian": 9030.11180280281,
           "simRange": [
-            8403.828709269772,
-            10140.730027932419
+            7962.066668299458,
+            10295.506792060405
           ],
-          "diffPct": 0.5781327678298799
+          "diffPct": 0.5758767479898094
         },
         {
           "hex": {
@@ -3713,13 +3713,13 @@
           },
           "championId": "TFT17_Morgana",
           "actual": 3254,
-          "simMean": 3974.6802906780695,
-          "simMedian": 3979.5113615479872,
+          "simMean": 3804.9401232250702,
+          "simMedian": 3816.560268073102,
           "simRange": [
-            3640.7155401714735,
-            4246.733044811429
+            3572.726554024419,
+            4129.807902261959
           ],
-          "diffPct": 0.22147519688938827
+          "diffPct": 0.1693116543408329
         },
         {
           "hex": {
@@ -3728,13 +3728,13 @@
           },
           "championId": "TFT17_TahmKench",
           "actual": 2584,
-          "simMean": 510.37080920470345,
-          "simMedian": 514.0193976556498,
+          "simMean": 509.18640195531424,
+          "simMedian": 528.8494936627167,
           "simRange": [
             383.15649867374,
-            623.6224522763483
+            616.7986458896135
           ],
-          "diffPct": -0.8024880769331643
+          "diffPct": -0.8029464388717825
         },
         {
           "hex": {
@@ -3743,13 +3743,13 @@
           },
           "championId": "TFT17_Blitzcrank",
           "actual": 2409,
-          "simMean": 761.6451874491532,
+          "simMean": 783.6673772862641,
           "simMedian": 804.4876780352818,
           "simRange": [
-            451.7625396700696,
+            462.8008578658342,
             1375.2881058683188
           ],
-          "diffPct": -0.6838334630763166
+          "diffPct": -0.6746918317616172
         },
         {
           "hex": {
@@ -3758,13 +3758,13 @@
           },
           "championId": "TFT17_Fiora",
           "actual": 2393,
-          "simMean": 2904.9704690055432,
-          "simMedian": 2886.696638856367,
+          "simMean": 2928.105255077831,
+          "simMedian": 2927.883752170347,
           "simRange": [
             2523.3408285121886,
             3351.913076472056
           ],
-          "diffPct": 0.2139450351046984
+          "diffPct": 0.2236127267354078
         },
         {
           "hex": {
@@ -3773,13 +3773,13 @@
           },
           "championId": "TFT17_Sona",
           "actual": 2037,
-          "simMean": 7337.982770736997,
-          "simMedian": 7060.78522324929,
+          "simMean": 7494.2564271966085,
+          "simMedian": 7512.393312323173,
           "simRange": [
             6822.99466255145,
-            7944.473863907413
+            8203.873045150696
           ],
-          "diffPct": 2.6023479483244953
+          "diffPct": 2.6790655018147316
         }
       ],
       "survivors": [
@@ -3905,9 +3905,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 78.63600677712542,
+          "simMeanHp": 73.87938092877184,
           "aliveMismatch": true,
-          "hpDiffPoints": 78.63600677712542
+          "hpDiffPoints": 73.87938092877184
         },
         {
           "hex": {
@@ -3918,10 +3918,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.5,
-          "simMeanHp": 48.14658962841944,
-          "aliveMismatch": false,
-          "hpDiffPoints": 48.14658962841944
+          "simAliveRate": 0.7,
+          "simMeanHp": 31.986533527082265,
+          "aliveMismatch": true,
+          "hpDiffPoints": 31.986533527082265
         },
         {
           "hex": {
@@ -3933,9 +3933,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 71.57503236389084,
+          "simMeanHp": 66.84192759839397,
           "aliveMismatch": true,
-          "hpDiffPoints": 71.57503236389084
+          "hpDiffPoints": 66.84192759839397
         },
         {
           "hex": {
@@ -3974,10 +3974,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.5,
-          "simMeanHp": 38.20737995366685,
+          "simAliveRate": 0.3,
+          "simMeanHp": 62.83112509863728,
           "aliveMismatch": false,
-          "hpDiffPoints": 38.20737995366685
+          "hpDiffPoints": 62.83112509863728
         },
         {
           "hex": {
@@ -3988,10 +3988,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.9,
-          "simMeanHp": 74.07640818616214,
+          "simAliveRate": 0.7,
+          "simMeanHp": 54.04994108281803,
           "aliveMismatch": true,
-          "hpDiffPoints": 74.07640818616214
+          "hpDiffPoints": 54.04994108281803
         },
         {
           "hex": {
@@ -4002,10 +4002,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 1,
-          "simMeanHp": 35.06470884802746,
+          "simAliveRate": 0.9,
+          "simMeanHp": 19.51857717598733,
           "aliveMismatch": true,
-          "hpDiffPoints": 35.06470884802746
+          "hpDiffPoints": 19.51857717598733
         }
       ],
       "warnings": []
@@ -4432,13 +4432,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 9078,
-          "simMean": 6437.718214494697,
-          "simMedian": 6290.088448720046,
+          "simMean": 6740.737599156659,
+          "simMedian": 7217.812079485708,
           "simRange": [
             4524.8644235205375,
-            8720.848794504747
+            7938.374087111268
           ],
-          "diffPct": -0.2908439948783105
+          "diffPct": -0.25746446363112374
         },
         {
           "hex": {
@@ -4447,13 +4447,13 @@
           },
           "championId": "TFT17_Corki",
           "actual": 5651,
-          "simMean": 2579.77369698205,
+          "simMean": 2578.802540599372,
           "simMedian": 2627.2943908650377,
           "simRange": [
             2066.6229683666825,
             2999.6374625345643
           ],
-          "diffPct": -0.543483684837719
+          "diffPct": -0.5436555405062162
         },
         {
           "hex": {
@@ -4462,13 +4462,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 4828,
-          "simMean": 1101.4732162298394,
+          "simMean": 1110.9913289406054,
           "simMedian": 1008.3251386692915,
           "simRange": [
             837.7422445960614,
-            1475.8966116474132
+            1508.8455524518363
           ],
-          "diffPct": -0.7718572460170174
+          "diffPct": -0.76988580593608
         },
         {
           "hex": {
@@ -4492,13 +4492,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 2846,
-          "simMean": 1101.2851179403897,
-          "simMedian": 1161.5857644504517,
+          "simMean": 1906.0572590646443,
+          "simMedian": 2165.9609103846087,
           "simRange": [
             807.2356126323001,
-            1236.9973891578843
+            2405.039200433253
           ],
-          "diffPct": -0.6130410688895328
+          "diffPct": -0.33026800454510036
         },
         {
           "hex": {
@@ -4507,13 +4507,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 925,
-          "simMean": 706.774957980492,
+          "simMean": 706.618257158176,
           "simMedian": 731.3373731631297,
           "simRange": [
             309.7894736842105,
-            968.4153427666668
+            1033.1231830773597
           ],
-          "diffPct": -0.23591896434541407
+          "diffPct": -0.23608837063980972
         }
       ],
       "opponentDamage": [
@@ -4524,13 +4524,13 @@
           },
           "championId": "TFT17_Vex",
           "actual": 7575,
-          "simMean": 13863.279419055581,
-          "simMedian": 13961.832764009796,
+          "simMean": 14292.670997895399,
+          "simMedian": 14306.083271001145,
           "simRange": [
             12820.500878736542,
-            14552.85531111205
+            16692.529449317102
           ],
-          "diffPct": 0.8301358969050272
+          "diffPct": 0.8868212538475774
         },
         {
           "hex": {
@@ -4539,13 +4539,13 @@
           },
           "championId": "TFT17_Morgana",
           "actual": 2901,
-          "simMean": 694.659210127305,
+          "simMean": 674.7055215191441,
           "simMedian": 635.5992716731544,
           "simRange": [
             535.5953283451622,
             1033.6392563185218
           ],
-          "diffPct": -0.760544912055393
+          "diffPct": -0.7674231225373512
         },
         {
           "hex": {
@@ -4554,13 +4554,13 @@
           },
           "championId": "TFT17_Fiora",
           "actual": 2384,
-          "simMean": 1525.0210576860136,
-          "simMedian": 1462.0814177939415,
+          "simMean": 1529.0210576860138,
+          "simMedian": 1432.606056896867,
           "simRange": [
-            1196.8275741892087,
-            1923.3352603428202
+            1185.2413674368465,
+            2067.335259048548
           ],
-          "diffPct": -0.36030995902432317
+          "diffPct": -0.3586321066753298
         },
         {
           "hex": {
@@ -4569,13 +4569,13 @@
           },
           "championId": "TFT17_Sona",
           "actual": 2348,
-          "simMean": 7542.152387036384,
-          "simMedian": 7481.108676794332,
+          "simMean": 6726.38371491562,
+          "simMedian": 6500.644807905508,
           "simRange": [
-            6923.225228991936,
+            4311.185526397594,
             8162.847662278562
           ],
-          "diffPct": 2.2121603011228212
+          "diffPct": 1.8647290097596336
         },
         {
           "hex": {
@@ -4584,13 +4584,13 @@
           },
           "championId": "TFT17_Blitzcrank",
           "actual": 1769,
-          "simMean": 1228.858440026489,
-          "simMedian": 1215.9850343214846,
+          "simMean": 1287.1112794567007,
+          "simMedian": 1308.3976385191525,
           "simRange": [
-            1025.3849517069627,
+            1038.458163632329,
             1560.7464861157555
           ],
-          "diffPct": -0.3053372300585138
+          "diffPct": -0.27240741692668136
         },
         {
           "hex": {
@@ -4599,13 +4599,13 @@
           },
           "championId": "TFT17_TahmKench",
           "actual": 1551,
-          "simMean": 523.5624457810148,
-          "simMedian": 498.59943614588144,
+          "simMean": 552.2411307221086,
+          "simMedian": 550.0877116701124,
           "simRange": [
             409.13232972004096,
             725.301719906515
           ],
-          "diffPct": -0.6624355604248775
+          "diffPct": -0.6439451123648559
         }
       ],
       "survivors": [
@@ -4731,9 +4731,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 72.72992003581473,
+          "simMeanHp": 37.51215953703097,
           "aliveMismatch": true,
-          "hpDiffPoints": 72.72992003581473
+          "hpDiffPoints": 37.51215953703097
         },
         {
           "hex": {
@@ -4745,9 +4745,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.7,
-          "simMeanHp": 62.2512890793492,
+          "simMeanHp": 35.65035974781061,
           "aliveMismatch": true,
-          "hpDiffPoints": 62.2512890793492
+          "hpDiffPoints": 35.65035974781061
         },
         {
           "hex": {
@@ -4772,10 +4772,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 1,
-          "simMeanHp": 21.01561750253574,
-          "aliveMismatch": true,
-          "hpDiffPoints": 21.01561750253574
+          "simAliveRate": 0.4,
+          "simMeanHp": 23.42484998953561,
+          "aliveMismatch": false,
+          "hpDiffPoints": 23.42484998953561
         },
         {
           "hex": {
@@ -4800,10 +4800,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.9,
-          "simMeanHp": 70.42397777669125,
+          "simAliveRate": 0.8,
+          "simMeanHp": 77.06725763800675,
           "aliveMismatch": true,
-          "hpDiffPoints": 70.42397777669125
+          "hpDiffPoints": 77.06725763800675
         },
         {
           "hex": {
@@ -4814,10 +4814,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.9,
-          "simMeanHp": 62.31360910307413,
+          "simAliveRate": 0.8,
+          "simMeanHp": 77.68059899780144,
           "aliveMismatch": true,
-          "hpDiffPoints": 62.31360910307413
+          "hpDiffPoints": 77.68059899780144
         },
         {
           "hex": {
@@ -5671,7 +5671,7 @@
     "pvpRoundCount": 22,
     "winnerMatchRate": 0.5454545454545454,
     "weakSignalRoundCount": 0,
-    "avgPlayerDamageErrorPct": -0.29737331882186896,
-    "avgSurvivorHpErrorPts": 7.56218930885148
+    "avgPlayerDamageErrorPct": -0.2855873062565342,
+    "avgSurvivorHpErrorPts": 7.2276967896733
   }
 }

--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-06-15T05:41:26.469Z",
+  "computedAt": "2026-06-15T05:48:56.090Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "3bcc078c85c489c720aca19bf6743f4b39a7d4e2",
+  "engineSha": "af6e031027bcc8b95edc2eee4f173d772f50e786",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [
@@ -810,13 +810,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 1926,
-          "simMean": 919.22649138913,
-          "simMedian": 909.9847845408756,
+          "simMean": 942.1314673293391,
+          "simMedian": 926.4794363429556,
           "simRange": [
             748.6236951860823,
-            1127.4401342643362
+            1277.8021926076315
           ],
-          "diffPct": -0.5227276784064745
+          "diffPct": -0.5108351675340919
         },
         {
           "hex": {
@@ -855,13 +855,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 835,
-          "simMean": 856.6857088120212,
-          "simMedian": 833.3797315344889,
+          "simMean": 880.538021813946,
+          "simMedian": 887.2721887135285,
           "simRange": [
-            537.7445355967523,
-            1054.4048746678402
+            595.296257302454,
+            1047.1738358688572
           ],
-          "diffPct": 0.025970908756911586
+          "diffPct": 0.054536553070594
         }
       ],
       "opponentDamage": [
@@ -872,13 +872,13 @@
           },
           "championId": "TFT17_Teemo",
           "actual": 2698,
-          "simMean": 4609.1638066093765,
-          "simMedian": 4641.554403412709,
+          "simMean": 4612.376640182555,
+          "simMedian": 4634.035157609565,
           "simRange": [
             4278.113778443334,
             4958.146863536553
           ],
-          "diffPct": 0.7083631603444687
+          "diffPct": 0.7095539807941271
         },
         {
           "hex": {
@@ -887,13 +887,13 @@
           },
           "championId": "TFT17_Leona",
           "actual": 1093,
-          "simMean": 315.7765138282121,
-          "simMedian": 316.39714387304093,
+          "simMean": 336.5457445057434,
+          "simMedian": 350.3132278907236,
           "simRange": [
-            244.6969673037529,
+            236.7424223233353,
             403.8607203955208
           ],
-          "diffPct": -0.7110919361132553
+          "diffPct": -0.6920898952371972
         },
         {
           "hex": {
@@ -917,13 +917,13 @@
           },
           "championId": "TFT17_Illaoi",
           "actual": 557,
-          "simMean": 373.83432181600506,
-          "simMedian": 409.36188580767885,
+          "simMean": 372.22750368159967,
+          "simMedian": 424.7465002752997,
           "simRange": [
             187.49999813735485,
-            506.8840297979491
+            501.9160813761132
           ],
-          "diffPct": -0.32884322833751334
+          "diffPct": -0.3317280005716343
         },
         {
           "hex": {
@@ -947,13 +947,13 @@
           },
           "championId": "TFT17_Nasus",
           "actual": 860,
-          "simMean": 517.6946401015401,
-          "simMedian": 540.2126243905275,
+          "simMean": 508.61541536013675,
+          "simMedian": 524.7357191607418,
           "simRange": [
             378.8412564454378,
             569.8494914914393
           ],
-          "diffPct": -0.3980294882540231
+          "diffPct": -0.40858672632542237
         }
       ],
       "survivors": [
@@ -1037,9 +1037,9 @@
           "actualAlive": true,
           "actualHp": 65,
           "simAliveRate": 1,
-          "simMeanHp": 72.48706114146205,
+          "simMeanHp": 73.33474634065165,
           "aliveMismatch": false,
-          "hpDiffPoints": 7.48706114146205
+          "hpDiffPoints": 8.334746340651648
         },
         {
           "hex": {
@@ -1051,9 +1051,9 @@
           "actualAlive": true,
           "actualHp": 8,
           "simAliveRate": 1,
-          "simMeanHp": 55.631003039443,
+          "simMeanHp": 57.432473610421425,
           "aliveMismatch": false,
-          "hpDiffPoints": 47.631003039443
+          "hpDiffPoints": 49.432473610421425
         },
         {
           "hex": {
@@ -1064,10 +1064,10 @@
           "team": "opponent",
           "actualAlive": true,
           "actualHp": 40,
-          "simAliveRate": 1,
-          "simMeanHp": 29.121668226026816,
+          "simAliveRate": 0.9,
+          "simMeanHp": 27.27514055226952,
           "aliveMismatch": false,
-          "hpDiffPoints": -10.878331773973184
+          "hpDiffPoints": -12.72485944773048
         }
       ],
       "warnings": [
@@ -1942,13 +1942,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 6242,
-          "simMean": 4501.710891853725,
+          "simMean": 4523.970514980496,
           "simMedian": 4578.038074877815,
           "simRange": [
-            2914.4733365915054,
-            5017.433392303931
+            3077.4586174460537,
+            5017.816109402249
           ],
-          "diffPct": -0.2788031253037928
+          "diffPct": -0.27523702098998787
         },
         {
           "hex": {
@@ -1972,13 +1972,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 944,
-          "simMean": 903.5696596379164,
-          "simMedian": 944.128080673144,
+          "simMean": 840.4138471576834,
+          "simMedian": 746.9953927851615,
           "simRange": [
-            723.9139649874332,
+            705.4692356464423,
             1068.986470896965
           ],
-          "diffPct": -0.04282875038356313
+          "diffPct": -0.10973109411262347
         },
         {
           "hex": {
@@ -2002,13 +2002,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 846,
-          "simMean": 308.0233882972092,
-          "simMedian": 323.5750653257719,
+          "simMean": 309.2125774920705,
+          "simMedian": 326.25527652363576,
           "simRange": [
             193.46830981720385,
             386.56161445252883
           ],
-          "diffPct": -0.6359061604051901
+          "diffPct": -0.6345004994183564
         }
       ],
       "survivors": [
@@ -2078,9 +2078,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 86.24184238296353,
+          "simMeanHp": 91.66318310272989,
           "aliveMismatch": true,
-          "hpDiffPoints": 86.24184238296353
+          "hpDiffPoints": 91.66318310272989
         },
         {
           "hex": {
@@ -2157,13 +2157,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 5564,
-          "simMean": 6244.3242156124015,
+          "simMean": 6208.190279517702,
           "simMedian": 6024.343468541345,
           "simRange": [
             5389.68585219609,
             7180.309343732593
           ],
-          "diffPct": 0.12227250460323535
+          "diffPct": 0.1157782673468192
         },
         {
           "hex": {
@@ -2172,13 +2172,13 @@
           },
           "championId": "TFT17_Caitlyn",
           "actual": 1482,
-          "simMean": 873.2728282053749,
-          "simMedian": 895.0156718266952,
+          "simMean": 899.553371234328,
+          "simMedian": 1026.4183869714611,
           "simRange": [
             200.27586206896555,
             1401.6073400000423
           ],
-          "diffPct": -0.41074707948355266
+          "diffPct": -0.3930139195449879
         },
         {
           "hex": {
@@ -2187,13 +2187,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 1342,
-          "simMean": 1222.494018624789,
+          "simMean": 1241.5079246332957,
           "simMedian": 1228.2390733060474,
           "simRange": [
             826.9234595770029,
             1631.1139121130172
           ],
-          "diffPct": -0.08905065676245225
+          "diffPct": -0.07488232143569619
         },
         {
           "hex": {
@@ -2202,13 +2202,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 1464,
-          "simMean": 728.2303739937689,
-          "simMedian": 737.1030067613249,
+          "simMean": 660.2401972233681,
+          "simMedian": 642.0521596720789,
           "simRange": [
             233.08637815754545,
-            1287.1863331750349
+            1035.3311343690418
           ],
-          "diffPct": -0.5025748811517972
+          "diffPct": -0.5490162587272076
         },
         {
           "hex": {
@@ -2217,13 +2217,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 382,
-          "simMean": 500.37847798398843,
-          "simMedian": 475.8811420758933,
+          "simMean": 509.4192019604933,
+          "simMedian": 510.0030130286082,
           "simRange": [
             306.50249774354955,
             726.0262987719577
           ],
-          "diffPct": 0.3098913036230064
+          "diffPct": 0.3335581203154275
         },
         {
           "hex": {
@@ -2232,13 +2232,13 @@
           },
           "championId": "TFT17_Milio",
           "actual": 1069,
-          "simMean": 2008.2893686141608,
-          "simMedian": 1974.111485030909,
+          "simMean": 2010.259375390798,
+          "simMedian": 1995.6273038723025,
           "simRange": [
-            1524.7151325343461,
-            2548.391534798646
+            1600.6572126437009,
+            2437.905178596631
           ],
-          "diffPct": 0.8786617105838735
+          "diffPct": 0.8805045607023367
         }
       ],
       "opponentDamage": [
@@ -2264,13 +2264,13 @@
           },
           "championId": "TFT17_Veigar",
           "actual": 2565,
-          "simMean": 889.9544380312185,
-          "simMedian": 758.8930594784701,
+          "simMean": 898.8540700425017,
+          "simMedian": 760.8423676982144,
           "simRange": [
             646.6060589698982,
             1228.181167244135
           ],
-          "diffPct": -0.6530392054459186
+          "diffPct": -0.6495695633362567
         },
         {
           "hex": {
@@ -2329,9 +2329,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 40.8779254992133,
+          "simMeanHp": 40.4279677442915,
           "aliveMismatch": true,
-          "hpDiffPoints": 40.8779254992133
+          "hpDiffPoints": 40.4279677442915
         },
         {
           "hex": {
@@ -2385,9 +2385,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.6,
-          "simMeanHp": 43.939136414508404,
+          "simMeanHp": 44.46914203173451,
           "aliveMismatch": true,
-          "hpDiffPoints": 43.939136414508404
+          "hpDiffPoints": 44.46914203173451
         },
         {
           "hex": {
@@ -3606,13 +3606,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 10653,
-          "simMean": 6202.4248154387715,
-          "simMedian": 6273.564201732295,
+          "simMean": 6192.414736456545,
+          "simMedian": 6527.924445214121,
           "simRange": [
             4717.93695993069,
-            7735.280269161957
+            7224.941706537424
           ],
-          "diffPct": -0.4177766999494254
+          "diffPct": -0.4187163487790721
         },
         {
           "hex": {
@@ -3636,13 +3636,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 2853,
-          "simMean": 492.02974544130194,
-          "simMedian": 511.33226159994854,
+          "simMean": 490.73583266853456,
+          "simMedian": 496.7648425502081,
           "simRange": [
             439.73799044644494,
-            526.6491691751354
+            535.7883148052538
           ],
-          "diffPct": -0.8275395214015765
+          "diffPct": -0.8279930484863182
         },
         {
           "hex": {
@@ -3651,13 +3651,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 1703,
-          "simMean": 1918.827580435801,
-          "simMedian": 2319.9441636833853,
+          "simMean": 1463.8038122316068,
+          "simMedian": 1669.5181670431725,
           "simRange": [
             581.0038610038611,
-            2743.1053470724664
+            2002.8220208844407
           ],
-          "diffPct": 0.12673375245789847
+          "diffPct": -0.1404557767283577
         },
         {
           "hex": {
@@ -3698,13 +3698,13 @@
           },
           "championId": "TFT17_Vex",
           "actual": 5808,
-          "simMean": 9152.692152324813,
-          "simMedian": 9030.11180280281,
+          "simMean": 9350.792990542268,
+          "simMedian": 9253.183431973299,
           "simRange": [
-            7962.066668299458,
-            10295.506792060405
+            8004.002051069678,
+            10780.661539357734
           ],
-          "diffPct": 0.5758767479898094
+          "diffPct": 0.6099850190327596
         },
         {
           "hex": {
@@ -3713,13 +3713,13 @@
           },
           "championId": "TFT17_Morgana",
           "actual": 3254,
-          "simMean": 3804.9401232250702,
-          "simMedian": 3816.560268073102,
+          "simMean": 3928.1791944822508,
+          "simMedian": 3877.5724229047455,
           "simRange": [
-            3572.726554024419,
-            4129.807902261959
+            3569.928152034444,
+            4643.7998617092835
           ],
-          "diffPct": 0.1693116543408329
+          "diffPct": 0.20718475552619875
         },
         {
           "hex": {
@@ -3728,13 +3728,13 @@
           },
           "championId": "TFT17_TahmKench",
           "actual": 2584,
-          "simMean": 509.18640195531424,
-          "simMedian": 528.8494936627167,
+          "simMean": 512.874747716316,
+          "simMedian": 527.0625447443047,
           "simRange": [
             383.15649867374,
-            616.7986458896135
+            629.9693768118938
           ],
-          "diffPct": -0.8029464388717825
+          "diffPct": -0.8015190604813018
         },
         {
           "hex": {
@@ -3743,13 +3743,13 @@
           },
           "championId": "TFT17_Blitzcrank",
           "actual": 2409,
-          "simMean": 783.6673772862641,
-          "simMedian": 804.4876780352818,
+          "simMean": 755.0974475967547,
+          "simMedian": 802.4010899094919,
           "simRange": [
-            462.8008578658342,
+            451.7625396700696,
             1375.2881058683188
           ],
-          "diffPct": -0.6746918317616172
+          "diffPct": -0.6865514953936261
         },
         {
           "hex": {
@@ -3758,13 +3758,13 @@
           },
           "championId": "TFT17_Fiora",
           "actual": 2393,
-          "simMean": 2928.105255077831,
-          "simMedian": 2927.883752170347,
+          "simMean": 2952.1576569007166,
+          "simMedian": 3043.109103559188,
           "simRange": [
             2523.3408285121886,
             3351.913076472056
           ],
-          "diffPct": 0.2236127267354078
+          "diffPct": 0.23366387668228858
         },
         {
           "hex": {
@@ -3773,13 +3773,13 @@
           },
           "championId": "TFT17_Sona",
           "actual": 2037,
-          "simMean": 7494.2564271966085,
-          "simMedian": 7512.393312323173,
+          "simMean": 7142.748664615649,
+          "simMedian": 7014.035921867031,
           "simRange": [
-            6822.99466255145,
-            8203.873045150696
+            5982.030856436558,
+            7912.9604990714815
           ],
-          "diffPct": 2.6790655018147316
+          "diffPct": 2.506504008156922
         }
       ],
       "survivors": [
@@ -3905,9 +3905,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 73.87938092877184,
+          "simMeanHp": 78.66366677725316,
           "aliveMismatch": true,
-          "hpDiffPoints": 73.87938092877184
+          "hpDiffPoints": 78.66366677725316
         },
         {
           "hex": {
@@ -3918,10 +3918,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.7,
-          "simMeanHp": 31.986533527082265,
-          "aliveMismatch": true,
-          "hpDiffPoints": 31.986533527082265
+          "simAliveRate": 0.5,
+          "simMeanHp": 41.50957251809465,
+          "aliveMismatch": false,
+          "hpDiffPoints": 41.50957251809465
         },
         {
           "hex": {
@@ -3933,9 +3933,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 66.84192759839397,
+          "simMeanHp": 75.14752043762651,
           "aliveMismatch": true,
-          "hpDiffPoints": 66.84192759839397
+          "hpDiffPoints": 75.14752043762651
         },
         {
           "hex": {
@@ -3974,10 +3974,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.3,
-          "simMeanHp": 62.83112509863728,
+          "simAliveRate": 0.4,
+          "simMeanHp": 52.960608937767745,
           "aliveMismatch": false,
-          "hpDiffPoints": 62.83112509863728
+          "hpDiffPoints": 52.960608937767745
         },
         {
           "hex": {
@@ -3988,10 +3988,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.7,
-          "simMeanHp": 54.04994108281803,
+          "simAliveRate": 0.9,
+          "simMeanHp": 67.11311608235616,
           "aliveMismatch": true,
-          "hpDiffPoints": 54.04994108281803
+          "hpDiffPoints": 67.11311608235616
         },
         {
           "hex": {
@@ -4432,13 +4432,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 9078,
-          "simMean": 6740.737599156659,
-          "simMedian": 7217.812079485708,
+          "simMean": 6601.959725941153,
+          "simMedian": 6484.0287397967495,
           "simRange": [
             4524.8644235205375,
-            7938.374087111268
+            8405.756337183422
           ],
-          "diffPct": -0.25746446363112374
+          "diffPct": -0.2727517376138849
         },
         {
           "hex": {
@@ -4447,13 +4447,13 @@
           },
           "championId": "TFT17_Corki",
           "actual": 5651,
-          "simMean": 2578.802540599372,
+          "simMean": 2587.4861175071164,
           "simMedian": 2627.2943908650377,
           "simRange": [
             2066.6229683666825,
-            2999.6374625345643
+            3024.0357205684245
           ],
-          "diffPct": -0.5436555405062162
+          "diffPct": -0.5421188962118003
         },
         {
           "hex": {
@@ -4462,13 +4462,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 4828,
-          "simMean": 1110.9913289406054,
-          "simMedian": 1008.3251386692915,
+          "simMean": 1123.0322638027933,
+          "simMedian": 1025.3000175674972,
           "simRange": [
             837.7422445960614,
-            1508.8455524518363
+            1571.3977070634112
           ],
-          "diffPct": -0.76988580593608
+          "diffPct": -0.7673918260557595
         },
         {
           "hex": {
@@ -4492,13 +4492,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 2846,
-          "simMean": 1906.0572590646443,
-          "simMedian": 2165.9609103846087,
+          "simMean": 1386.9987861642724,
+          "simMedian": 1513.3759570190566,
           "simRange": [
             807.2356126323001,
-            2405.039200433253
+            1579.1368837309724
           ],
-          "diffPct": -0.33026800454510036
+          "diffPct": -0.5126497589022233
         },
         {
           "hex": {
@@ -4507,13 +4507,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 925,
-          "simMean": 706.618257158176,
-          "simMedian": 731.3373731631297,
+          "simMean": 724.5524434523775,
+          "simMedian": 770.8471420408525,
           "simRange": [
             309.7894736842105,
-            1033.1231830773597
+            1097.0716581154802
           ],
-          "diffPct": -0.23608837063980972
+          "diffPct": -0.2167000611325649
         }
       ],
       "opponentDamage": [
@@ -4524,13 +4524,13 @@
           },
           "championId": "TFT17_Vex",
           "actual": 7575,
-          "simMean": 14292.670997895399,
-          "simMedian": 14306.083271001145,
+          "simMean": 14021.124088010121,
+          "simMedian": 13943.213331264747,
           "simRange": [
             12820.500878736542,
-            16692.529449317102
+            15136.818911830296
           ],
-          "diffPct": 0.8868212538475774
+          "diffPct": 0.8509734769650326
         },
         {
           "hex": {
@@ -4539,13 +4539,13 @@
           },
           "championId": "TFT17_Morgana",
           "actual": 2901,
-          "simMean": 674.7055215191441,
-          "simMedian": 635.5992716731544,
+          "simMean": 688.6971773257744,
+          "simMedian": 641.3232815741442,
           "simRange": [
             535.5953283451622,
             1033.6392563185218
           ],
-          "diffPct": -0.7674231225373512
+          "diffPct": -0.7626000767577474
         },
         {
           "hex": {
@@ -4554,13 +4554,13 @@
           },
           "championId": "TFT17_Fiora",
           "actual": 2384,
-          "simMean": 1529.0210576860138,
-          "simMedian": 1432.606056896867,
+          "simMean": 1578.6028987698269,
+          "simMedian": 1554.1606248177131,
           "simRange": [
             1185.2413674368465,
-            2067.335259048548
+            2223.894396885127
           ],
-          "diffPct": -0.3586321066753298
+          "diffPct": -0.3378343545428579
         },
         {
           "hex": {
@@ -4569,13 +4569,13 @@
           },
           "championId": "TFT17_Sona",
           "actual": 2348,
-          "simMean": 6726.38371491562,
-          "simMedian": 6500.644807905508,
+          "simMean": 7114.435498290282,
+          "simMedian": 6890.610617613077,
           "simRange": [
-            4311.185526397594,
+            6333.387452499893,
             8162.847662278562
           ],
-          "diffPct": 1.8647290097596336
+          "diffPct": 2.029998082747139
         },
         {
           "hex": {
@@ -4584,13 +4584,13 @@
           },
           "championId": "TFT17_Blitzcrank",
           "actual": 1769,
-          "simMean": 1287.1112794567007,
-          "simMedian": 1308.3976385191525,
+          "simMean": 1293.0704935555307,
+          "simMedian": 1298.3190088756721,
           "simRange": [
             1038.458163632329,
             1560.7464861157555
           ],
-          "diffPct": -0.27240741692668136
+          "diffPct": -0.26903872608505897
         },
         {
           "hex": {
@@ -4599,13 +4599,13 @@
           },
           "championId": "TFT17_TahmKench",
           "actual": 1551,
-          "simMean": 552.2411307221086,
-          "simMedian": 550.0877116701124,
+          "simMean": 548.1028603682787,
+          "simMedian": 541.9681690490877,
           "simRange": [
             409.13232972004096,
-            725.301719906515
+            759.0517178948583
           ],
-          "diffPct": -0.6439451123648559
+          "diffPct": -0.6466132428315418
         }
       ],
       "survivors": [
@@ -4731,9 +4731,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 37.51215953703097,
+          "simMeanHp": 72.99482866030195,
           "aliveMismatch": true,
-          "hpDiffPoints": 37.51215953703097
+          "hpDiffPoints": 72.99482866030195
         },
         {
           "hex": {
@@ -4745,9 +4745,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.7,
-          "simMeanHp": 35.65035974781061,
+          "simMeanHp": 44.042531980674276,
           "aliveMismatch": true,
-          "hpDiffPoints": 35.65035974781061
+          "hpDiffPoints": 44.042531980674276
         },
         {
           "hex": {
@@ -4772,10 +4772,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.4,
-          "simMeanHp": 23.42484998953561,
+          "simAliveRate": 0.5,
+          "simMeanHp": 21.114288584778713,
           "aliveMismatch": false,
-          "hpDiffPoints": 23.42484998953561
+          "hpDiffPoints": 21.114288584778713
         },
         {
           "hex": {
@@ -4800,10 +4800,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.8,
-          "simMeanHp": 77.06725763800675,
+          "simAliveRate": 1,
+          "simMeanHp": 68.6472717439248,
           "aliveMismatch": true,
-          "hpDiffPoints": 77.06725763800675
+          "hpDiffPoints": 68.6472717439248
         },
         {
           "hex": {
@@ -4814,10 +4814,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.8,
-          "simMeanHp": 77.68059899780144,
+          "simAliveRate": 0.9,
+          "simMeanHp": 67.91805474436607,
           "aliveMismatch": true,
-          "hpDiffPoints": 77.68059899780144
+          "hpDiffPoints": 67.91805474436607
         },
         {
           "hex": {
@@ -4828,10 +4828,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.1,
-          "simMeanHp": 8.517573794531925,
+          "simAliveRate": 0.2,
+          "simMeanHp": 5.759799878972509,
           "aliveMismatch": false,
-          "hpDiffPoints": 8.517573794531925
+          "hpDiffPoints": 5.759799878972509
         }
       ],
       "warnings": []
@@ -5671,7 +5671,7 @@
     "pvpRoundCount": 22,
     "winnerMatchRate": 0.5454545454545454,
     "weakSignalRoundCount": 0,
-    "avgPlayerDamageErrorPct": -0.2855873062565342,
-    "avgSurvivorHpErrorPts": 7.2276967896733
+    "avgPlayerDamageErrorPct": -0.28972991594803443,
+    "avgSurvivorHpErrorPts": 7.367597153170844
   }
 }

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-06-15T05:04:17.626Z",
+  "computedAt": "2026-06-15T05:31:01.398Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "26cd77cd447e34d9e24df3aed61ee3767922903d",
+  "engineSha": "3bcc078c85c489c720aca19bf6743f4b39a7d4e2",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [
@@ -1391,13 +1391,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 6549,
-          "simMean": 4394.703880619522,
-          "simMedian": 4392.089361338942,
+          "simMean": 4315.759434004797,
+          "simMedian": 4335.101883509315,
           "simRange": [
             4070.2823108894404,
-            4577.11302057378
+            4497.5091044898645
           ],
-          "diffPct": -0.3289503923317266
+          "diffPct": -0.3410048199717824
         },
         {
           "hex": {
@@ -1406,13 +1406,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 2012,
-          "simMean": 3719.0015938043966,
+          "simMean": 3679.1089557675864,
           "simMedian": 3684.0889617503217,
           "simRange": [
             3475.2747000949894,
-            4044.212030681634
+            3890.139306278345
           ],
-          "diffPct": 0.8484103348928412
+          "diffPct": 0.8285829800037706
         },
         {
           "hex": {
@@ -1451,13 +1451,13 @@
           },
           "championId": "TFT17_Nunu",
           "actual": 758,
-          "simMean": 150.47525891783917,
+          "simMean": 144.1218044805833,
           "simMedian": 156.42604754088077,
           "simRange": [
             45.11278195488722,
-            298.7328293771794
+            235.1982850046208
           ],
-          "diffPct": -0.8014838272851726
+          "diffPct": -0.8098656932973836
         },
         {
           "hex": {
@@ -2202,13 +2202,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 7979,
-          "simMean": 7303.3229904303225,
-          "simMedian": 7204.873046113686,
+          "simMean": 7309.752772217222,
+          "simMedian": 7243.7731983017675,
           "simRange": [
-            6624.1813495622555,
+            6540.306371591056,
             8489.67980556526
           ],
-          "diffPct": -0.08468191622630374
+          "diffPct": -0.08387607817806471
         },
         {
           "hex": {
@@ -2217,13 +2217,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 4967,
-          "simMean": 5444.209684225585,
-          "simMedian": 5342.103517420235,
+          "simMean": 5365.8456378788105,
+          "simMedian": 5394.823252915723,
           "simRange": [
-            4958.669788903179,
-            6291.83438500026
+            4939.0961772944775,
+            5803.769610611248
           ],
-          "diffPct": 0.09607603870054059
+          "diffPct": 0.08029910164662986
         },
         {
           "hex": {
@@ -2232,13 +2232,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 1620,
-          "simMean": 218.4163636754659,
+          "simMean": 211.72312360986058,
           "simMedian": 215.05128156298233,
           "simRange": [
             158.5256407505426,
-            300.4291265908652
+            265.69285266658244
           ],
-          "diffPct": -0.865175084150947
+          "diffPct": -0.8693067138210737
         },
         {
           "hex": {
@@ -2247,13 +2247,13 @@
           },
           "championId": "TFT17_Rammus",
           "actual": 700,
-          "simMean": 227.31248009832115,
+          "simMean": 229.61124160857966,
           "simMedian": 246.05983482814736,
           "simRange": [
             112.8482972136223,
             280.5412579802679
           ],
-          "diffPct": -0.6752678855738269
+          "diffPct": -0.6719839405591719
         },
         {
           "hex": {
@@ -2262,13 +2262,13 @@
           },
           "championId": "TFT17_Nunu",
           "actual": 418,
-          "simMean": 89.91114916710839,
-          "simMedian": 92.19893031866809,
+          "simMean": 93.20147615450222,
+          "simMedian": 95.65061824141284,
           "simRange": [
             23.076923076923077,
             182.06435565861443
           ],
-          "diffPct": -0.784901557016487
+          "diffPct": -0.7770299613528656
         }
       ],
       "survivors": [
@@ -2375,13 +2375,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 8618,
-          "simMean": 7024.44239858072,
-          "simMedian": 7117.19505228394,
+          "simMean": 6947.046701318866,
+          "simMedian": 6897.365753657081,
           "simRange": [
-            6765.474059798327,
+            6641.174217512647,
             7264.892396296083
           ],
-          "diffPct": -0.1849103738012625
+          "diffPct": -0.19389107666293035
         },
         {
           "hex": {
@@ -2390,13 +2390,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 4851,
-          "simMean": 5593.511917403509,
+          "simMean": 5557.209797332075,
           "simMedian": 5613.808716731666,
           "simRange": [
-            5008.109326501724,
+            4645.088125787387,
             5903.401246282694
           ],
-          "diffPct": 0.15306368117986166
+          "diffPct": 0.145580250944563
         },
         {
           "hex": {
@@ -2522,9 +2522,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 61.58817266397663,
+          "simMeanHp": 59.40653644251495,
           "aliveMismatch": true,
-          "hpDiffPoints": 61.58817266397663
+          "hpDiffPoints": 59.40653644251495
         },
         {
           "hex": {
@@ -2536,9 +2536,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 42.43886265674625,
+          "simMeanHp": 42.15988690058866,
           "aliveMismatch": true,
-          "hpDiffPoints": 42.43886265674625
+          "hpDiffPoints": 42.15988690058866
         },
         {
           "hex": {
@@ -2550,9 +2550,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 39.75369124912946,
+          "simMeanHp": 37.7006364996355,
           "aliveMismatch": true,
-          "hpDiffPoints": 39.75369124912946
+          "hpDiffPoints": 37.7006364996355
         },
         {
           "hex": {
@@ -2605,10 +2605,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.7,
-          "simMeanHp": 25.940168543677306,
+          "simAliveRate": 0.6,
+          "simMeanHp": 25.872507983794723,
           "aliveMismatch": true,
-          "hpDiffPoints": 25.940168543677306
+          "hpDiffPoints": 25.872507983794723
         },
         {
           "hex": {
@@ -2619,10 +2619,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.7,
-          "simMeanHp": 11.011003699944894,
-          "aliveMismatch": true,
-          "hpDiffPoints": 11.011003699944894
+          "simAliveRate": 0.5,
+          "simMeanHp": 12.876975521186077,
+          "aliveMismatch": false,
+          "hpDiffPoints": 12.876975521186077
         },
         {
           "hex": {
@@ -2903,13 +2903,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 8933,
-          "simMean": 6543.508150636884,
-          "simMedian": 6583.330748078995,
+          "simMean": 6508.54092676415,
+          "simMedian": 6538.971766495464,
           "simRange": [
-            6009.518056048523,
+            6017.688011436117,
             6759.803072708181
           ],
-          "diffPct": -0.26749041188437434
+          "diffPct": -0.27140479942190193
         },
         {
           "hex": {
@@ -2933,13 +2933,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 1981,
-          "simMean": 8524.140037281071,
-          "simMedian": 8245.312047058136,
+          "simMean": 8562.798464992302,
+          "simMedian": 8298.657213612176,
           "simRange": [
             8002.866415798337,
-            9503.637366499379
+            9586.154194253651
           ],
-          "diffPct": 3.3029480248768657
+          "diffPct": 3.3224626274569924
         },
         {
           "hex": {
@@ -2948,13 +2948,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 1439,
-          "simMean": 148.26699763740967,
+          "simMean": 144.95643279222244,
           "simMedian": 151.93768516383534,
           "simRange": [
             87.14774999473644,
-            207.92113344066271
+            195.55671438201094
           ],
-          "diffPct": -0.8969652552901948
+          "diffPct": -0.8992658562944945
         },
         {
           "hex": {
@@ -3319,7 +3319,7 @@
     "pvpRoundCount": 21,
     "winnerMatchRate": 0.7619047619047619,
     "weakSignalRoundCount": 0,
-    "avgPlayerDamageErrorPct": -0.21944084251895402,
-    "avgSurvivorHpErrorPts": 0.03956082415803176
+    "avgPlayerDamageErrorPct": -0.22005245389511505,
+    "avgSurvivorHpErrorPts": 0.1595366624480135
   }
 }

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-06-15T05:31:01.398Z",
+  "computedAt": "2026-06-15T05:48:54.248Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "3bcc078c85c489c720aca19bf6743f4b39a7d4e2",
+  "engineSha": "af6e031027bcc8b95edc2eee4f173d772f50e786",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [
@@ -1391,13 +1391,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 6549,
-          "simMean": 4315.759434004797,
-          "simMedian": 4335.101883509315,
+          "simMean": 4307.799042396406,
+          "simMedian": 4318.200338795628,
           "simRange": [
             4070.2823108894404,
             4497.5091044898645
           ],
-          "diffPct": -0.3410048199717824
+          "diffPct": -0.3422203325093288
         },
         {
           "hex": {
@@ -1406,13 +1406,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 2012,
-          "simMean": 3679.1089557675864,
+          "simMean": 3682.3816828452436,
           "simMedian": 3684.0889617503217,
           "simRange": [
             3475.2747000949894,
             3890.139306278345
           ],
-          "diffPct": 0.8285829800037706
+          "diffPct": 0.8302095839191072
         },
         {
           "hex": {
@@ -2202,13 +2202,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 7979,
-          "simMean": 7309.752772217222,
+          "simMean": 7330.888719048933,
           "simMedian": 7243.7731983017675,
           "simRange": [
             6540.306371591056,
             8489.67980556526
           ],
-          "diffPct": -0.08387607817806471
+          "diffPct": -0.08122713133864731
         },
         {
           "hex": {
@@ -2217,13 +2217,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 4967,
-          "simMean": 5365.8456378788105,
-          "simMedian": 5394.823252915723,
+          "simMean": 5435.130929359356,
+          "simMedian": 5378.1880909735555,
           "simRange": [
             4939.0961772944775,
-            5803.769610611248
+            6249.150728867409
           ],
-          "diffPct": 0.08029910164662986
+          "diffPct": 0.09424822415126954
         },
         {
           "hex": {
@@ -2232,13 +2232,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 1620,
-          "simMean": 211.72312360986058,
-          "simMedian": 215.05128156298233,
+          "simMean": 215.79503510192217,
+          "simMedian": 206.22435871989282,
           "simRange": [
             158.5256407505426,
-            265.69285266658244
+            296.1004557723763
           ],
-          "diffPct": -0.8693067138210737
+          "diffPct": -0.86679318820869
         },
         {
           "hex": {
@@ -2247,13 +2247,13 @@
           },
           "championId": "TFT17_Rammus",
           "actual": 700,
-          "simMean": 229.61124160857966,
-          "simMedian": 246.05983482814736,
+          "simMean": 230.78152027624515,
+          "simMedian": 249.194509750748,
           "simRange": [
             112.8482972136223,
             280.5412579802679
           ],
-          "diffPct": -0.6719839405591719
+          "diffPct": -0.6703121138910784
         },
         {
           "hex": {
@@ -2262,13 +2262,13 @@
           },
           "championId": "TFT17_Nunu",
           "actual": 418,
-          "simMean": 93.20147615450222,
-          "simMedian": 95.65061824141284,
+          "simMean": 82.85046452492699,
+          "simMedian": 85.8962501949956,
           "simRange": [
             23.076923076923077,
             182.06435565861443
           ],
-          "diffPct": -0.7770299613528656
+          "diffPct": -0.8017931470695526
         }
       ],
       "survivors": [
@@ -2375,13 +2375,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 8618,
-          "simMean": 6947.046701318866,
-          "simMedian": 6897.365753657081,
+          "simMean": 6975.918657792443,
+          "simMedian": 7013.79290751881,
           "simRange": [
-            6641.174217512647,
+            6605.496070212387,
             7264.892396296083
           ],
-          "diffPct": -0.19389107666293035
+          "diffPct": -0.19054088445202566
         },
         {
           "hex": {
@@ -2390,13 +2390,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 4851,
-          "simMean": 5557.209797332075,
+          "simMean": 5578.965434892614,
           "simMedian": 5613.808716731666,
           "simRange": [
-            4645.088125787387,
+            4862.644501392769,
             5903.401246282694
           ],
-          "diffPct": 0.145580250944563
+          "diffPct": 0.15006502471503075
         },
         {
           "hex": {
@@ -2405,13 +2405,13 @@
           },
           "championId": "TFT17_Mordekaiser",
           "actual": 742,
-          "simMean": 16.8827585023025,
+          "simMean": 21.416091835635832,
           "simMedian": 0,
           "simRange": [
             0,
             69.51724019543877
           ],
-          "diffPct": -0.9772469561963578
+          "diffPct": -0.9711373425395744
         }
       ],
       "survivors": [
@@ -2522,9 +2522,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 59.40653644251495,
+          "simMeanHp": 60.91929846365641,
           "aliveMismatch": true,
-          "hpDiffPoints": 59.40653644251495
+          "hpDiffPoints": 60.91929846365641
         },
         {
           "hex": {
@@ -2536,9 +2536,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 42.15988690058866,
+          "simMeanHp": 42.15319785353199,
           "aliveMismatch": true,
-          "hpDiffPoints": 42.15988690058866
+          "hpDiffPoints": 42.15319785353199
         },
         {
           "hex": {
@@ -2550,9 +2550,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 37.7006364996355,
+          "simMeanHp": 39.13830663374485,
           "aliveMismatch": true,
-          "hpDiffPoints": 37.7006364996355
+          "hpDiffPoints": 39.13830663374485
         },
         {
           "hex": {
@@ -2605,10 +2605,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.6,
-          "simMeanHp": 25.872507983794723,
+          "simAliveRate": 0.7,
+          "simMeanHp": 24.47508125951513,
           "aliveMismatch": true,
-          "hpDiffPoints": 25.872507983794723
+          "hpDiffPoints": 24.47508125951513
         },
         {
           "hex": {
@@ -2903,13 +2903,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 8933,
-          "simMean": 6508.54092676415,
+          "simMean": 6512.643360672615,
           "simMedian": 6538.971766495464,
           "simRange": [
-            6017.688011436117,
+            5985.461913196704,
             6759.803072708181
           ],
-          "diffPct": -0.27140479942190193
+          "diffPct": -0.27094555460958075
         },
         {
           "hex": {
@@ -3319,7 +3319,7 @@
     "pvpRoundCount": 21,
     "winnerMatchRate": 0.7619047619047619,
     "weakSignalRoundCount": 0,
-    "avgPlayerDamageErrorPct": -0.22005245389511505,
+    "avgPlayerDamageErrorPct": -0.2199234639934946,
     "avgSurvivorHpErrorPts": 0.1595366624480135
   }
 }

--- a/docs/wiki/champions/jax.md
+++ b/docs/wiki/champions/jax.md
@@ -15,7 +15,8 @@ last_verified: 2026-05-29 (17.4 patch fact 추가, sim 미반영 명시; 이전:
 sources:
   - "public/data/tft_set17_champions.json (TFT17_Jax entry)"
   - "src/types/index.ts:39 (mapGameRole: 'Tank' 포함 → 'Tank')"
-  - "src/lib/simulator/systems/ability.ts:206 (abilityOverride aoe_circle r=1 + stun 1.5 + selfBuff durability 0.3 for 3s)"
+  - "src/lib/simulator/systems/ability.ts:224 (TFT17_Jax: aoe_circle r=1 + stun 1.5 + selfBuff durability 0.3 for 3s + casterArmorScaleVar/casterMrScaleVar 'ArmorMRScale')"
+  - "src/lib/simulator/engine/combatLoop.ts:6603-6622 (damageVar 없는 순수 armor/MR 스케일 → base 0 magic + ArmorMRScale×armor + ArmorMRScale×MR, main path) / :7494-7515 (OOR 동일)"
   - "src/lib/simulator/engine/combatLoop.ts:2258-2296 (applyHeroCarryTransforms — JaxCarry 활성 시 role=Fighter + selectedCarryAugment set)"
   - "src/lib/simulator/engine/combatLoop.ts:4643 (carry 변환 시 Fighter AS bonus 자동 수령)"
   - "src/lib/simulator/engine/combatLoop.ts:6193-6195 (self_buff pattern self-hit 회피 comment — Jax/Zed carry 사례)"
@@ -61,28 +62,28 @@ raw 명세 (`public/data/tft_set17_champions.json` desc): "`@Duration@`초 동�
 
 → **3단계 효과**: (1) `Duration`초 자기 buff (DR + shield), (2) duration 만료 시 주변 AOE damage, (3) AOE 적에 stun.
 
-**sim 적용** (`ability.ts:206`):
+**sim 적용** (`ability.ts:224`):
 ```ts
-TFT17_Jax: { pattern: 'aoe_circle', radius: 1, stun: 1.5, selfBuff: { durability: 0.3, duration: 3 } }
+TFT17_Jax: { pattern: 'aoe_circle', radius: 1, stun: 1.5, selfBuff: { durability: 0.3, duration: 3 }, casterArmorScaleVar: 'ArmorMRScale', casterMrScaleVar: 'ArmorMRScale' }
 ```
 
-→ cast 시점 즉시 모두 적용: aoe_circle r=1 damage + stun 1.5초 + selfBuff durability 0.3 (3초). **3초 지연 AOE 미모델링** (raw spec 의 "방어 태세가 끝나면" delay 가 sim 에 instant 로 처리됨).
+→ cast 시점 즉시 모두 적용: aoe_circle r=1 magic damage = `ArmorMRScale★ × (armor + MR)` (damageVar 없음 → base 0, magic) + stun 1.5초 + selfBuff durability 0.3 (3초). **3초 지연 AOE 미모델링** (raw spec 의 "방어 태세가 끝나면" delay 가 sim 에 instant 로 처리됨).
 
 ### raw ability variables (★1~★4 인덱스 — 첫 값 sentinel filler)
 
 | 변수 | raw 값 | sim 적용 | 비고 |
 |------|--------|---------|------|
 | `Duration` | `[3,3,3,3,3,3,3]` (전부 3초) | ✅ selfBuff.duration 3 (정합) | 단 sim 은 cast 시점 즉시 AOE → "방어 태세 끝나면" delay 누락 |
-| `FlatDR` | `[0, 15, 20, 25, 30, 0, 0]` ★1=15, ★2=20, ★3=25, ★4=30 | ❌ **미반영 (semantic 불일치)** | raw 는 **flat damage reduction 수치 + AP 스케일**. sim 은 `selfBuff.durability 0.3` (30% **percentage** reduction) — 단위/스케일 양쪽 다름 |
+| `FlatDR` | `[0, 20, 25, 30, 30, 0, 0]` (17.4 raw) filler → ★1=20, ★2=25, ★3=30, ★4=30 | ❌ **미반영 (semantic 불일치)** | raw 는 **flat damage reduction 수치 + AP 스케일**. sim 은 `selfBuff.durability 0.3` (30% **percentage** reduction) — 단위/스케일 양쪽 다름 |
 | `ShieldAP` | `[0, 400, 450, 500, 600, 0, 0]` ★1=400, ★2=450, ★3=500, ★4=600 | ❌ **미반영** | base ability 가 shield 부여 — sim 의 selfBuff 분기에 shield 적용 없음. `getAbilityShield` 헬퍼는 별도 경로 (PR #105 등 carry 한정) |
 | `StunDuration` | `[1.5, 1, 1.25, 1.5, 1.75, 1.5, 1.5]` ★1=1.0, ★2=1.25, ★3=1.5, ★4=1.75 (index 0 sentinel 1.5) | ❌ **미반영 (starLevel별)** | sim 은 `stun: 1.5` 하드코딩 — ★2 실제 1.25초, ★3 1.5초, ★4 1.75초 starLevel 스케일 미반영. [[ability-targeting]] cast path 3종 (main + OOR + recast) 모두 영향 |
-| `ArmorMRScale` | `[50, 0.75, 1.15, 1.7, 2.9, 500, 500]` ★1=0.75, ★2=1.15, ★3=1.7, ★4=2.9 (base 50 + sentinel) | 🔍 **미verify** | raw 명세 `@ModifiedDamage@(scaleArmor scaleMR)` 는 `base + armor*scale + MR*scale` 추정. sim 의 aoe_circle damage 가 어떤 base 값을 read 하는지 추가 verify 필요 (`Damage` 필드 없음 — `readVarByStar` fallback 동작?) |
+| `ArmorMRScale` | `[50, 0.75, 1.15, 1.7, 2.9, 500, 500]` filler(v0>v1) → idx=star → ★1=0.75, ★2=1.15, ★3=1.7, ★4=2.9 | ✅ **반영** | `@ModifiedDamage@(scaleArmor scaleMR)` = `ArmorMRScale★ × armor`(casterArmorScaleVar) + `ArmorMRScale★ × MR`(casterMrScaleVar) magic. damageVar 없어 base 0 (auto-detect garbage 제거). main + OOR cast path 일관 |
 | `AttackRadius` | `[1,1,1,1,1,1,1]` (전부 1) | ✅ aoe_circle r=1 (정합) | — |
 
 ### Trait — 별돌보미(Stargazer) + 요새(Bastion)
 
-- **별돌보미**: 강화 칸의 별돌보미 유닛에 별자리 효과 추가 적용 — [[stargazer]] 참조. Jax 는 1코 별돌보미 4명 (나서스/뽀삐/렉사이/리산드라/등) 그룹과 별개 2코.
-- **요새**: Bastion — `applyBastionEffects` (`combatLoop.ts:1817` 함수 정의 + `:4580-4581` combat-start 호출) 통합. Tank role 보강 효과 (armor/MR 가산 + `bastionDoubleEndTick` Duration doubled 만료 처리). PR #162 subagent P2-4 정정 (이전 `traitModules.ts` 잘못 인용).
+- **별돌보미**: Stargazer — `applyStargazerEffects` (`combatLoop.ts:3283` 함수 정의 + `:4774-4775` combat-start 호출) 통합. 강화 칸 별자리 효과 (constellation variant) — 상세는 [[stargazer]] 참조.
+- **요새**: Bastion — `applyBastionEffects` (`combatLoop.ts:1926` 함수 정의 + `:4780-4781` combat-start 호출) 통합. Tank role 보강 효과 (armor/MR 가산 + `bastionDoubleEndTick` Duration doubled 만료 처리). PR #162 subagent P2-4 정정 (이전 `traitModules.ts` 잘못 인용).
 
 ## JaxCarry 변환 시 (참조)
 
@@ -99,7 +100,7 @@ JaxCarry augment 활성 시:
 | 패치 | 변경 | sim 적용 |
 |------|------|---------|
 | [[patch-17-2b]] (2026-04-29) | `ShieldAmount` (=`ShieldAP`): `400/500/625 → 400/470/550` — base ability shield 너프 | ❌ sim 미반영 (ShieldAP 자체 미적용) |
-| [[patch-17-3]] (2026-05-13) | `FlatDR` (AP): `15/25/35/45 → 15/20/25/30` + `ShieldAP`: `400/470/550 → 400/450/500` — base ability 너프 2건 | ❌ sim 미반영 (양쪽 변수 모두 dead in sim) |
+| [[patch-17-3]] (2026-05-13) | `FlatDR` (AP): `15/25/35/45 → 20/25/30/30` (17.3 이전값 raw diff 미확인 — 이전 스냅샷 부재) + `ShieldAP`: `400/470/550 → 400/450/500` — base ability 너프 2건 | ❌ sim 미반영 (양쪽 변수 모두 dead in sim) |
 | [[patch-17-4]] (2026-05-27) | **조정 (Adjustment)**: `FlatDR` **AP 스케일링 제거** — `15/20/25 AP` (★1~★3) → **`20/25/30`** (평탄 수치, AP scaling 제거). raw desc 의 `(scaleAP)` 제거 | ❌ sim 미반영 + **분기 구조 영향**: AP scaling 자체 제거라 단순 수치 변경 아니라 변수 type 변경 (AP 의존 → flat). [[patch-17-4]] sequence B/C 대기 |
 
 ⚠️ **17.4 sim 영향 평가**:
@@ -119,12 +120,13 @@ JaxCarry augment 활성 시:
 ❌ **미반영**:
 - **3초 지연 AOE** — raw 는 "방어 태세 만료 시 주변 AOE" 시퀀스. sim 은 cast 즉시 selfBuff + damage + stun 동시 적용
 - **`ShieldAP` (보호막)** — base ability 의 AP 스케일 shield 없음 (sim selfBuff 분기에 shield 추가 안 함)
-- **`FlatDR` raw 수치** — 30% durability 하드코딩 (raw `15~30 + AP scale flat reduction` 의미 미반영)
+- **`FlatDR` raw 수치** — 30% durability 하드코딩 (raw `20~30 + AP scale flat reduction` (17.4) 의미 미반영)
 - **`StunDuration` starLevel별** — 1.5초 하드코딩 (★1=1.0, ★2=1.25, ★3=1.5, ★4=1.75 raw 스케일 미반영)
 - 17.2b/17.3 두 차례 patch 변경 (`FlatDR`, `ShieldAP`) — sim 미반영 (변수 자체 dead)
 
+✅ **해소**: `ArmorMRScale` damage formula — `@ModifiedDamage@(scaleArmor scaleMR)` = `ArmorMRScale★ × armor`(casterArmorScaleVar) + `ArmorMRScale★ × MR`(casterMrScaleVar) magic 으로 모델 (damageVar 없어 base 0, under-damage fix). calibration Jax -57%→-49%.
+
 🔍 **검증 필요**:
-- `ArmorMRScale` 기반 damage formula (`@ModifiedDamage@(scaleArmor scaleMR)`) — raw 명세는 `base + armor*scale + MR*scale` 추정. sim aoe_circle damage 가 어떤 값을 read 하는지 (`damageVar` 미지정 → `'Damage'` fallback? raw 에 `Damage` 변수 없음) 추가 verify 필요
 - `Duration` 의 3초 selfBuff vs raw "방어 태세 만료 후 AOE" 의도 차이 — gameplay 시뮬 정확도 평가 필요 (boss 가 3초 후 죽으면 sim 은 다시 시전 가능 vs raw 는 만료 후 AOE 가 나옴)
 
 ## Lint 신규 등록 후보 (champion ingest 발견)
@@ -137,7 +139,7 @@ JaxCarry augment 활성 시:
 | L2 | `FlatDR` flat 수치 + AP 스케일 | sim 30% percent durability 와 다른 의미 |
 | L3 | `StunDuration` starLevel별 (1.0/1.25/1.5/1.75) | hardcoded 1.5 — ★1/★2 부족, ★4 부족 |
 | L4 | 3초 지연 AOE 시퀀스 | "방어 태세 만료 후 AOE" 모델링 부재 |
-| L5 | `ArmorMRScale` damage formula | sim aoe_circle damage source 미verify |
+| ~~L5~~ | ~~`ArmorMRScale` damage formula~~ | ✅ **해소** — casterArmorScaleVar+casterMrScaleVar 로 armor+MR 비례 magic 모델 (under-damage fix) |
 
 ⚠️ **우선순위 평가**: Jax 는 carry augment 활성 시점 (`Stargazer JaxCarry`) 이 주된 사용 컨텍스트. base raw 사용 빈도가 낮으면 위 lint 5건은 후순위. 단 carry 미활성 시 sim 결과 신뢰도 낮음 (특히 starLevel별 stun 차이 ★2/★4 0.5초+).
 
@@ -149,7 +151,7 @@ JaxCarry augment 활성 시:
 - [x] **raw role `APTank` → mapGameRole → sim Tank** (`src/types/index.ts:39` 'Tank' substring match 우선)
 - [x] JaxCarry 변환 시 role overwrite `Fighter` (`combatLoop.ts:2265`)
 - [x] cast path 3종 (main + OOR + recast) — base ability self_buff/aoe_circle 의 OOR 동작은 [[jax-carry]] 페이지에서 다룸 (base raw 는 단순 in-range aoe)
-- [ ] (사용자 verify) ArmorMRScale damage formula sim read site 추적
+- [x] ArmorMRScale damage formula sim read site ✅ casterArmorScaleVar+casterMrScaleVar (combatLoop.ts:6604-6621 main + 7496-7511 OOR)
 - [ ] (사용자 verify) 3초 지연 AOE 의도 vs sim instant 차이 — gameplay impact 평가
 - [ ] (선택) Lint L1~L5 정식 등록 (#17+) — 우선순위 평가 후
 
@@ -162,5 +164,5 @@ JaxCarry augment 활성 시:
 - [[stargazer]] — 별돌보미 trait + 강화 칸
 - [[patch-17-3]] — Jax FlatDR + ShieldAP 너프 (sim dead)
 - [[shen]] — 다른 raw role 변형 사례 (APFighter → Fighter)
-- 코드: `src/lib/simulator/systems/ability.ts:206`, `src/lib/simulator/engine/combatLoop.ts:2258`
+- 코드: `src/lib/simulator/systems/ability.ts:224`, `src/lib/simulator/engine/combatLoop.ts:2258`
 - 테스트: `tests/unit/simulator/hero-carry-augments.test.ts:223+` / `tests/unit/simulator/stargazer-huntress-serpent.test.ts`

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6599,14 +6599,25 @@ export function simulateCombat(
               rawAbilityDmgBase = result.damage;
               dmgType = result.type;
             }
-            // scaleArmor: caster(자기) 방어력 비례 추가 피해 (Rammus 중력회전 — 사용자 확인 표준 Rammus).
-            // 주 피해(DamageAP scaleAP) + (DamageArmor × caster.armor). 고방어 탱커 carry 의 주력 데미지원.
+            // scaleArmor/scaleMR: caster(자기) 방어 스탯 비례 추가 피해 (Rammus 중력회전 armor / Jax 별의반격 armor+MR).
+            // damageVar 없는 순수 스케일 어빌리티(Jax)는 base 0 (auto-detect garbage 제거) + magic.
+            if ((config.casterArmorScaleVar || config.casterMrScaleVar) && !config.damageVar) {
+              rawAbilityDmgBase = 0;
+              dmgType = 'magic';
+            }
             if (config.casterArmorScaleVar) {
               const armorCoef = readVarByStar(
                 unit.champion.ability.variables?.find(v => v.name === config.casterArmorScaleVar)?.value,
                 unit.starLevel, 0,
               );
               rawAbilityDmgBase += armorCoef * unit.stats.armor;
+            }
+            if (config.casterMrScaleVar) {
+              const mrCoef = readVarByStar(
+                unit.champion.ability.variables?.find(v => v.name === config.casterMrScaleVar)?.value,
+                unit.starLevel, 0,
+              );
+              rawAbilityDmgBase += mrCoef * unit.stats.magicResist;
             }
             // codex P1 (PR #98): self_buff pattern 은 caster 가 findAbilityTargets 의 self-target.
             // resolveAbilityDamage 의 damageVar fallback (Poppy ★3 'Shield'=575 등) 으로 인해
@@ -7481,14 +7492,23 @@ export function simulateCombat(
             bonusAdPercentOf(unit),
           );
           // codex P1 (PR #98): self_buff OOR 경로도 self-hit 회귀 방지 — damage 0 강제.
-          let rawOORDmg = outOfRangeConfig.pattern === 'self_buff' ? 0 : rawOORDmgResolved;
-          // scaleArmor: caster 방어력 비례 추가 (Rammus) — main path 와 동일 (cast path 3종 일관, PR #129 룰).
-          if (outOfRangeConfig.casterArmorScaleVar && rawOORDmg > 0) {
+          // damageVar 없는 순수 armor/MR 스케일(Jax) 도 base 0 (auto-detect garbage 제거).
+          const oorPureScale = (outOfRangeConfig.casterArmorScaleVar || outOfRangeConfig.casterMrScaleVar) && !outOfRangeConfig.damageVar;
+          let rawOORDmg = (outOfRangeConfig.pattern === 'self_buff' || oorPureScale) ? 0 : rawOORDmgResolved;
+          // scaleArmor/scaleMR: caster 방어 스탯 비례 추가 (Rammus armor / Jax armor+MR) — main path 와 일관 (PR #129 룰).
+          if (outOfRangeConfig.casterArmorScaleVar) {
             const oorArmorCoef = readVarByStar(
               unit.champion.ability.variables?.find(v => v.name === outOfRangeConfig.casterArmorScaleVar)?.value,
               unit.starLevel, 0,
             );
             rawOORDmg += oorArmorCoef * unit.stats.armor;
+          }
+          if (outOfRangeConfig.casterMrScaleVar) {
+            const oorMrCoef = readVarByStar(
+              unit.champion.ability.variables?.find(v => v.name === outOfRangeConfig.casterMrScaleVar)?.value,
+              unit.starLevel, 0,
+            );
+            rawOORDmg += oorMrCoef * unit.stats.magicResist;
           }
           // 타격당 확률 proc 기대값 배수 (main path 와 일관 — Corki dash OOR).
           const oorProcMult = outOfRangeConfig.procChance && outOfRangeConfig.procDamageMult

--- a/src/lib/simulator/systems/ability.ts
+++ b/src/lib/simulator/systems/ability.ts
@@ -49,6 +49,8 @@ export interface AbilityConfig {
     mrReduction?: number;
     duration?: number;
   };
+  /** aoe_circle 을 caster 중심으로 (기본 target 중심). Jax 별의반격 "주변 적" 등. */
+  selfCentered?: boolean;
   /** 다회 타격 횟수 — 총 피해 = base × hitCount (벨베스 12, 아칼리 5 등) */
   hitCount?: number;
   /**
@@ -221,7 +223,7 @@ export const CHAMPION_ABILITY_PATTERNS: Record<string, AbilityConfig> = {
   TFT17_Pyke:        { pattern: 'aoe_circle', radius: 1, dash: 'to_target', damageVar: 'TargetDamage', secondaryDamageVar: 'AoEDamage' },  // 작살+순간이동 TargetDamage + 주변 AoEDamage
   TFT17_Gragas:      { pattern: 'aoe_circle', radius: 1, heal: true, stun: 0.5 },  // 회복 + 인접 피해 + 냉각 2초 (stun 0.5초로 근사)
   TFT17_Gwen:        { pattern: 'cone', radius: 2, dash: 'to_lowest_hp', secondaryDamageVar: 'AreaDamage' },  // 대상 Damage + 원뿔 AreaDamage
-  TFT17_Jax:         { pattern: 'aoe_circle', radius: 1, stun: 1.5, selfBuff: { durability: 0.3, duration: 3 }, casterArmorScaleVar: 'ArmorMRScale', casterMrScaleVar: 'ArmorMRScale' },  // 방어 태세 + 종료 시 ArmorMRScale×(armor+MR) 마법 AOE + 기절 (damageVar 없음 → base 0)
+  TFT17_Jax:         { pattern: 'aoe_circle', radius: 1, selfCentered: true, stun: 1.5, selfBuff: { durability: 0.3, duration: 3 }, casterArmorScaleVar: 'ArmorMRScale', casterMrScaleVar: 'ArmorMRScale' },  // 방어 태세 + 종료 시 주변(caster 중심) ArmorMRScale×(armor+MR) 마법 AOE + 기절 (damageVar 없음 → base 0)
   TFT17_Milio:       { pattern: 'bounce', maxTargets: 4 },  // 공 튕기기
   TFT17_Zoe:         { pattern: 'line', maxTargets: 4 },  // 통통별 관통 + 방향전환
   TFT17_IvernMinion: { pattern: 'aoe_circle', radius: 1, stun: 1.0, heal: true },  // 회복 + 강타 + 열 피해
@@ -309,7 +311,9 @@ export function findAbilityTargets(
 
     case 'aoe_circle': {
       const radius = config.radius ?? 1;
-      const aoeHexes = getHexesInRadius(primaryTarget.position, radius);
+      // selfCentered: caster 중심 AOE (Jax 별의반격 "주변 적"). 기본은 target 중심.
+      const center = config.selfCentered ? caster.position : primaryTarget.position;
+      const aoeHexes = getHexesInRadius(center, radius);
       const aoeSet = new Set(aoeHexes.map(h => `${h.q},${h.r}`));
       return alive.filter(u => aoeSet.has(`${u.position.q},${u.position.r}`));
     }

--- a/src/lib/simulator/systems/ability.ts
+++ b/src/lib/simulator/systems/ability.ts
@@ -64,6 +64,8 @@ export interface AbilityConfig {
   damageVar?: string;
   /** caster(자기) 방어력 비례 추가 피해 변수명 (scaleArmor — Rammus 중력회전 등). 주 피해 + (변수값 × caster.armor) */
   casterArmorScaleVar?: string;
+  /** caster(자기) 마법 저항 비례 추가 피해 변수명 (scaleMR — Jax 별의 반격). 주 피해 + (변수값 × caster.magicResist). damageVar 없으면 armor/MR 스케일이 전체 피해(base 0). */
+  casterMrScaleVar?: string;
   /** 2차 피해 변수명 (폭발, 추가 투사체 등) — 주 피해와 합산 */
   secondaryDamageVar?: string;
   /**
@@ -219,7 +221,7 @@ export const CHAMPION_ABILITY_PATTERNS: Record<string, AbilityConfig> = {
   TFT17_Pyke:        { pattern: 'aoe_circle', radius: 1, dash: 'to_target', damageVar: 'TargetDamage', secondaryDamageVar: 'AoEDamage' },  // 작살+순간이동 TargetDamage + 주변 AoEDamage
   TFT17_Gragas:      { pattern: 'aoe_circle', radius: 1, heal: true, stun: 0.5 },  // 회복 + 인접 피해 + 냉각 2초 (stun 0.5초로 근사)
   TFT17_Gwen:        { pattern: 'cone', radius: 2, dash: 'to_lowest_hp', secondaryDamageVar: 'AreaDamage' },  // 대상 Damage + 원뿔 AreaDamage
-  TFT17_Jax:         { pattern: 'aoe_circle', radius: 1, stun: 1.5, selfBuff: { durability: 0.3, duration: 3 } },  // 방어 태세 + 기절
+  TFT17_Jax:         { pattern: 'aoe_circle', radius: 1, stun: 1.5, selfBuff: { durability: 0.3, duration: 3 }, casterArmorScaleVar: 'ArmorMRScale', casterMrScaleVar: 'ArmorMRScale' },  // 방어 태세 + 종료 시 ArmorMRScale×(armor+MR) 마법 AOE + 기절 (damageVar 없음 → base 0)
   TFT17_Milio:       { pattern: 'bounce', maxTargets: 4 },  // 공 튕기기
   TFT17_Zoe:         { pattern: 'line', maxTargets: 4 },  // 통통별 관통 + 방향전환
   TFT17_IvernMinion: { pattern: 'aoe_circle', radius: 1, stun: 1.0, heal: true },  // 회복 + 강타 + 열 피해

--- a/tests/unit/simulator/jax-armor-mr-scaling.test.ts
+++ b/tests/unit/simulator/jax-armor-mr-scaling.test.ts
@@ -1,0 +1,58 @@
+/**
+ * 회귀 가드 — 잭스(Jax) 「별의 반격」 armor+MR 비례 마법 피해 (under-damage fix, 2026-06-15).
+ *
+ * 버그: Jax 어빌리티는 방어 태세 종료 시 주변 적에 ModifiedDamage(scaleArmor scaleMR)
+ *   = ArmorMRScale★ × (caster.armor + caster.magicResist) 마법 피해를 입히는데, sim config 에
+ *   damageVar 가 없어 어빌리티 데미지가 통째로 미모델 (selfBuff+stun 만) → Jax -57% under.
+ * fix: AbilityConfig.casterMrScaleVar 추가 + damageVar 없는 순수 스케일은 base 0(magic).
+ *   damage = ArmorMRScale × armor (casterArmorScaleVar) + ArmorMRScale × MR (casterMrScaleVar).
+ *
+ * 검증: calibration Jax -57%→-49% (sim +19%), overshoot 0. game-423 2-5 simTotal≈actual.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { setScalingData, type ScalingData } from '@/lib/simulator/systems/ability';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import scalingJson from '../../../public/data/tft_set17_scaling.json';
+import type { PlacedChampion, RawChampion, RawItem } from '@/types';
+
+const { champions, traits, items } = loadServerCatalogs();
+const jax = champions.find(c => c.apiName === 'TFT17_Jax')!;
+const cho = champions.find(c => c.apiName === 'TFT17_Chogath')!;
+// armor+MR +100/+100 — armor/MR 스케일 신호 증폭용.
+const omni = items.find(i => i.apiName === 'TFT17_AnimaSquadItem_Tier4_Omniweapon')!;
+
+beforeAll(() => {
+  setScalingData(scalingJson as unknown as ScalingData);
+});
+
+function placed(c: RawChampion, q: number, r: number, star: 1 | 2 | 3, it: RawItem[] = []): PlacedChampion {
+  return { champion: c, starLevel: star, position: { q, r }, items: it };
+}
+
+function jaxCastValue(jaxItems: RawItem[]): number {
+  // Jax 포위 → 마나 충전 + 3초 방어 태세 생존 → cast.
+  const r = simulateCombat(
+    [placed(jax, 5, 3, 2, jaxItems)],
+    [placed(cho, 6, 3, 2), placed(cho, 4, 3, 2), placed(cho, 5, 4, 2), placed(cho, 5, 2, 2)],
+    { seed: 0, allTraits: traits, skipMirror: true, stageNumber: 5 },
+  );
+  const t = r.playerUnits[0];
+  const cast = r.logs.find(l => l.type === 'ability' && l.sourceId === t.id);
+  return cast?.value ?? 0;
+}
+
+describe('잭스 armor+MR 비례 마법 피해 (회귀 가드)', () => {
+  it('어빌리티가 armor+MR 비례 마법 피해를 입힘 — damageVar 없어도 base 0 + 스케일', () => {
+    const base = jaxCastValue([]);
+    // 버그(어빌리티 데미지 미모델) 시 cast 데미지 0/없음. 정상 시 > 0.
+    expect(base).toBeGreaterThan(0);
+  });
+
+  it('armor+MR 증가 시 어빌리티 피해 증가 (scaleArmor + scaleMR 검증)', () => {
+    const base = jaxCastValue([]);
+    const buffed = jaxCastValue([omni]); // +100 armor +100 MR
+    // ArmorMRScale★2(1.15) × +200(armor+MR) ≈ +230 pre-mitig → mitigated 후에도 유의미 증가.
+    expect(buffed).toBeGreaterThan(base * 1.2);
+  });
+});


### PR DESCRIPTION
## 배경

under-damage 잔여 갭 Jax(-57%, 비-DOT 중 최대 %). 진단 결과 Jax 「별의 반격」은 방어 태세 종료 시 주변 적에 `ModifiedDamage`(scaleArmor scaleMR) = `ArmorMRScale★ × (armor + MR)` 마법 피해 + 기절인데, **sim config 에 damageVar 가 없어 어빌리티 데미지가 통째로 미모델** (selfBuff durability + stun 만).

## 변경

- `AbilityConfig.casterMrScaleVar` 추가 (caster MR 비례, scaleMR). Rammus 의 `casterArmorScaleVar`(armor) 와 짝.
- **damageVar 없는 순수 armor/MR 스케일** (Jax) 은 base 0 (auto-detect garbage 제거) + `magic` 강제.
- Jax config: `casterArmorScaleVar: 'ArmorMRScale', casterMrScaleVar: 'ArmorMRScale'` → `ArmorMRScale × armor + ArmorMRScale × MR`.
- main + OOR cast path 일관 (PR #129 룰).
- `jax.md` sim_active 갱신 — `wiki-ingest-verifier` dispatch, P0(FlatDR raw 값 17.4 stale)/P1(체크리스트 page-internal·Bastion line drift)/P2 fix.
- 회귀 가드 `jax-armor-mr-scaling.test.ts` (cast 데미지 >0 + armor/MR(+100/+100 Omniweapon) 증가 시 피해 증가).

## 결과

- calibration Jax -57% → **-49%** (sim +19%), **overshoot 0** (여전히 과소 = 안전).
- game-423 -29.7% → -28.6%.
- 잔여: FlatDR(방어 효과, 데미지 무관) / 3초 지연 AOE / duration.

## 검증
- `pnpm lint`(0 errors) / `typecheck` / `build` ✅ · 958 test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)