### PR TITLE
feat(sim): 모르가나(Morgana) 어둠의 형상 사슬 dot.perSecond + 위키 ingest

### DIFF
--- a/actual-data/diff-game-20260423-001.json
+++ b/actual-data/diff-game-20260423-001.json
@@ -1,8 +1,8 @@
 {
   "gameId": "game-20260423-001",
-  "computedAt": "2026-06-16T01:32:08.137Z",
+  "computedAt": "2026-06-16T02:26:00.806Z",
   "sourceGameMtime": 1779323641263,
-  "engineSha": "1132270ee65261ab148b6e1efcdc38ba7a4b9055",
+  "engineSha": "088abcb3408e4b174f405565e4c19980537e7914",
   "nRuns": 10,
   "seedBase": 0,
   "rounds": [
@@ -3606,13 +3606,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 10653,
-          "simMean": 6056.695159412956,
-          "simMedian": 6280.581294749543,
+          "simMean": 5938.073748933129,
+          "simMedian": 6069.334616663433,
           "simRange": [
-            4717.93695993069,
-            7123.271183618954
+            4729.017118606051,
+            6839.801379650972
           ],
-          "diffPct": -0.43145638229485067
+          "diffPct": -0.44259140627681137
         },
         {
           "hex": {
@@ -3621,13 +3621,13 @@
           },
           "championId": "TFT17_Corki",
           "actual": 6404,
-          "simMean": 2240.5623694888463,
-          "simMedian": 2424.752013308148,
+          "simMean": 2203.8605621530537,
+          "simMedian": 2356.2304338576037,
           "simRange": [
-            1227.4037274726552,
-            2675.812599760121
+            1373.8702081390866,
+            2567.1782752301647
           ],
-          "diffPct": -0.6501307980186062
+          "diffPct": -0.6558618734926526
         },
         {
           "hex": {
@@ -3636,13 +3636,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 2853,
-          "simMean": 488.70254116847127,
-          "simMedian": 489.4340296687211,
+          "simMean": 484.3586911456088,
+          "simMedian": 486.12182873037455,
           "simRange": [
             439.73799044644494,
-            538.5609850326128
+            524.6976338958175
           ],
-          "diffPct": -0.8287057339051976
+          "diffPct": -0.8302282891182584
         },
         {
           "hex": {
@@ -3651,13 +3651,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 1703,
-          "simMean": 1368.0565092242125,
-          "simMedian": 1586.6478698930507,
+          "simMean": 1306.783201936151,
+          "simMedian": 1607.9322677552145,
           "simRange": [
             581.0038610038611,
-            2002.8220208844407
+            1890.0596742409618
           ],
-          "diffPct": -0.19667850309793747
+          "diffPct": -0.23265813157008158
         },
         {
           "hex": {
@@ -3666,13 +3666,13 @@
           },
           "championId": "TFT17_Milio",
           "actual": 1591,
-          "simMean": 664.2947732786818,
-          "simMedian": 659.1673006717976,
+          "simMean": 677.5474528003473,
+          "simMedian": 661.207768432964,
           "simRange": [
             574.0595384740191,
-            794.4760557112232
+            798.5113437236779
           ],
-          "diffPct": -0.5824671443880064
+          "diffPct": -0.5741373646760859
         },
         {
           "hex": {
@@ -3681,13 +3681,13 @@
           },
           "championId": "TFT17_Caitlyn",
           "actual": 1590,
-          "simMean": 285.7875452084827,
-          "simMedian": 271.0024616775205,
+          "simMean": 274.9218654006622,
+          "simMedian": 257.8330993272314,
           "simRange": [
-            245.16922526991598,
+            222.38573324958608,
             378.39300902732134
           ],
-          "diffPct": -0.8202594055292561
+          "diffPct": -0.8270931664146779
         }
       ],
       "opponentDamage": [
@@ -3698,13 +3698,13 @@
           },
           "championId": "TFT17_Vex",
           "actual": 5808,
-          "simMean": 9255.18565756384,
-          "simMedian": 9112.4171996718,
+          "simMean": 8859.284300571273,
+          "simMedian": 8978.418829805123,
           "simRange": [
-            8004.002051069678,
-            10780.661539357734
+            7947.278496196578,
+            9433.962414904952
           ],
-          "diffPct": 0.5935237013711845
+          "diffPct": 0.5253588671782495
         },
         {
           "hex": {
@@ -3713,13 +3713,13 @@
           },
           "championId": "TFT17_Morgana",
           "actual": 3254,
-          "simMean": 3974.588974515933,
-          "simMedian": 3930.7821813335177,
+          "simMean": 4807.116723077012,
+          "simMedian": 4785.310556001905,
           "simRange": [
-            3637.310503005082,
-            4643.7998617092835
+            4184.283865522941,
+            5361.862605060467
           ],
-          "diffPct": 0.22144713414749015
+          "diffPct": 0.47729462909557824
         },
         {
           "hex": {
@@ -3728,13 +3728,13 @@
           },
           "championId": "TFT17_TahmKench",
           "actual": 2584,
-          "simMean": 539.7676046292696,
-          "simMedian": 530.244926966724,
+          "simMean": 472.9199769333667,
+          "simMedian": 493.23781198701863,
           "simRange": [
             383.15649867374,
-            693.4820353970442
+            579.5747346493301
           ],
-          "diffPct": -0.7911116081156078
+          "diffPct": -0.8169814330753224
         },
         {
           "hex": {
@@ -3743,13 +3743,13 @@
           },
           "championId": "TFT17_Blitzcrank",
           "actual": 2409,
-          "simMean": 751.6778046416899,
-          "simMedian": 802.4010899094919,
+          "simMean": 634.6608010437266,
+          "simMedian": 558.1058710248192,
           "simRange": [
-            451.7625396700696,
-            1375.2881058683188
+            412.1758578658342,
+            1262.6440948828167
           ],
-          "diffPct": -0.6879710233948984
+          "diffPct": -0.7365459522441982
         },
         {
           "hex": {
@@ -3758,13 +3758,13 @@
           },
           "championId": "TFT17_Fiora",
           "actual": 2393,
-          "simMean": 2938.357657135729,
-          "simMedian": 3010.3241755101762,
+          "simMean": 2853.238671728343,
+          "simMedian": 2900.3447096438254,
           "simRange": [
-            2523.3408285121886,
-            3351.913076472056
+            2389.1656941924025,
+            3230.3769534940584
           ],
-          "diffPct": 0.22789705688914705
+          "diffPct": 0.19232706716604386
         },
         {
           "hex": {
@@ -3773,13 +3773,13 @@
           },
           "championId": "TFT17_Sona",
           "actual": 2037,
-          "simMean": 7145.448664722938,
-          "simMedian": 7014.035921867031,
+          "simMean": 6813.742250868042,
+          "simMedian": 6959.231679358585,
           "simRange": [
-            5982.030856436558,
-            7928.822037204963
+            5984.152067546298,
+            7874.768904296019
           ],
-          "diffPct": 2.5078294868546576
+          "diffPct": 2.3449888320412575
         }
       ],
       "survivors": [
@@ -3905,9 +3905,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 78.66366677725316,
+          "simMeanHp": 77.39866682751975,
           "aliveMismatch": true,
-          "hpDiffPoints": 78.66366677725316
+          "hpDiffPoints": 77.39866682751975
         },
         {
           "hex": {
@@ -3919,9 +3919,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.7,
-          "simMeanHp": 39.220662222819485,
+          "simMeanHp": 39.17258229676076,
           "aliveMismatch": true,
-          "hpDiffPoints": 39.220662222819485
+          "hpDiffPoints": 39.17258229676076
         },
         {
           "hex": {
@@ -3932,10 +3932,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 1,
-          "simMeanHp": 77.47775111123289,
+          "simAliveRate": 0.9,
+          "simMeanHp": 83.55716050207302,
           "aliveMismatch": true,
-          "hpDiffPoints": 77.47775111123289
+          "hpDiffPoints": 83.55716050207302
         },
         {
           "hex": {
@@ -3975,9 +3975,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.5,
-          "simMeanHp": 41.43380924837099,
+          "simMeanHp": 51.88507064252387,
           "aliveMismatch": false,
-          "hpDiffPoints": 41.43380924837099
+          "hpDiffPoints": 51.88507064252387
         },
         {
           "hex": {
@@ -3989,9 +3989,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.9,
-          "simMeanHp": 68.50610371669372,
+          "simMeanHp": 74.2235549213402,
           "aliveMismatch": true,
-          "hpDiffPoints": 68.50610371669372
+          "hpDiffPoints": 74.2235549213402
         },
         {
           "hex": {
@@ -4003,9 +4003,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.9,
-          "simMeanHp": 22.47184004542024,
+          "simMeanHp": 25.7090533872428,
           "aliveMismatch": true,
-          "hpDiffPoints": 22.47184004542024
+          "hpDiffPoints": 25.7090533872428
         }
       ],
       "warnings": []
@@ -4432,13 +4432,13 @@
           },
           "championId": "TFT17_TwistedFate",
           "actual": 9078,
-          "simMean": 7014.562624797678,
-          "simMedian": 7336.625221185671,
+          "simMean": 6897.856308223566,
+          "simMedian": 7237.23064402409,
           "simRange": [
             4524.8644235205375,
-            8405.756337183422
+            8134.173661169307
           ],
-          "diffPct": -0.22730087851975347
+          "diffPct": -0.2401568287922928
         },
         {
           "hex": {
@@ -4447,13 +4447,13 @@
           },
           "championId": "TFT17_Corki",
           "actual": 5651,
-          "simMean": 2564.4429265765903,
+          "simMean": 2550.9608376058513,
           "simMedian": 2627.2943908650377,
           "simRange": [
             2066.6229683666825,
-            2999.6374625345643
+            2864.816572827175
           ],
-          "diffPct": -0.5461966153642558
+          "diffPct": -0.5485824035381611
         },
         {
           "hex": {
@@ -4462,13 +4462,13 @@
           },
           "championId": "TFT17_Talon",
           "actual": 4828,
-          "simMean": 1116.8722065318084,
+          "simMean": 1105.7515622586657,
           "simMedian": 1025.3000175674972,
           "simRange": [
             837.7422445960614,
             1526.4566086338025
           ],
-          "diffPct": -0.7686677285559634
+          "diffPct": -0.7709710931527205
         },
         {
           "hex": {
@@ -4492,13 +4492,13 @@
           },
           "championId": "TFT17_Jax",
           "actual": 2846,
-          "simMean": 1384.6519500463892,
-          "simMedian": 1500.3732156065075,
+          "simMean": 1376.4062733707874,
+          "simMedian": 1468.7797919173486,
           "simRange": [
             807.2356126323001,
             1610.5577380712714
           ],
-          "diffPct": -0.5134743675170804
+          "diffPct": -0.5163716537699271
         },
         {
           "hex": {
@@ -4507,13 +4507,13 @@
           },
           "championId": "TFT17_Aatrox",
           "actual": 925,
-          "simMean": 651.7587573843754,
+          "simMean": 653.2431584069767,
           "simMedian": 731.3373731631297,
           "simRange": [
             309.7894736842105,
-            819.7941697770517
+            822.2451209189823
           ],
-          "diffPct": -0.2953959379628374
+          "diffPct": -0.2937911801005657
         }
       ],
       "opponentDamage": [
@@ -4524,13 +4524,13 @@
           },
           "championId": "TFT17_Vex",
           "actual": 7575,
-          "simMean": 13896.067184819607,
-          "simMedian": 13879.048331829492,
+          "simMean": 13654.212257769006,
+          "simMedian": 13747.086446372348,
           "simRange": [
-            12820.500878736542,
-            14779.335756453323
+            12379.621729427208,
+            14647.012990810963
           ],
-          "diffPct": 0.8344643148276709
+          "diffPct": 0.802536271652674
         },
         {
           "hex": {
@@ -4539,13 +4539,13 @@
           },
           "championId": "TFT17_Morgana",
           "actual": 2901,
-          "simMean": 686.7299543938041,
-          "simMedian": 633.6043520452189,
+          "simMean": 848.65497325292,
+          "simMedian": 840.6585578437132,
           "simRange": [
             535.5953283451622,
-            1033.6392563185218
+            1314.8246304002887
           ],
-          "diffPct": -0.7632781956588058
+          "diffPct": -0.7074612294888245
         },
         {
           "hex": {
@@ -4554,13 +4554,13 @@
           },
           "championId": "TFT17_Fiora",
           "actual": 2384,
-          "simMean": 1506.123223267319,
-          "simMedian": 1507.232487675541,
+          "simMean": 1502.3111079096716,
+          "simMedian": 1528.9859868927,
           "simRange": [
             1185.2413674368465,
-            1957.703539065021
+            1819.3352616370926
           ],
-          "diffPct": -0.36823690299189643
+          "diffPct": -0.3698359446687619
         },
         {
           "hex": {
@@ -4569,13 +4569,13 @@
           },
           "championId": "TFT17_Sona",
           "actual": 2348,
-          "simMean": 6943.959148509331,
-          "simMedian": 6500.644807905508,
+          "simMean": 6983.445372488112,
+          "simMedian": 6889.862571262281,
           "simRange": [
-            6232.030804758382,
-            7948.238223514001
+            6299.145966261085,
+            7843.225228991936
           ],
-          "diffPct": 1.9573931637603623
+          "diffPct": 1.9742101245690427
         },
         {
           "hex": {
@@ -4584,13 +4584,13 @@
           },
           "championId": "TFT17_Blitzcrank",
           "actual": 1769,
-          "simMean": 1258.4166897373962,
+          "simMean": 1249.5372736263807,
           "simMedian": 1244.9006326522056,
           "simRange": [
-            1026.4213875470277,
+            1009.9928170976754,
             1560.7464861157555
           ],
-          "diffPct": -0.28862821382849285
+          "diffPct": -0.29364766895060446
         },
         {
           "hex": {
@@ -4599,13 +4599,13 @@
           },
           "championId": "TFT17_TahmKench",
           "actual": 1551,
-          "simMean": 566.8039869797641,
-          "simMedian": 556.484297216117,
+          "simMean": 571.6524785971416,
+          "simMedian": 573.9036510165522,
           "simRange": [
             409.13232972004096,
             759.0517178948583
           ],
-          "diffPct": -0.6345557788654004
+          "diffPct": -0.6314297365589029
         }
       ],
       "survivors": [
@@ -4745,9 +4745,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 0.6,
-          "simMeanHp": 39.555796774306934,
+          "simMeanHp": 38.30788903785784,
           "aliveMismatch": true,
-          "hpDiffPoints": 39.555796774306934
+          "hpDiffPoints": 38.30788903785784
         },
         {
           "hex": {
@@ -4772,10 +4772,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.4,
-          "simMeanHp": 25.049429114114734,
-          "aliveMismatch": false,
-          "hpDiffPoints": 25.049429114114734
+          "simAliveRate": 0.6,
+          "simMeanHp": 17.640878585579205,
+          "aliveMismatch": true,
+          "hpDiffPoints": 17.640878585579205
         },
         {
           "hex": {
@@ -4801,9 +4801,9 @@
           "actualAlive": false,
           "actualHp": 0,
           "simAliveRate": 1,
-          "simMeanHp": 68.5693470354995,
+          "simMeanHp": 75.03483749054388,
           "aliveMismatch": true,
-          "hpDiffPoints": 68.5693470354995
+          "hpDiffPoints": 75.03483749054388
         },
         {
           "hex": {
@@ -4814,10 +4814,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.8,
-          "simMeanHp": 77.80296366834379,
+          "simAliveRate": 0.7,
+          "simMeanHp": 93.64430643895648,
           "aliveMismatch": true,
-          "hpDiffPoints": 77.80296366834379
+          "hpDiffPoints": 93.64430643895648
         },
         {
           "hex": {
@@ -4828,10 +4828,10 @@
           "team": "opponent",
           "actualAlive": false,
           "actualHp": 0,
-          "simAliveRate": 0.2,
-          "simMeanHp": 7.057150529656017,
+          "simAliveRate": 0.3,
+          "simMeanHp": 9.815350996866893,
           "aliveMismatch": false,
-          "hpDiffPoints": 7.057150529656017
+          "hpDiffPoints": 9.815350996866893
         }
       ],
       "warnings": []
@@ -5671,7 +5671,7 @@
     "pvpRoundCount": 22,
     "winnerMatchRate": 0.5454545454545454,
     "weakSignalRoundCount": 0,
-    "avgPlayerDamageErrorPct": -0.29772668326135393,
-    "avgSurvivorHpErrorPts": 7.491424194817291
+    "avgPlayerDamageErrorPct": -0.2983727183581872,
+    "avgSurvivorHpErrorPts": 7.461225979137195
   }
 }

--- a/docs/wiki/champions/morgana.md
+++ b/docs/wiki/champions/morgana.md
@@ -1,0 +1,98 @@
+---
+id: morgana
+type: champion
+display_name_kr: 모르가나
+api_name: TFT17_Morgana
+cost: 4
+traits:
+  - 어둠의 여인
+role: Tank   # raw "APTank" → mapGameRole() → sim Tank (types/index.ts includes('Tank')). carry augment 없음
+raw_role: APTank
+current_patch_status: active
+sim_active: partial   # ability 「어둠의 형상」 변신 5초 + 사슬 NumEnemies(3) 매초 TetherDamagePerSecond(scaleAP) 마법 DOT + 보호막 + 변신 종료 FinalDamage 버스트 + omnivamp 20% 패시브. sim multi maxTargets:3 + dot{duration:5, perSecond:true} → 사슬 DOT = TetherDamagePerSecond × 5 (Bard/Viktor/AurelionSol/Pantheon 동형 perSecond). damage var = TetherDamagePerSecond(fuzzy includes 'Damage' pick), filler(v0=0) → ★1=50/★2=75/★3=1500. 보호막 getAbilityShield(Shield scaleAP) 반영. 어둠의 여인(MorganaUniqueTrait) — applyMorganaDarklight(combatLoop:1904) 아군 전체 damageReduction +10%(fallback) ✅. ⚠️ 미반영: FinalDamage(변신 종료 버스트) / OmnivampPercent(20% — config heal:true 가 classifyHealVar 매칭 변수 없어 no-op) / trait raw Durability(0.04) 별도 보너스 미read 여부 verify. calibration: game-423 에 enemy 로 존재(playerDamage 미측정) — perSecond fix 로 enemy coupling 통해 diff-cache 변동(avgErr -0.298→-0.298, flat)
+last_verified: 2026-06-16
+sources:
+  - "public/data/tft_set17_champions.json (TFT17_Morgana entry — cost 4, role APTank, traits [어둠의 여인], hp 1300, armor/MR 70/70, AD 60, AS 0.65, range 2, mana 30/90, ability '어둠의 형상' variables Shield/TetherDamagePerSecond/NumEnemies/FinalDamage/OmnivampPercent/Duration)"
+  - "public/data/tft_set17_traits.json (TFT17_MorganaUniqueTrait = 어둠의 여인 bp 1 — unique trait, variables {816175b9}:0.10 / Durability:0.04)"
+  - "src/lib/simulator/engine/combatLoop.ts:1904 applyMorganaDarklight (어둠의 여인 — 아군 damageReduction += UntransformedAbilityDA fallback 0.10, :4776-4777 호출)"
+  - "src/lib/simulator/systems/ability.ts:280 (TFT17_Morgana: { pattern: 'multi', maxTargets: 3, heal: true, dot: { duration: 5, perSecond: true } } — fuzzy damageVar 'TetherDamagePerSecond')"
+  - "src/lib/simulator/engine/combatLoop.ts:6813 (main) / :7676 (OOR) dot.perSecond → dotTotal = TetherDamagePerSecond × duration(5) / getAbilityShield(ability.ts:505) Shield / classifyHealVar(:197) OmnivampPercent → null (no-op)"
+related:
+  - "[[role-passive]]"
+  - "[[ability-targeting]]"
+  - "[[pantheon]]"
+  - "[[aurelionsol]]"
+---
+
+# 모르가나 (Morgana)
+
+## 요약
+
+4코스트 **어둠의 여인 (`TFT17_MorganaUniqueTrait`)** unique trait. raw role `APTank`. carry augment 없음.
+
+- **role**: `mapGameRole('APTank')` → sim **Tank** ([[role-passive]] — 공격당 5 / 초당 0 / 피격 ✅). hp 1300, armor/MR 70/70, range 2.
+- **ability "어둠의 형상"**: 패시브 — 스킬 피해의 `OmnivampPercent`(20%) 회복. 사용 시 `Duration`(5)초 변신 + `Shield`(scaleAP) 보호막. 변신 동안 가장 가까운 적 `NumEnemies`(3)명을 사슬로 연결해 **매초** `TetherDamagePerSecond`(scaleAP) 마법. 변신 종료 시 연결된 적에게 `FinalDamage`(scaleAP) 마법 버스트.
+
+> 🎯 **Morgana 는 변신형 사슬 DOT 탱커** — 사슬 피해 `TetherDamagePerSecond` 가 **매초** 적용이라 [[pantheon]]·[[aurelionsol]] 와 동일하게 `dot.perSecond` 로 × Duration(5) 반영. FinalDamage 버스트 + omnivamp 는 미반영.
+
+> ⚠️ **set17 entity confirm**: `TFT17_Morgana` apiName 으로 소속 확인 (cost 4, traits 어둠의 여인, role APTank). 한글명 list 만으로 후보 선정 금지.
+
+## 메커니즘
+
+### Stats (raw, 17.4 LIVE)
+
+| Stat | 값 |
+|------|---|
+| hp | 1300 |
+| armor / magicResist | 70 / 70 |
+| damage | 60 |
+| attackSpeed | 0.65 |
+| range | 2 |
+| critChance / critMultiplier | 0.25 / 1.4 |
+| initialMana / mana | 30 / 90 |
+
+### Role — Tank
+
+| 형태 | role | weight | 공격당 마나 | 초당 마나 | 피격 시 마나 | 근거 |
+|------|------|--------|-----------|---------|------------|------|
+| base (증강 없음) | **Tank** | 3 | 5 | 0 | ✅ | `mapGameRole('APTank')` includes 'Tank' ([[role-passive]]) |
+
+### Active — 어둠의 형상 (변신 + 사슬 DOT)
+
+| 변수 | raw value | sim 적용 |
+|------|-----------|---------|
+| Shield | [300, 250, 300, 4000, ...] | ✅ `getAbilityShield`(ability.ts:505) — 'Shield' 변수 pick. filler(v0>v1: 300>250) → ★1=250/★2=300/★3=4000. scaleAP |
+| TetherDamagePerSecond | [0, 50, 75, 1500, 3000, ...] | ✅ fuzzy `damageVar` (includes 'Damage') filler(v0=0) → ★1=50/★2=75/★3=1500 (scaleAP, **매초**) |
+| NumEnemies | [3, ...] | ✅ `maxTargets: 3` — 사슬 연결 적 수 |
+| FinalDamage | [0, 240, 360, 4000, ...] | ⚠️ **미반영** — 변신 종료 시 버스트 (지연 final burst 메커니즘 부재). filler → ★1=240/★2=360 |
+| OmnivampPercent | [0.2, ...] | ⚠️ **미반영** — config `heal:true` 이나 `classifyHealVar`(combatLoop:197)가 OmnivampPercent 를 매칭 못 함(null) → resolveSelfHeal 0. ability omnivamp 20% 누락 |
+| Duration | [5, ...] | ✅ `dot.duration: 5` |
+
+- sim: `pattern: 'multi', maxTargets: 3, heal: true, dot: { duration: 5, perSecond: true }`. `dot.perSecond` → 사슬 DOT 총량 = `TetherDamagePerSecond★ × Duration(5)` (매초값 × 5, [[pantheon]] 동형).
+- ⚠️ **FinalDamage 미반영**: 변신 종료 시 1회 버스트(★2=360)는 지연 final burst 모델 부재로 미적용.
+- ⚠️ **omnivamp 미반영**: `heal:true` flag 가 있으나 OmnivampPercent 가 `classifyHealVar` 매칭 패턴(Healing/Heal/HealthGain/PercentHealing) 에 없어 no-op. ability 피해 20% 회복 누락.
+
+### Trait — 어둠의 여인 (MorganaUniqueTrait)
+
+- **어둠의 여인** (`TFT17_MorganaUniqueTrait`, bp 1): unique trait (단일 unit 전용). `applyMorganaDarklight` (combatLoop.ts:1904, 전투 시작 시 아군/적군 각 1회 `:4776-4777`) — 아군 전체 `damageReduction += UntransformedAbilityDA`(fallback 0.10 ≈ 10%, 90% cap). raw trait json 은 `UntransformedAbilityDA` 심볼 부재(`{816175b9}`: 0.10 해시 + `Durability`: 0.04) → 코드가 항상 fallback 0.10 사용(값은 `{816175b9}` 와 일치). ⚠️ raw `Durability`(0.04) 별도 보너스는 미read 여부 추가 verify 필요.
+
+## sim 통합 상태 — `partial`
+
+✅ **활성**:
+- stats 17.4 정합 (hp 1300, armor/MR 70, AD 60, AS 0.65, range 2, mana 30/90)
+- role Tank (`mapGameRole('APTank')`)
+- 사슬 DOT: `TetherDamagePerSecond★ × Duration(5)` (dot.perSecond), maxTargets 3
+- 보호막 Shield(scaleAP, getAbilityShield)
+- trait 어둠의 여인: `applyMorganaDarklight` (combatLoop.ts:1904) — 아군 전체 `damageReduction +10%`(fallback)
+
+⚠️ **미반영** (Lint 후보):
+- **P2**: FinalDamage(변신 종료 버스트, ★2=360) — 지연 final burst 메커니즘 부재
+- **P2**: OmnivampPercent(20% ability omnivamp) — config heal:true 가 classifyHealVar 매칭 없어 no-op
+- **P2**: 어둠의 여인 raw `Durability`(0.04) 별도 보너스 — `applyMorganaDarklight` 가 `UntransformedAbilityDA` 만 read(fallback 0.10) → Durability 4% 미read 여부 verify 필요
+- calibration: game-423 에 **enemy** 로 존재(playerDamage 미측정). perSecond fix 로 enemy Morgana 사슬 5× → player units 약간 빨리 사망 → diff-cache 변동(avgErr -0.298→-0.298, flat). correctness fix ([[pantheon]] 동형, unit test 검증).
+
+## 관련 문서
+
+- [[role-passive]] — Tank role 마나/타게팅
+- [[pantheon]] — dot.perSecond 동형 (초당값 × duration)
+- [[aurelionsol]] — dot.perSecond 동형 DOT

--- a/src/lib/simulator/systems/ability.ts
+++ b/src/lib/simulator/systems/ability.ts
@@ -277,7 +277,7 @@ export const CHAMPION_ABILITY_PATTERNS: Record<string, AbilityConfig> = {
   TFT17_Shen:        { pattern: 'aoe_circle', radius: 2, selfBuff: { attackSpeed: 0.3, duration: 999 } },  // 보호막 + 균열 AOE + AS둔화
   TFT17_Zed:         { pattern: 'self_buff' },  // 분신 소환 (복제)
   TFT17_Graves:      { pattern: 'cone', radius: 2, secondaryDamageVar: 'SecondaryDamageAD' },  // 원뿔 스킬 Damage + 인접 SecondaryDamageAD
-  TFT17_Morgana:     { pattern: 'multi', maxTargets: 3, heal: true, dot: { duration: 5 } },  // 변신 + 사슬 3명 5초 DOT + 최종 폭발
+  TFT17_Morgana:     { pattern: 'multi', maxTargets: 3, heal: true, dot: { duration: 5, perSecond: true } },  // 변신 + 사슬 3명 매초 TetherDamagePerSecond(scaleAP) × 5 (Bard/Viktor/AurelionSol/Pantheon 동형 perSecond) + 최종 폭발(FinalDamage 미반영)
 
   // === 미등록 챔피언 추가 (2차 — audit 검출분) ===
   TFT16_Blitzcrank:  { pattern: 'aoe_circle', radius: 2 },               // 보호막 + 주변 적 데미지

--- a/tests/unit/simulator/morgana-tether-persecond.test.ts
+++ b/tests/unit/simulator/morgana-tether-persecond.test.ts
@@ -1,0 +1,41 @@
+/**
+ * 회귀 가드 — 모르가나(Morgana) 어둠의 형상 사슬 DOT 초당값 × duration (under-damage fix, 2026-06-16).
+ *
+ * Morgana 「어둠의 형상」 사슬 피해 var = TetherDamagePerSecond 는 **매초** 값인데 dot 이
+ * 총량 처리하던 것을 dot.perSecond 로 × Duration(5) 정정
+ * (Bard #241 / Viktor #252 / AurelionSol #253 / Pantheon #254 동형).
+ * 미측정 챔프(diff-cache playerDamage 부재)라 unit test 로 검증.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { simulateCombat } from '@/lib/simulator/engine/combatLoop';
+import { getAbilityDamage, setScalingData, type ScalingData } from '@/lib/simulator/systems/ability';
+import { loadServerCatalogs } from '@/lib/validation/serverCatalogs';
+import scalingJson from '../../../public/data/tft_set17_scaling.json';
+import type { PlacedChampion, RawChampion } from '@/types';
+
+const { champions, traits } = loadServerCatalogs();
+const morg = champions.find(c => c.apiName === 'TFT17_Morgana')!;
+const cho = champions.find(c => c.apiName === 'TFT17_Chogath')!;
+
+beforeAll(() => {
+  setScalingData(scalingJson as unknown as ScalingData);
+});
+
+function placed(c: RawChampion, q: number, r: number, star: 1 | 2 | 3): PlacedChampion {
+  return { champion: c, starLevel: star, position: { q, r }, items: [] };
+}
+
+describe('모르가나 어둠의 형상 사슬 DOT 초당값×duration (회귀 가드)', () => {
+  it('cast DOT 총량 = TetherDamagePerSecond★ × Duration(5) — 초당값 ×5', () => {
+    const r = simulateCombat(
+      [placed(morg, 2, 3, 2)],
+      [placed(cho, 5, 2, 2), placed(cho, 5, 3, 2), placed(cho, 5, 4, 2)],
+      { seed: 0, allTraits: traits, skipMirror: true, stageNumber: 4 },
+    );
+    const t = r.playerUnits[0];
+    const cast = r.logs.find(l => l.type === 'ability' && l.sourceId === t.id && /지속 피해/.test(l.message ?? ''));
+    expect(cast).toBeDefined();
+    const dmg = getAbilityDamage(morg, 2, 0, 0).damage; // TetherDamagePerSecond★2=75 (per-second)
+    expect(cast!.value ?? 0).toBeGreaterThan(dmg * 4); // ×5 (perSecond)
+  });
+});


### PR DESCRIPTION
## 요약

champion ingest **48/65** — 모르가나(Morgana).

「어둠의 형상」 사슬 피해 var `TetherDamagePerSecond` 가 **매초** 값인데 sim `dot` 이 총량 처리(1초분만) → 5× under-damage. `dot.perSecond: true` 로 × Duration(5) 정정. **perSecond 패턴 5번째 적용** (Bard #241 / Viktor #252 / AurelionSol #253 / Pantheon #254 / Morgana).

## 변경

- `src/lib/simulator/systems/ability.ts:280` — `dot: { duration: 5, perSecond: true }`
- fuzzy `findDamageVariable`(includes 'Damage') 가 `TetherDamagePerSecond` pick. filler(v0=0) → ★1=50/★2=75/★3=1500 (scaleAP magic)
- `tests/unit/simulator/morgana-tether-persecond.test.ts` — 사슬 DOT 총량 = TetherDamagePerSecond★ × 5 회귀 가드
- `docs/wiki/champions/morgana.md` — ingest
- `actual-data/diff-game-20260423-001.json` — enemy Morgana coupling 재생성

## calibration

Morgana 는 game-423 에 **enemy** 로 존재(playerDamage 미측정). perSecond fix 로 enemy Morgana 사슬 5× → player units 약간 빨리 사망 → diff-cache 재생성(avgErr -0.298→-0.298, **flat**). 실제 coupling 변화 반영.

## 검증

- `pnpm lint && pnpm typecheck && pnpm build` ✅
- unit test ✅
- wiki-ingest-verifier: **P0 1 / P1 1 / P2 1**
  - **P0**: 어둠의 여인 trait 에 `applyMorganaDarklight`(combatLoop:1904) 함수 **존재**(아군 damageReduction +10%) — 초안의 "trait 함수 없음" 오기재를 **반영 사실로 정정**(룰 #16 — apply함수 grep 누락)
  - P1: frontmatter/활성 리스트에 trait 반영 추가 / P2: FinalDamage·Omnivamp·Durability(0.04) 미반영 명시

⚠️ 미반영(P2): FinalDamage(변신 종료 버스트), OmnivampPercent(20% — heal:true no-op), trait Durability(0.04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)