### PR TITLE
fix(sim): 바드(Bard) 비행접시 DOT 초당값 × duration (under-damage)

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-06-15T05:48:56.090Z",
+  "computedAt": "2026-06-15T06:00:36.403Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "af6e031027bcc8b95edc2eee4f173d772f50e786",
+  "engineSha": "8cdab54c1fc80a0281642ecd523a93d722e25474",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [
@@ -3606,13 +3606,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 10653,
-          "simMean": 6192.414736456545,
-          "simMedian": 6527.924445214121,
+          "simMean": 6056.695159412956,
+          "simMedian": 6280.581294749543,
           "simRange": [
             4717.93695993069,
-            7224.941706537424
+            7123.271183618954
           ],
-          "diffPct": -0.4187163487790721
+          "diffPct": -0.43145638229485067
         },
         {
           "hex": {
@@ -3636,13 +3636,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 2853,
-          "simMean": 490.73583266853456,
-          "simMedian": 496.7648425502081,
+          "simMean": 488.70254116847127,
+          "simMedian": 489.4340296687211,
           "simRange": [
             439.73799044644494,
-            535.7883148052538
+            538.5609850326128
           ],
-          "diffPct": -0.8279930484863182
+          "diffPct": -0.8287057339051976
         },
         {
           "hex": {
@@ -3651,13 +3651,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 1703,
-          "simMean": 1463.8038122316068,
-          "simMedian": 1669.5181670431725,
+          "simMean": 1368.0565092242125,
+          "simMedian": 1586.6478698930507,
           "simRange": [
             581.0038610038611,
             2002.8220208844407
           ],
-          "diffPct": -0.1404557767283577
+          "diffPct": -0.19667850309793747
         },
         {
           "hex": {
@@ -3698,13 +3698,13 @@
           },
           "championId": "TFT17_Vex",
           "actual": 5808,
-          "simMean": 9350.792990542268,
-          "simMedian": 9253.183431973299,
+          "simMean": 9255.18565756384,
+          "simMedian": 9112.4171996718,
           "simRange": [
             8004.002051069678,
             10780.661539357734
           ],
-          "diffPct": 0.6099850190327596
+          "diffPct": 0.5935237013711845
         },
         {
           "hex": {
@@ -3713,13 +3713,13 @@
           },
           "championId": "TFT17_Morgana",
           "actual": 3254,
-          "simMean": 3928.1791944822508,
-          "simMedian": 3877.5724229047455,
+          "simMean": 3974.588974515933,
+          "simMedian": 3930.7821813335177,
           "simRange": [
-            3569.928152034444,
+            3637.310503005082,
             4643.7998617092835
           ],
-          "diffPct": 0.20718475552619875
+          "diffPct": 0.22144713414749015
         },
         {
           "hex": {
@@ -3728,13 +3728,13 @@
           },
           "championId": "TFT17_TahmKench",
           "actual": 2584,
-          "simMean": 512.874747716316,
-          "simMedian": 527.0625447443047,
+          "simMean": 539.7676046292696,
+          "simMedian": 530.244926966724,
           "simRange": [
             383.15649867374,
-            629.9693768118938
+            693.4820353970442
           ],
-          "diffPct": -0.8015190604813018
+          "diffPct": -0.7911116081156078
         },
         {
           "hex": {
@@ -3743,13 +3743,13 @@
           },
           "championId": "TFT17_Blitzcrank",
           "actual": 2409,
-          "simMean": 755.0974475967547,
+          "simMean": 751.6778046416899,
           "simMedian": 802.4010899094919,
           "simRange": [
             451.7625396700696,
             1375.2881058683188
           ],
-          "diffPct": -0.6865514953936261
+          "diffPct": -0.6879710233948984
         },
         {
           "hex": {
@@ -3758,13 +3758,13 @@
           },
           "championId": "TFT17_Fiora",
           "actual": 2393,
-          "simMean": 2952.1576569007166,
-          "simMedian": 3043.109103559188,
+          "simMean": 2938.357657135729,
+          "simMedian": 3010.3241755101762,
           "simRange": [
             2523.3408285121886,
             3351.913076472056
           ],
-          "diffPct": 0.23366387668228858
+          "diffPct": 0.22789705688914705
         },
         {
           "hex": {
@@ -3773,13 +3773,13 @@
           },
           "championId": "TFT17_Sona",
           "actual": 2037,
-          "simMean": 7142.748664615649,
+          "simMean": 7145.448664722938,
           "simMedian": 7014.035921867031,
           "simRange": [
             5982.030856436558,
-            7912.9604990714815
+            7928.822037204963
           ],
-          "diffPct": 2.506504008156922
+          "diffPct": 2.5078294868546576
         }
       ],
       "survivors": [
@@ -3918,10 +3918,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.5,
-          "simMeanHp": 41.50957251809465,
-          "aliveMismatch": false,
-          "hpDiffPoints": 41.50957251809465
+          "simAliveRate": 0.7,
+          "simMeanHp": 39.220662222819485,
+          "aliveMismatch": true,
+          "hpDiffPoints": 39.220662222819485
         },
         {
           "hex": {
@@ -3933,9 +3933,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 75.14752043762651,
+          "simMeanHp": 77.47775111123289,
           "aliveMismatch": true,
-          "hpDiffPoints": 75.14752043762651
+          "hpDiffPoints": 77.47775111123289
         },
         {
           "hex": {
@@ -3974,10 +3974,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.4,
-          "simMeanHp": 52.960608937767745,
+          "simAliveRate": 0.5,
+          "simMeanHp": 41.43380924837099,
           "aliveMismatch": false,
-          "hpDiffPoints": 52.960608937767745
+          "hpDiffPoints": 41.43380924837099
         },
         {
           "hex": {
@@ -3989,9 +3989,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.9,
-          "simMeanHp": 67.11311608235616,
+          "simMeanHp": 68.50610371669372,
           "aliveMismatch": true,
-          "hpDiffPoints": 67.11311608235616
+          "hpDiffPoints": 68.50610371669372
         },
         {
           "hex": {
@@ -4003,9 +4003,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.9,
-          "simMeanHp": 19.51857717598733,
+          "simMeanHp": 22.47184004542024,
           "aliveMismatch": true,
-          "hpDiffPoints": 19.51857717598733
+          "hpDiffPoints": 22.47184004542024
         }
       ],
       "warnings": []
@@ -4432,13 +4432,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 9078,
-          "simMean": 6601.959725941153,
-          "simMedian": 6484.0287397967495,
+          "simMean": 7014.562624797678,
+          "simMedian": 7336.625221185671,
           "simRange": [
             4524.8644235205375,
             8405.756337183422
           ],
-          "diffPct": -0.2727517376138849
+          "diffPct": -0.22730087851975347
         },
         {
           "hex": {
@@ -4447,13 +4447,13 @@
           },
           "championId": "TFT17_Corki",
           "actual": 5651,
-          "simMean": 2587.4861175071164,
+          "simMean": 2564.4429265765903,
           "simMedian": 2627.2943908650377,
           "simRange": [
             2066.6229683666825,
-            3024.0357205684245
+            2999.6374625345643
           ],
-          "diffPct": -0.5421188962118003
+          "diffPct": -0.5461966153642558
         },
         {
           "hex": {
@@ -4462,13 +4462,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 4828,
-          "simMean": 1123.0322638027933,
+          "simMean": 1116.8722065318084,
           "simMedian": 1025.3000175674972,
           "simRange": [
             837.7422445960614,
-            1571.3977070634112
+            1526.4566086338025
           ],
-          "diffPct": -0.7673918260557595
+          "diffPct": -0.7686677285559634
         },
         {
           "hex": {
@@ -4492,13 +4492,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 2846,
-          "simMean": 1386.9987861642724,
-          "simMedian": 1513.3759570190566,
+          "simMean": 1384.6519500463892,
+          "simMedian": 1500.3732156065075,
           "simRange": [
             807.2356126323001,
-            1579.1368837309724
+            1610.5577380712714
           ],
-          "diffPct": -0.5126497589022233
+          "diffPct": -0.5134743675170804
         },
         {
           "hex": {
@@ -4507,13 +4507,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 925,
-          "simMean": 724.5524434523775,
-          "simMedian": 770.8471420408525,
+          "simMean": 651.7587573843754,
+          "simMedian": 731.3373731631297,
           "simRange": [
             309.7894736842105,
-            1097.0716581154802
+            819.7941697770517
           ],
-          "diffPct": -0.2167000611325649
+          "diffPct": -0.2953959379628374
         }
       ],
       "opponentDamage": [
@@ -4524,13 +4524,13 @@
           },
           "championId": "TFT17_Vex",
           "actual": 7575,
-          "simMean": 14021.124088010121,
-          "simMedian": 13943.213331264747,
+          "simMean": 13896.067184819607,
+          "simMedian": 13879.048331829492,
           "simRange": [
             12820.500878736542,
-            15136.818911830296
+            14779.335756453323
           ],
-          "diffPct": 0.8509734769650326
+          "diffPct": 0.8344643148276709
         },
         {
           "hex": {
@@ -4539,13 +4539,13 @@
           },
           "championId": "TFT17_Morgana",
           "actual": 2901,
-          "simMean": 688.6971773257744,
-          "simMedian": 641.3232815741442,
+          "simMean": 686.7299543938041,
+          "simMedian": 633.6043520452189,
           "simRange": [
             535.5953283451622,
             1033.6392563185218
           ],
-          "diffPct": -0.7626000767577474
+          "diffPct": -0.7632781956588058
         },
         {
           "hex": {
@@ -4554,13 +4554,13 @@
           },
           "championId": "TFT17_Fiora",
           "actual": 2384,
-          "simMean": 1578.6028987698269,
-          "simMedian": 1554.1606248177131,
+          "simMean": 1506.123223267319,
+          "simMedian": 1507.232487675541,
           "simRange": [
             1185.2413674368465,
-            2223.894396885127
+            1957.703539065021
           ],
-          "diffPct": -0.3378343545428579
+          "diffPct": -0.36823690299189643
         },
         {
           "hex": {
@@ -4569,13 +4569,13 @@
           },
           "championId": "TFT17_Sona",
           "actual": 2348,
-          "simMean": 7114.435498290282,
-          "simMedian": 6890.610617613077,
+          "simMean": 6943.959148509331,
+          "simMedian": 6500.644807905508,
           "simRange": [
-            6333.387452499893,
-            8162.847662278562
+            6232.030804758382,
+            7948.238223514001
           ],
-          "diffPct": 2.029998082747139
+          "diffPct": 1.9573931637603623
         },
         {
           "hex": {
@@ -4584,13 +4584,13 @@
           },
           "championId": "TFT17_Blitzcrank",
           "actual": 1769,
-          "simMean": 1293.0704935555307,
-          "simMedian": 1298.3190088756721,
+          "simMean": 1258.4166897373962,
+          "simMedian": 1244.9006326522056,
           "simRange": [
-            1038.458163632329,
+            1026.4213875470277,
             1560.7464861157555
           ],
-          "diffPct": -0.26903872608505897
+          "diffPct": -0.28862821382849285
         },
         {
           "hex": {
@@ -4599,13 +4599,13 @@
           },
           "championId": "TFT17_TahmKench",
           "actual": 1551,
-          "simMean": 548.1028603682787,
-          "simMedian": 541.9681690490877,
+          "simMean": 566.8039869797641,
+          "simMedian": 556.484297216117,
           "simRange": [
             409.13232972004096,
             759.0517178948583
           ],
-          "diffPct": -0.6466132428315418
+          "diffPct": -0.6345557788654004
         }
       ],
       "survivors": [
@@ -4744,10 +4744,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.7,
-          "simMeanHp": 44.042531980674276,
+          "simAliveRate": 0.6,
+          "simMeanHp": 39.555796774306934,
           "aliveMismatch": true,
-          "hpDiffPoints": 44.042531980674276
+          "hpDiffPoints": 39.555796774306934
         },
         {
           "hex": {
@@ -4772,10 +4772,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.5,
-          "simMeanHp": 21.114288584778713,
+          "simAliveRate": 0.4,
+          "simMeanHp": 25.049429114114734,
           "aliveMismatch": false,
-          "hpDiffPoints": 21.114288584778713
+          "hpDiffPoints": 25.049429114114734
         },
         {
           "hex": {
@@ -4801,9 +4801,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 68.6472717439248,
+          "simMeanHp": 68.5693470354995,
           "aliveMismatch": true,
-          "hpDiffPoints": 68.6472717439248
+          "hpDiffPoints": 68.5693470354995
         },
         {
           "hex": {
@@ -4814,10 +4814,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.9,
-          "simMeanHp": 67.91805474436607,
+          "simAliveRate": 0.8,
+          "simMeanHp": 77.80296366834379,
           "aliveMismatch": true,
-          "hpDiffPoints": 67.91805474436607
+          "hpDiffPoints": 77.80296366834379
         },
         {
           "hex": {
@@ -4829,9 +4829,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.2,
-          "simMeanHp": 5.759799878972509,
+          "simMeanHp": 7.057150529656017,
           "aliveMismatch": false,
-          "hpDiffPoints": 5.759799878972509
+          "hpDiffPoints": 7.057150529656017
         }
       ],
       "warnings": []
@@ -5671,7 +5671,7 @@
     "pvpRoundCount": 22,
     "winnerMatchRate": 0.5454545454545454,
     "weakSignalRoundCount": 0,
-    "avgPlayerDamageErrorPct": -0.28972991594803443,
-    "avgSurvivorHpErrorPts": 7.367597153170844
+    "avgPlayerDamageErrorPct": -0.2907127870589164,
+    "avgSurvivorHpErrorPts": 7.084825937266642
   }
 }

--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-06-15T06:00:36.403Z",
+  "computedAt": "2026-06-15T06:06:34.363Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "8cdab54c1fc80a0281642ecd523a93d722e25474",
+  "engineSha": "d736e317cb27f3e1417353456fc4d454b6327cb8",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-06-15T05:58:35.122Z",
+  "computedAt": "2026-06-15T06:06:32.437Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "8cdab54c1fc80a0281642ecd523a93d722e25474",
+  "engineSha": "d736e317cb27f3e1417353456fc4d454b6327cb8",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [

--- a/actual-data/diff-game-20260424-001.json
+++ b/actual-data/diff-game-20260424-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260424-001",
-  "computedAt": "2026-06-15T05:48:54.248Z",
+  "computedAt": "2026-06-15T05:58:35.122Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "af6e031027bcc8b95edc2eee4f173d772f50e786",
+  "engineSha": "8cdab54c1fc80a0281642ecd523a93d722e25474",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [
@@ -1766,13 +1766,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 10368,
-          "simMean": 4985.292695050451,
-          "simMedian": 4941.37908932997,
+          "simMean": 4951.6069266474215,
+          "simMedian": 4997.338370724297,
           "simRange": [
             4679.308425877075,
-            5424.933518654543
+            5308.395060418711
           ],
-          "diffPct": -0.5191654422212143
+          "diffPct": -0.5224144553773706
         },
         {
           "hex": {
@@ -1781,13 +1781,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 4461,
-          "simMean": 5011.179841160959,
-          "simMedian": 5082.474462942976,
+          "simMean": 4975.289536468786,
+          "simMedian": 4989.124292364924,
           "simRange": [
             4398.993260163622,
             5454.875917904824
           ],
-          "diffPct": 0.1233310560773277
+          "diffPct": 0.11528570644895442
         },
         {
           "hex": {
@@ -1796,13 +1796,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 1717,
-          "simMean": 109.17774349792111,
-          "simMedian": 96.35042620374753,
+          "simMean": 183.8422292037861,
+          "simMedian": 134.5418712204117,
           "simRange": [
-            77.58241758241758,
-            159.03065083009915
+            86.04395604395604,
+            376.12260485308747
           ],
-          "diffPct": -0.9364136613291083
+          "diffPct": -0.8929282299337298
         },
         {
           "hex": {
@@ -1998,13 +1998,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 16797,
-          "simMean": 7695.281332347232,
-          "simMedian": 7569.699500890946,
+          "simMean": 7701.473079260456,
+          "simMedian": 7668.585479849175,
           "simRange": [
-            7299.449888710146,
-            8271.30058391873
+            7292.819453927538,
+            8064.357370144354
           ],
-          "diffPct": -0.5418657300501737
+          "diffPct": -0.5414971078609003
         },
         {
           "hex": {
@@ -2013,13 +2013,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 7430,
-          "simMean": 4274.7731565554,
-          "simMedian": 4151.2605320400635,
+          "simMean": 4267.804605863529,
+          "simMedian": 4337.392614173688,
           "simRange": [
-            3899.644861882917,
+            3678.4272442830174,
             4670.732777404359
           ],
-          "diffPct": -0.42466040961569307
+          "diffPct": -0.4255983033831051
         },
         {
           "hex": {
@@ -2028,13 +2028,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 2059,
-          "simMean": 121.17133136889868,
-          "simMedian": 121.48100880701983,
+          "simMean": 197.2553005544398,
+          "simMedian": 192.58390765628602,
           "simRange": [
-            112.17298793354257,
-            130.8227880334926
+            181.35612193903052,
+            226.2896548863116
           ],
-          "diffPct": -0.9411503975867417
+          "diffPct": -0.9041984941454881
         },
         {
           "hex": {
@@ -2043,13 +2043,13 @@
           },
           "championId": "TFT17_Rammus",
           "actual": 1719,
-          "simMean": 368.04244935916876,
-          "simMedian": 361.53620115915567,
+          "simMean": 361.64304051286865,
+          "simMedian": 357.91395302483414,
           "simRange": [
             232.09169054441264,
             470.10236263737806
           ],
-          "diffPct": -0.7858973534850676
+          "diffPct": -0.789620104413689
         },
         {
           "hex": {
@@ -2058,13 +2058,13 @@
           },
           "championId": "TFT17_Rhaast",
           "actual": 1067,
-          "simMean": 324.5408303834808,
-          "simMedian": 335.4384218060911,
+          "simMean": 321.56152021623393,
+          "simMedian": 332.24630361120103,
           "simRange": [
             223.44827586206895,
             443.70442988250056
           ],
-          "diffPct": -0.6958380221335699
+          "diffPct": -0.6986302528432672
         },
         {
           "hex": {
@@ -2073,13 +2073,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 894,
-          "simMean": 145.82478360064988,
-          "simMedian": 142.35612298130994,
+          "simMean": 150.69198331054218,
+          "simMedian": 150.84204628746517,
           "simRange": [
-            119.34,
-            183.87434655866628
+            121.68000000000002,
+            177.84
           ],
-          "diffPct": -0.8368850295294744
+          "diffPct": -0.8314407345519663
         }
       ],
       "survivors": [
@@ -2202,13 +2202,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 7979,
-          "simMean": 7330.888719048933,
-          "simMedian": 7243.7731983017675,
+          "simMean": 7049.473551267377,
+          "simMedian": 7047.89532783536,
           "simRange": [
-            6540.306371591056,
-            8489.67980556526
+            6420.816086812365,
+            8031.5028613893655
           ],
-          "diffPct": -0.08122713133864731
+          "diffPct": -0.11649660969201943
         },
         {
           "hex": {
@@ -2217,13 +2217,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 4967,
-          "simMean": 5435.130929359356,
-          "simMedian": 5378.1880909735555,
+          "simMean": 5252.283233144414,
+          "simMedian": 5307.138135454095,
           "simRange": [
-            4939.0961772944775,
-            6249.150728867409
+            4612.662111200128,
+            5968.524392737357
           ],
-          "diffPct": 0.09424822415126954
+          "diffPct": 0.05743572239670107
         },
         {
           "hex": {
@@ -2232,13 +2232,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 1620,
-          "simMean": 215.79503510192217,
-          "simMedian": 206.22435871989282,
+          "simMean": 578.3101866495848,
+          "simMedian": 615.2307689763027,
           "simRange": [
-            158.5256407505426,
-            296.1004557723763
+            393.9877242688849,
+            694.1890338609528
           ],
-          "diffPct": -0.86679318820869
+          "diffPct": -0.6430184033027253
         },
         {
           "hex": {
@@ -2247,13 +2247,13 @@
           },
           "championId": "TFT17_Rammus",
           "actual": 700,
-          "simMean": 230.78152027624515,
-          "simMedian": 249.194509750748,
+          "simMean": 227.82045607587278,
+          "simMedian": 243.70775637948307,
           "simRange": [
-            112.8482972136223,
-            280.5412579802679
+            142.10526216140843,
+            270.83591062218045
           ],
-          "diffPct": -0.6703121138910784
+          "diffPct": -0.674542205605896
         },
         {
           "hex": {
@@ -2262,13 +2262,13 @@
           },
           "championId": "TFT17_Nunu",
           "actual": 418,
-          "simMean": 82.85046452492699,
-          "simMedian": 85.8962501949956,
+          "simMean": 78.63482047942284,
+          "simMedian": 65.25932276747486,
           "simRange": [
             23.076923076923077,
-            182.06435565861443
+            159.11713005861444
           ],
-          "diffPct": -0.8017931470695526
+          "diffPct": -0.811878419905687
         }
       ],
       "survivors": [
@@ -2375,13 +2375,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 8618,
-          "simMean": 6975.918657792443,
-          "simMedian": 7013.79290751881,
+          "simMean": 6875.870470005514,
+          "simMedian": 6832.576741238252,
           "simRange": [
-            6605.496070212387,
-            7264.892396296083
+            6348.919852079369,
+            7265.552541248024
           ],
-          "diffPct": -0.19054088445202566
+          "diffPct": -0.2021500963094089
         },
         {
           "hex": {
@@ -2390,13 +2390,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 4851,
-          "simMean": 5578.965434892614,
-          "simMedian": 5613.808716731666,
+          "simMean": 5341.464230842718,
+          "simMedian": 5309.214030267102,
           "simRange": [
-            4862.644501392769,
+            4645.088125787387,
             5903.401246282694
           ],
-          "diffPct": 0.15006502471503075
+          "diffPct": 0.10110579897809076
         },
         {
           "hex": {
@@ -2405,13 +2405,13 @@
           },
           "championId": "TFT17_Mordekaiser",
           "actual": 742,
-          "simMean": 21.416091835635832,
+          "simMean": 16.8827585023025,
           "simMedian": 0,
           "simRange": [
             0,
             69.51724019543877
           ],
-          "diffPct": -0.9711373425395744
+          "diffPct": -0.9772469561963578
         }
       ],
       "survivors": [
@@ -2522,9 +2522,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 60.91929846365641,
+          "simMeanHp": 41.832407050385065,
           "aliveMismatch": true,
-          "hpDiffPoints": 60.91929846365641
+          "hpDiffPoints": 41.832407050385065
         },
         {
           "hex": {
@@ -2536,9 +2536,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 42.15319785353199,
+          "simMeanHp": 25.846279129438663,
           "aliveMismatch": true,
-          "hpDiffPoints": 42.15319785353199
+          "hpDiffPoints": 25.846279129438663
         },
         {
           "hex": {
@@ -2550,9 +2550,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 39.13830663374485,
+          "simMeanHp": 36.47518543686157,
           "aliveMismatch": true,
-          "hpDiffPoints": 39.13830663374485
+          "hpDiffPoints": 36.47518543686157
         },
         {
           "hex": {
@@ -2564,9 +2564,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.1,
-          "simMeanHp": 7.661351136572322,
+          "simMeanHp": 3.2446688225227316,
           "aliveMismatch": false,
-          "hpDiffPoints": 7.661351136572322
+          "hpDiffPoints": 3.2446688225227316
         },
         {
           "hex": {
@@ -2605,10 +2605,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.7,
-          "simMeanHp": 24.47508125951513,
+          "simAliveRate": 0.6,
+          "simMeanHp": 27.18086922961732,
           "aliveMismatch": true,
-          "hpDiffPoints": 24.47508125951513
+          "hpDiffPoints": 27.18086922961732
         },
         {
           "hex": {
@@ -2620,9 +2620,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.5,
-          "simMeanHp": 12.876975521186077,
+          "simMeanHp": 5.989634009789237,
           "aliveMismatch": false,
-          "hpDiffPoints": 12.876975521186077
+          "hpDiffPoints": 5.989634009789237
         },
         {
           "hex": {
@@ -2671,13 +2671,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 12360,
-          "simMean": 6215.083084304349,
-          "simMedian": 6220.286268678704,
+          "simMean": 6155.7487439856,
+          "simMedian": 6091.7482858665035,
           "simRange": [
-            5985.435918118145,
-            6542.984942708292
+            5929.585269665297,
+            6452.545221017814
           ],
-          "diffPct": -0.49716156275854784
+          "diffPct": -0.5019620757293204
         },
         {
           "hex": {
@@ -2686,13 +2686,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 7824,
-          "simMean": 6616.476384906596,
-          "simMedian": 6597.9340276858,
+          "simMean": 6617.1940024406385,
+          "simMedian": 6641.954704277716,
           "simRange": [
-            6328.126254537521,
-            7116.056943960446
+            6398.711950841917,
+            6912.316406158586
           ],
-          "diffPct": -0.15433584037492384
+          "diffPct": -0.15424412034245416
         },
         {
           "hex": {
@@ -2701,13 +2701,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 2111,
-          "simMean": 112.53133933987564,
-          "simMedian": 110.53253235371866,
+          "simMean": 189.053912157423,
+          "simMedian": 184.7797791837334,
           "simRange": [
-            100.44844635632855,
-            130.9699684202493
+            152.75775775775776,
+            232.32232232232252
           ],
-          "diffPct": -0.9466928757272025
+          "diffPct": -0.9104434333692928
         },
         {
           "hex": {
@@ -2716,13 +2716,13 @@
           },
           "championId": "TFT17_Samira",
           "actual": 1946,
-          "simMean": 184.87172336874335,
-          "simMedian": 126.82758569306341,
+          "simMean": 169.5117232924494,
+          "simMedian": 135.4482748344027,
           "simRange": [
             86.20689655172414,
-            314.6482740714632
+            301.8482748344027
           ],
-          "diffPct": -0.9049991144045512
+          "diffPct": -0.9128922285239212
         },
         {
           "hex": {
@@ -2731,13 +2731,13 @@
           },
           "championId": "TFT17_Rammus",
           "actual": 1500,
-          "simMean": 274.669713167463,
+          "simMean": 278.4137129443032,
           "simMedian": 241.2,
           "simRange": [
             234.5142857142857,
-            360.2057123729161
+            397.6457101413182
           ],
-          "diffPct": -0.816886857888358
+          "diffPct": -0.8143908580371313
         },
         {
           "hex": {
@@ -2746,13 +2746,13 @@
           },
           "championId": "TFT17_Nunu",
           "actual": 1312,
-          "simMean": 293.5720930961645,
+          "simMean": 284.55706805442827,
           "simMedian": 275.8236010083933,
           "simRange": [
             232.09169054441264,
             371.0883925485951
           ],
-          "diffPct": -0.7762407827010941
+          "diffPct": -0.7831119908121735
         }
       ],
       "survivors": [
@@ -2903,13 +2903,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 8933,
-          "simMean": 6512.643360672615,
-          "simMedian": 6538.971766495464,
+          "simMean": 6479.727447236823,
+          "simMedian": 6470.205458405439,
           "simRange": [
             5985.461913196704,
-            6759.803072708181
+            6714.24121730708
           ],
-          "diffPct": -0.27094555460958075
+          "diffPct": -0.27463030927607496
         },
         {
           "hex": {
@@ -2933,13 +2933,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 1981,
-          "simMean": 8562.798464992302,
-          "simMedian": 8298.657213612176,
+          "simMean": 8592.206808152778,
+          "simMedian": 8408.826097157416,
           "simRange": [
             8002.866415798337,
             9586.154194253651
           ],
-          "diffPct": 3.3224626274569924
+          "diffPct": 3.3373078284466318
         },
         {
           "hex": {
@@ -2948,13 +2948,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 1439,
-          "simMean": 144.95643279222244,
-          "simMedian": 151.93768516383534,
+          "simMean": 304.22066077879856,
+          "simMedian": 328.13605097008895,
           "simRange": [
-            87.14774999473644,
-            195.55671438201094
+            128.42119295726567,
+            496.03121435995604
           ],
-          "diffPct": -0.8992658562944945
+          "diffPct": -0.7885888389306474
         },
         {
           "hex": {
@@ -2963,13 +2963,13 @@
           },
           "championId": "TFT17_Rammus",
           "actual": 1235,
-          "simMean": 226.2580757649761,
+          "simMean": 221.70332384950575,
           "simMedian": 222.99440350308748,
           "simRange": [
-            130.38817470860528,
+            84.84065555390183,
             344.4205715845049
           ],
-          "diffPct": -0.8167950803522461
+          "diffPct": -0.8204831385833962
         }
       ],
       "survivors": [
@@ -3104,13 +3104,13 @@
           },
           "championId": "TFT17_Xayah",
           "actual": 10628,
-          "simMean": 6818.265735728559,
-          "simMedian": 6799.827449373648,
+          "simMean": 6958.274189098956,
+          "simMedian": 6884.907790952056,
           "simRange": [
-            6116.35379502348,
+            6079.816457789871,
             8258.039070345849
           ],
-          "diffPct": -0.3584620120691985
+          "diffPct": -0.3452884654592627
         },
         {
           "hex": {
@@ -3119,13 +3119,13 @@
           },
           "championId": "TFT17_Jhin",
           "actual": 5725,
-          "simMean": 8990.994737986555,
-          "simMedian": 9063.059258919991,
+          "simMean": 9086.54891959424,
+          "simMedian": 9153.79283315607,
           "simRange": [
             7945.002681082999,
-            9581.499081860413
+            9781.539171289784
           ],
-          "diffPct": 0.5704794302159922
+          "diffPct": 0.5871701169596925
         },
         {
           "hex": {
@@ -3134,13 +3134,13 @@
           },
           "championId": "TFT17_Gnar",
           "actual": 2263,
-          "simMean": 2293.425190302375,
-          "simMedian": 2176.6636056055368,
+          "simMean": 2247.0660779807217,
+          "simMedian": 2151.567696588413,
           "simRange": [
             2042.646121781567,
-            3201.1697232611477
+            2976.8953167655645
           ],
-          "diffPct": 0.013444626735472861
+          "diffPct": -0.007041061431408869
         },
         {
           "hex": {
@@ -3149,13 +3149,13 @@
           },
           "championId": "TFT17_Nunu",
           "actual": 1626,
-          "simMean": 227.5155093245316,
-          "simMedian": 266.7472729269554,
+          "simMean": 241.0404312454365,
+          "simMedian": 241.1039671213046,
           "simRange": [
             49.31404962625155,
             339.17088074751246
           ],
-          "diffPct": -0.8600765625310384
+          "diffPct": -0.8517586523705802
         },
         {
           "hex": {
@@ -3164,13 +3164,13 @@
           },
           "championId": "TFT17_Bard",
           "actual": 1353,
-          "simMean": 101.6878244729701,
-          "simMedian": 103.71799293140236,
+          "simMean": 208.88377430046995,
+          "simMedian": 198.63346513592217,
           "simRange": [
-            84.03914926607595,
-            117.41324688268065
+            132.18032696579957,
+            358.6167089993127
           ],
-          "diffPct": -0.9248427017938137
+          "diffPct": -0.8456143575015005
         }
       ],
       "survivors": [
@@ -3183,10 +3183,10 @@
           "team": "player",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 1,
-          "simMeanHp": 60.8121386431769,
+          "simAliveRate": 0.7,
+          "simMeanHp": 22.796566852015875,
           "aliveMismatch": true,
-          "hpDiffPoints": 60.8121386431769
+          "hpDiffPoints": 22.796566852015875
         },
         {
           "hex": {
@@ -3212,9 +3212,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 98.51249994917049,
+          "simMeanHp": 98.9124999402298,
           "aliveMismatch": true,
-          "hpDiffPoints": 98.51249994917049
+          "hpDiffPoints": 98.9124999402298
         },
         {
           "hex": {
@@ -3226,9 +3226,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 68.60380811515728,
+          "simMeanHp": 67.7686434696206,
           "aliveMismatch": true,
-          "hpDiffPoints": 68.60380811515728
+          "hpDiffPoints": 67.7686434696206
         },
         {
           "hex": {
@@ -3240,9 +3240,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 74.43370465879771,
+          "simMeanHp": 74.62122300013402,
           "aliveMismatch": true,
-          "hpDiffPoints": 74.43370465879771
+          "hpDiffPoints": 74.62122300013402
         },
         {
           "hex": {
@@ -3254,9 +3254,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 99.11967335826304,
+          "simMeanHp": 99.5666099147276,
           "aliveMismatch": true,
-          "hpDiffPoints": 99.11967335826304
+          "hpDiffPoints": 99.5666099147276
         },
         {
           "hex": {
@@ -3268,9 +3268,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 42.07995568797892,
+          "simMeanHp": 45.12173319083878,
           "aliveMismatch": true,
-          "hpDiffPoints": 42.07995568797892
+          "hpDiffPoints": 45.12173319083878
         },
         {
           "hex": {
@@ -3281,10 +3281,10 @@
           "team": "player",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 1,
-          "simMeanHp": 78.99548499356806,
+          "simAliveRate": 0.7,
+          "simMeanHp": 32.69117974419898,
           "aliveMismatch": true,
-          "hpDiffPoints": 78.99548499356806
+          "hpDiffPoints": 32.69117974419898
         },
         {
           "hex": {
@@ -3296,9 +3296,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 95.84285709822734,
+          "simMeanHp": 96.042857093757,
           "aliveMismatch": true,
-          "hpDiffPoints": 95.84285709822734
+          "hpDiffPoints": 96.042857093757
         }
       ],
       "warnings": []
@@ -3319,7 +3319,7 @@
     "pvpRoundCount": 21,
     "winnerMatchRate": 0.7619047619047619,
     "weakSignalRoundCount": 0,
-    "avgPlayerDamageErrorPct": -0.2199234639934946,
-    "avgSurvivorHpErrorPts": 0.1595366624480135
+    "avgPlayerDamageErrorPct": -0.2154883576251032,
+    "avgSurvivorHpErrorPts": 0.05389157996720573
   }
 }

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -6809,13 +6809,15 @@ export function simulateCombat(
             // DOT 스킬: 즉발 대신 burn statusEffect로 지속 피해 적용
             if (config.dot) {
               const dotTicks = Math.round(config.dot.duration * TICKS_PER_SECOND);
+              // perSecond: damageVar 가 초당 값이면 총량 = abilityDmg × duration (Bard DamagePerSecond).
+              const dotTotal = config.dot.perSecond ? abilityDmg * config.dot.duration : abilityDmg;
               for (const t of aliveTargets) {
                 // DOT도 방어력/피해감소 적용
                 const resistance = dmgType === 'magic' ? t.stats.magicResist : dmgType === 'physical' ? t.stats.armor : 0;
                 const pen = dmgType === 'magic' ? unit.stats.magicPen : dmgType === 'physical' ? unit.stats.armorPen : 0;
                 // 저격수 (Sniper) — DOT 도 거리 기반 추가 amp 포함 (codex P2 회귀 가드).
                 const dotDamageAmp = unit.damageAmp + computeSniperDamageAmp(unit, t);
-                const mitigated = dmgType === 'true' ? abilityDmg * (1 + dotDamageAmp) : applyResistance(abilityDmg * (1 + dotDamageAmp), resistance, pen);
+                const mitigated = dmgType === 'true' ? dotTotal * (1 + dotDamageAmp) : applyResistance(dotTotal * (1 + dotDamageAmp), resistance, pen);
                 const perTickDmg = mitigated / config.dot.duration * TICK_DURATION;
                 t.statusEffects.push({
                   type: 'burn', sourceId: unit.id,
@@ -6825,8 +6827,8 @@ export function simulateCombat(
               const dotLog: CombatLog = {
                 tick, time, type: 'ability',
                 sourceId: unit.id, targetId: abilityTarget.id,
-                value: Math.round(abilityDmg),
-                message: `${unit.champion.name}이(가) ${unit.champion.ability.name} 시전! ${config.dot.duration}초 동안 ${Math.round(abilityDmg)} ${dmgType === 'magic' ? '마법' : '물리'} 지속 피해`,
+                value: Math.round(dotTotal),
+                message: `${unit.champion.name}이(가) ${unit.champion.ability.name} 시전! ${config.dot.duration}초 동안 ${Math.round(dotTotal)} ${dmgType === 'magic' ? '마법' : '물리'} 지속 피해`,
               };
               logs.push(dotLog);
               tickLogs.push(dotLog);
@@ -7660,12 +7662,14 @@ export function simulateCombat(
 
           if (outOfRangeConfig.dot) {
             const dotTicks = Math.round(outOfRangeConfig.dot.duration * TICKS_PER_SECOND);
+            // perSecond: damageVar 가 초당 값이면 총량 = abilityDmg × duration (main path 와 일관).
+            const oorDotTotal = outOfRangeConfig.dot.perSecond ? abilityDmg * outOfRangeConfig.dot.duration : abilityDmg;
             for (const t of oorAlive) {
               const resistance = dmgType === 'magic' ? t.stats.magicResist : dmgType === 'physical' ? t.stats.armor : 0;
               const pen = dmgType === 'magic' ? unit.stats.magicPen : dmgType === 'physical' ? unit.stats.armorPen : 0;
               // 저격수 (Sniper) — OOR DOT 도 거리 기반 추가 amp 포함 (codex P2 회귀 가드).
               const oorDotDamageAmp = unit.damageAmp + computeSniperDamageAmp(unit, t);
-              const mitigated = dmgType === 'true' ? abilityDmg * (1 + oorDotDamageAmp) : applyResistance(abilityDmg * (1 + oorDotDamageAmp), resistance, pen);
+              const mitigated = dmgType === 'true' ? oorDotTotal * (1 + oorDotDamageAmp) : applyResistance(oorDotTotal * (1 + oorDotDamageAmp), resistance, pen);
               const perTickDmg = mitigated / outOfRangeConfig.dot.duration * TICK_DURATION;
               t.statusEffects.push({
                 type: 'burn', sourceId: unit.id,

--- a/src/lib/simulator/engine/combatLoop.ts
+++ b/src/lib/simulator/engine/combatLoop.ts
@@ -7429,7 +7429,9 @@ export function simulateCombat(
             // rawValue = totalRawAbilityDmg (per-target modifier 적용 후, resistance 미적용 누적).
             // value = totalAbilityDmg (실제 적용 mitigated total).
             // dot path 면 totalRawAbilityDmg 누적 안 됨 → hitCountTotal 폴백 (DOT total raw).
-            const rawForCast = totalRawAbilityDmg > 0 ? totalRawAbilityDmg : hitCountTotal;
+            // perSecond DOT 은 총량 = hitCountTotal × duration (codex P2 #241 — raw 소비자 일관).
+            const dotRawMult = config.dot?.perSecond ? config.dot.duration : 1;
+            const rawForCast = totalRawAbilityDmg > 0 ? totalRawAbilityDmg : hitCountTotal * dotRawMult;
             eventBus.emit('on_cast', { sourceId: unit.id, targetId: target.id, value: totalAbilityDmg, rawValue: rawForCast, tick });
           }
 
@@ -7787,8 +7789,9 @@ export function simulateCombat(
           triggerFountainHeal(unit, totalAbilityDmg, tick, time, tickLogs);
 
           // rawValue = totalRawAbilityDmg (per-target modifier 적용 후, resistance 미적용 누적).
-          // dot path 면 raw 누적 안 됨 → oorHitTotal 폴백.
-          const oorRawForCast = totalRawAbilityDmg > 0 ? totalRawAbilityDmg : oorHitTotal;
+          // dot path 면 raw 누적 안 됨 → oorHitTotal 폴백. perSecond DOT 은 × duration (codex P2 #241).
+          const oorDotRawMult = outOfRangeConfig.dot?.perSecond ? outOfRangeConfig.dot.duration : 1;
+          const oorRawForCast = totalRawAbilityDmg > 0 ? totalRawAbilityDmg : oorHitTotal * oorDotRawMult;
           eventBus.emit('on_cast', { sourceId: unit.id, targetId: target.id, value: totalAbilityDmg, rawValue: oorRawForCast, tick });
         } else {
           // 일반 이동

--- a/src/lib/simulator/systems/ability.ts
+++ b/src/lib/simulator/systems/ability.ts
@@ -60,8 +60,9 @@ export interface AbilityConfig {
    */
   procChance?: number;
   procDamageMult?: number;
-  /** DOT 지속 피해 — 스킬 피해를 duration초에 걸쳐 매초 적용 */
-  dot?: { duration: number };
+  /** DOT 지속 피해 — 스킬 피해를 duration초에 걸쳐 매초 적용.
+   * perSecond: damageVar 가 "초당" 값이면 총량 = damageVar × duration (Bard 비행접시 DamagePerSecond). */
+  dot?: { duration: number; perSecond?: boolean };
   /** parseAbility 대신 사용할 피해 변수명 오버라이드 */
   damageVar?: string;
   /** caster(자기) 방어력 비례 추가 피해 변수명 (scaleArmor — Rammus 중력회전 등). 주 피해 + (변수값 × caster.armor) */
@@ -261,7 +262,7 @@ export const CHAMPION_ABILITY_PATTERNS: Record<string, AbilityConfig> = {
   TFT17_TahmKench:   { pattern: 'aoe_circle', radius: 2, heal: true },  // 회복 + 2칸 혀 채찍
 
   // === 5코스트 ===
-  TFT17_Bard:        { pattern: 'aoe_circle', radius: 1, dot: { duration: 4 } },  // 비행접시 4초 DOT + 주변 분배
+  TFT17_Bard:        { pattern: 'aoe_circle', radius: 1, dot: { duration: 4, perSecond: true } },  // 비행접시 4초 DOT — DamagePerSecond(초당) × 4 + 주변 분배
   TFT17_Fiora:       { pattern: 'single', dash: 'to_target', heal: true },  // 급소 돌진 + 회복
   TFT17_Jhin:        { pattern: 'multi', maxTargets: 3, debuff: { armorReduction: 15, duration: 4 }, hitCount: 4, damageVar: 'ADDamage' },  // 잔상 손 4개 × 4회 사격 — TotalDamage scaleAD = ADDamage (raw <physicalDamage>). APDamage 는 미미한 부차 변수 (ingest #227 P0 fix)
   TFT17_Blitzcrank:  { pattern: 'aoe_circle', radius: 3, stun: 1.5, stunTargets: 1, damageVar: 'ExplosionDamage' },  // 띄움 1명 + 폭발 3칸

--- a/tests/unit/simulator/bard-dot-persecond.test.ts
+++ b/tests/unit/simulator/bard-dot-persecond.test.ts
@@ -1,0 +1,44 @@
+/**
+ * 회귀 가드 — 바드(Bard) 비행접시 DOT 가 초당값 × duration (under-damage fix, 2026-06-15).
+ *
+ * 버그: Bard 「비행접시」는 Duration(4)초 동안 **매초** ModifiedDamagePerSecond(scaleAP) 마법 피해
+ *   를 입히는데, sim dot 모델이 damageVar(DamagePerSecond)를 **총량**으로 4초에 분산 →
+ *   초당값 × duration(4) 누락 = ~4× under (Bard -90%).
+ * fix: dot.perSecond 플래그 → dotTotal = DamagePerSecond★ × duration. main + OOR cast path.
+ *
+ * 검증: Bard -90%→-84% (sim +93%, dot 부분 ×4). 잔여는 cast 빈도/split/duration (별개).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { getAbilityDamage, setScalingData, type ScalingData } from '@/lib/simulator/systems/ability';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import scalingJson from '../../../public/data/tft_set17_scaling.json';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+const bard = champions.find(c => c.apiName === 'TFT17_Bard')!;
+const cho = champions.find(c => c.apiName === 'TFT17_Chogath')!;
+
+beforeAll(() => {
+  setScalingData(scalingJson as unknown as ScalingData);
+});
+
+function placed(c: RawChampion, q: number, r: number, star: 1 | 2 | 3): PlacedChampion {
+  return { champion: c, starLevel: star, position: { q, r }, items: [] };
+}
+
+describe('바드 비행접시 DOT 초당값×duration (회귀 가드)', () => {
+  it('cast DOT 총량 = DamagePerSecond★ × Duration(4) — 초당값 ×4', () => {
+    const r = simulateCombat(
+      [placed(bard, 5, 3, 2)],
+      [placed(cho, 6, 3, 3), placed(cho, 7, 3, 3)],
+      { seed: 0, allTraits: traits, skipMirror: true, stageNumber: 6 },
+    );
+    const t = r.playerUnits[0];
+    const cast = r.logs.find(l => l.type === 'ability' && l.sourceId === t.id && /시전/.test(l.message));
+    expect(cast).toBeDefined();
+    // dotTotal = DamagePerSecond★2 × 4. 버그(perSecond 누락) 시 ×1 (DamagePerSecond 만).
+    const dps = getAbilityDamage(bard, 2, 0, 0).damage; // DamagePerSecond★2 (AP 0)
+    expect(cast!.value ?? 0).toBeGreaterThan(dps * 3.5); // ×4 (AP scaling 포함 시 더 큼)
+  });
+});


### PR DESCRIPTION
## 배경

under-damage 잔여 갭 Bard(-90%). 「비행접시」는 Duration(4)초 동안 **매초** `DamagePerSecond`(scaleAP) 마법 피해 + 주변 `SplitDamagePerSecond` 인데, sim dot 모델이 `damageVar`(DamagePerSecond)를 **총량**으로 4초에 분산 → 초당값 × duration(4) 누락 = ~4× under.

## 변경

- `AbilityConfig.dot.perSecond` 플래그 추가 → `dotTotal = DamagePerSecond★ × duration`. main + OOR cast path 일관. dot 로그 value 도 dotTotal 표시.
- Bard config: `dot: { duration: 4, perSecond: true }`.
- 회귀 가드 `bard-dot-persecond.test.ts` (cast DOT total = DamagePerSecond★ × 4).

## 결과

- Bard -90% → **-84%** (sim +93%, dot 부분 ×4 정상 적용), **overshoot 0**.
- game-424 -21.99% → **-21.55%**.
- 잔여: cast 빈도 / split(SplitDamagePerSecond 주변 분배) / duration (DOT 4초 vs 짧은 전투) — 별개 systemic. Bard 미ingest (위키 페이지 없음 — 순수 sim-fix).

## 검증
- `pnpm lint`(0 errors) / `typecheck` / `build` ✅ · 959 test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)