### PR TITLE
docs(wiki): 17.5/17.5b 패치 ingest + 진척도 동기화

### DIFF
--- a/docs/meta/sim-accuracy-followups.md
+++ b/docs/meta/sim-accuracy-followups.md
@@ -154,3 +154,21 @@ baseline (2026-04-27 trait 4개 모두 미구현):
 **재고 트리거:**
 - v1 리포트를 3~5판 돌려봤는데 **"오차는 보이는데 어디를 고쳐야 할지 감이 안 옴"** 상태 도달 시
 - 또는 단일 원인이 명확 (예: "모든 라운드에서 일관되게 내 팀 딜이 50% 낮음" → 데미지 공식 한 곳만 파면 됨) → 귀속 툴 없이 수동 처리 가능
+
+---
+
+## 📊 현재 진척 — under-damage calibration (2026-06-16 update)
+
+> baseline(2026-04-27) avgPlayerDamageErrorPct **-44.8%** → 이후 누적 fix.
+
+- **game-424 avgPlayerDamageErrorPct: -30.3% → -10.2%** (이번 세션 누적). winnerMatch ~76%.
+- **지배 단일 레버 = 공격 속도 하드캡 5.0 부재** (#236): Guinsoo 폭주로 전투 2~6s 조기종결 → 누적 데미지 과소. `getEffectiveAttackSpeed` 에 `Math.min(as, 5.0)` 추가가 최대 단일 개선.
+- **broad correctness**: raw AD-scaling 어빌리티가 bonus AD 반영(#238) / scaling.json calibration 경로 로드(#232).
+- 🆕 **perSecond 버그 클래스 5종 완결**: damageVar 가 `*PerSecond`(초당값)인데 `dot:{duration:N}` 가 perSecond 플래그 없이 총량 처리 → N배 under. `dot.perSecond:true` fix. Bard#241 / Viktor#252 / AurelionSol#253 / Pantheon#254 / Morgana#255.
+- **잔여 = duration 다요인**: 탱커 1~4s 조기사망(실전은 길게). 측정 챔프 Lissandra(-88%)/Veigar(-64%)도 probe 결과 per-cast 정상인데 빨리 죽어 캐스트 부족 → 모델링 아닌 survivability 레버(deferred). clean value-bug 는 소진됨.
+
+### ⚠️ 패치 컨텍스트 (raw data 갱신 신중)
+- raw data = **17.4 partial**, live = **17.5b** (2026-06-10). 위키 [[patch-17-5]] 에 delta 기록.
+- calibration 게임 = **17.1/17.3** (`game-20260423/424` 17.1, `game-20260519` 17.3). 따라서 17.4 도 이미 게임보다 앞섬 → **17.5b raw 갱신은 calibration 정렬을 악화** → 하지 말 것. live 17.5b 신규 게임 분석이 필요할 때만 별도 의사결정.
+
+> 상세 진단/히스토리: 로컬 메모리 `project_underdamage_calibration.md` (지속 갱신). 챔프 ingest 진행: `project_champion_ingest_status.md`.

--- a/docs/wiki/champions/akali.md
+++ b/docs/wiki/champions/akali.md
@@ -9,7 +9,7 @@ traits:
   - 습격자
 role: Fighter   # raw "ADFighter" → mapGameRole() → sim Fighter (types/index.ts:46 includes('Fighter')). carry augment 없음 → role 변환 분기 없음
 raw_role: ADFighter
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage AD ★2~ 37/56/84→39/59/88 (★1=27 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: partial   # active line dash 단검 5개(hitCount 5 split, DamageAD scaleAD) + armorReduction debuff + N.O.V.A.(DRX) surge Precision(팀 spellCanCrit)/selector burn[12,18,24]/단검 burn ×1.10 + 습격자(MeleeTrait) 정합. P2 armorReduction sim 15 flat vs raw ArmorShred 1/ArmorShredCrit 2 불일치 (단위 미확인) / P2 secondaryDamage SecondaryDamageModifier 0.4 (2차 적중 40%) 미반영 (grep 0) / P2 DamageAP(scaleAP) 미사용 (auto-detect DamageAD 우선)
 last_verified: 2026-06-04
 sources:
@@ -26,6 +26,7 @@ sources:
   - "src/lib/simulator/engine/combatLoop.ts:1280-1290 (post-cast — Akali 단검 hit 시 akali-nova-selector burn × 1.10, NovaShurikenBonusDamage 10%)"
   - "src/lib/simulator/engine/combatLoop.ts:421-434 (습격자 MeleeTrait 흡혈→보호막 변환 cap maxHp×0.25) / :471-474 applySet17SynergyBuffs 습격자 분기 (teamwideOmnivamp/championOmnivamp/championAD) / :535-545 MeleeTrait MaxPercentHealthShield+ShieldAD"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[aatrox]]"

--- a/docs/wiki/champions/bard.md
+++ b/docs/wiki/champions/bard.md
@@ -9,7 +9,7 @@ traits:
   - 전달자
 role: Caster   # raw "APCaster" → mapGameRole() → sim Caster (types/index.ts includes('Caster')). carry augment 없음
 raw_role: APCaster
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage 220/330→240/360 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: partial   # ability 「미확인 친절 물체」 비행접시 4초 DOT — DamagePerSecond(초당값)×Duration(4) 을 dot.perSecond 로 모델(#241), aoe_circle radius 1 (SecondaryHexRange). ★ filler ★1=220/★2=330/★3=3000. 정령족(Astronaut)/전달자(ManaTrait) trait 정합. ⚠️ 미반영: SplitDamagePerSecond(주변 적은 DamagePerSecond 가 아닌 split 값이어야 하나 sim 은 aoe 전체에 DamagePerSecond 동일 적용 → 주변 과다) / TankDamageIncrease(탱커 상대 +30%) / AbductChance(납치 — economy, sim 무관) / 정령 추가효과(전투시작 정령족 아군 추가 meep) / cast 빈도·DOT 4초 vs 짧은 전투(duration-bound, 잔여 -84%)
 last_verified: 2026-06-15
 sources:
@@ -19,6 +19,7 @@ sources:
   - "src/lib/simulator/engine/combatLoop.ts:6812-6813 (dot.perSecond → dotTotal = abilityDmg × duration, DamagePerSecond 초당값 × 4) / :7667 (OOR 동일)"
   - "src/lib/simulator/engine/combatLoop.ts:2060 applyAstronautEffects (정령족 BonusHealth/Meeps) / :601 전달자(ManaTrait) InnateManaGain"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[stargazer-fountain]]"

--- a/docs/wiki/champions/caitlyn.md
+++ b/docs/wiki/champions/caitlyn.md
@@ -9,7 +9,7 @@ traits:
   - 운명술사
 role: Specialist   # raw "ADSpecialist" → mapGameRole() → sim Specialist (types/index.ts includes('Specialist')). carry augment 없음. mana 0/0 → active cast 없음 (passive only)
 raw_role: ADSpecialist
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Headshot AD ★2~ 170/255/510/875→190/285/540/925 (★1=145 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: partial   # passive 평타 헤드샷(ProcChance 15% + Damage ★1=145/170/255) + N.O.V.A.(DRX) surge AS 20%/selector mark +10% incoming/selector 헤드샷[76,114,222] + 운명술사(Fateweaver) Precision+crit stat 정합. P2 평타 헤드샷 Damage flat (desc scaleAD+scaleAP, BonusDamage(scaleAP) 미사용) / P2 운명술사 Lucky(행운, 확률 두 번 굴림) 미구현 (:1775 후속 PR — Caitlyn ProcChance 단일 roll) / info selector 헤드샷 [76,114,222] 하드코딩 (=(Damage+BonusDamage)[★+1]×0.4, scaleAD/AP 없는 flat) / info 운명술사 Precision(spellCanCrit) Caitlyn ability 없어(mana 0) 실효 제한
 last_verified: 2026-06-05
 sources:
@@ -23,6 +23,7 @@ sources:
   - "src/lib/simulator/engine/combatLoop.ts:5283-5327 (tickCaitlynHeadshot — mark 적 HP 50% 이하 처음 시 1회 헤드샷 [76,114,222] starLevel별, applyAbilityMitigation physical, triggeredSet 1회 보장)"
   - "src/lib/simulator/engine/combatLoop.ts:1778-1801 (applyFateweaverEffects — 운명술사 Precision spellCanCrit :1785 + (4) crit stat :1798-1799. Lucky 행운 :1772/:1775 후속 PR 미구현)"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[aatrox]]"

--- a/docs/wiki/champions/ezreal.md
+++ b/docs/wiki/champions/ezreal.md
@@ -9,7 +9,7 @@ traits:
   - 저격수
 role: Caster   # raw "ADCaster" → mapGameRole() → sim Caster (types/index.ts includes('Caster')). carry augment 없음
 raw_role: ADCaster
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Ability AD 160/240/365/620→170/255/380/650 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: partial   # ability 「시간의 일격」 단일 파동 TotalDamage(scaleAD scaleAP) 물리. sim single, auto-detect damageVar 'ADDamage'(scaleAD, bonusAD #238). ADDamage filler ★1=160/★2=240/★3=365. 시간 균열자(Timebreaker)/저격수(Sniper RangedTrait) trait 정합. 드론 ✅ 반영 (permanentStacks ezreal_drones → cast 시 DroneDamage, combatLoop :7423-7434 main / :7755-7766 OOR — 단 전투 중 실시간 takedown 누적은 미추적, UI 사전설정 스택 의존). ⚠️ 미반영: APDamage(auto-detect 가 ADDamage 우선 pick) / 전투 중 실시간 takedown 누적 / TakedownsToForm3(60) 변신. calibration -25%(moderate)
 last_verified: 2026-06-16
 sources:
@@ -18,6 +18,7 @@ sources:
   - "src/lib/simulator/systems/ability.ts:219 (TFT17_Ezreal: { pattern: 'single' } — auto-detect damageVar 'ADDamage')"
   - "src/lib/simulator/engine/combatLoop.ts:1984 applySniperEffects 저격수 (base+per-hex amp) / :2100 applyTimebreakerEffects 시간 균열자"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[milio]]"

--- a/docs/wiki/champions/kindred.md
+++ b/docs/wiki/champions/kindred.md
@@ -9,7 +9,7 @@ traits:
   - 도전자
 role: Marksman   # raw "ADCarry" → mapGameRole() → sim Marksman (types/index.ts:43 includes('Carry')). carry augment 없음 → role 변환 분기 없음
 raw_role: ADCarry
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Base AD 55→58 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: partial   # active multi 화살(ADDamage scaleAD ★1=115/175/900) + 3표식 passive(SpellDamage) + N.O.V.A.(DRX) surge/Tank shield 800/selector +10% damageAmp/4.5초 주기 mark + 도전자(ASTrait) AS+Burst 정합 (AS off-by-one 은 PR #186 수정 완료 — scaling.json leading-0 제거). P2 passive 표식 평타만(desc "기본공격+스킬" 중 스킬 표식 미반영) / P2 passive mark 피해 SpellDamage flat (desc TotalDamage scaleAD+scaleAP — ad/ap scaling 미적용) / P2 active HexDistance(1) 도약 미구현 (기본 공격 AI 이동 위임) / info raw NovaDamageAmp 0.05·NovaRepeatTimer 5 미사용 (sim 17.4 하드코딩 0.10·4.5초, PR #166) / info NumTargets ★4=5 미반영 (★1-3=3, 4코 ★3까지)
 last_verified: 2026-06-04
 sources:
@@ -26,6 +26,7 @@ sources:
   - "src/lib/simulator/engine/combatLoop.ts:458-466 (도전자 TFT17_ASTrait AS — applySet17SynergyBuffs sc.teamwideAS[ti] 모든 아군 + sc.championAS[ti] 도전자 추가, scaling.json 수치 teamwideAS[0,0.1,0.15,0.2,0.3]/championAS[0,0.2,0.35,0.55,0.9])"
   - "src/lib/simulator/engine/combatLoop.ts:517/3529/5541/5613 (도전자 Burst — :517 combat-start challengerBurstPercent(0.5) set / :5541 challengerIds Burst 트리거 id 집합 / :5613 새 대상 dash 시 challengerBurstEndTick=tick+2.5초 [scaling.json burstDuration:3 은 dead config] / :3529 AS read as×(1+burstPercent))"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[aatrox]]"

--- a/docs/wiki/champions/mordekaiser.md
+++ b/docs/wiki/champions/mordekaiser.md
@@ -10,7 +10,7 @@ traits:
   - 선봉대
 role: Tank   # raw "APTank" → mapGameRole() → sim Tank. ⚠️ MordekaiserCarry augment 활성 시 Fighter 로 변환 (applyHeroCarryTransforms) — base 의 helper 메커니즘은 carry 활성 여부와 무관 동작 (mordekaiserCarryShield 만 InitialShield override)
 raw_role: APTank
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Initial Shield 300/375/500→350/425/550 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: active   # base raw 메커니즘 거의 완성 (helper 2개 + 별도 shield pool + healRefund + main/OOR cast parity)
 last_verified: 2026-05-26
 sources:
@@ -31,6 +31,7 @@ sources:
   - "tests/unit/mordekaiser-proc.test.ts (applyMordekaiserProcCast + tickMordekaiserProc 전용 test)"
   - "tests/unit/simulator/darkstar-execute-supermassive.test.ts:27+ (apMordekaiser 암흑의 별 fixture)"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[hero-augment-carry]]"
@@ -52,7 +53,7 @@ related:
 
 ## 메커니즘 (base raw, helper 통합 sim)
 
-### Stats (raw, 17.3 LIVE)
+### Stats (raw, 17.4 LIVE — 17.3 이후 변경 없음)
 
 | Stat | 값 |
 |------|---|
@@ -126,7 +127,7 @@ MordekaiserCarry augment 활성 시:
 ## sim 적용 상태 — `active`
 
 ✅ **활성** (base raw helper 통합):
-- stats 17.3 정합 (hp 950, armor/MR 45, AS 0.6, mana 40/100, range 1)
+- stats 17.3/17.4 정합 (hp 950, armor/MR 45, AS 0.6, mana 40/100, range 1)
 - ability override `pattern: 'self_buff'` + helper 통합 (applyMordekaiserProcCast + tickMordekaiserProc)
 - InitialShield × AP → 별도 shield pool (`mordekaiserShieldRemaining`)
 - 4초 동안 매초 펄스 (4 펄스): ShieldPerProc 본인 + DamagePerProc 1칸 적 magic
@@ -160,7 +161,7 @@ MordekaiserCarry augment 활성 시:
 
 - [x] **set17 entity 소속 0단계** — `public/data/tft_set17_champions.json` `TFT17_Mordekaiser` apiName grep 확인 (한글 매칭 금지)
 - [x] entity-wide grep `Mordekaiser` + `mordekaiser` — sim 23+ site + test 2 file 전수 식별 (helper 2개 + state 3 field + shield pool + carry data field + dark star group + per-tick 호출)
-- [x] raw stats 17.3 정합
+- [x] raw stats 17.3/17.4 정합
 - [x] **raw role `APTank` → mapGameRole → sim Tank** ([[jax]] / [[nasus]] 와 동일 매핑 — 3번째 base APTank champion)
 - [x] MordekaiserCarry 변환 시 role overwrite `Fighter` + `mordekaiserCarryShield` carry data 저장 (lint #7 해소)
 - [x] **cast path 3종** — main (`combatLoop.ts:7037`) + OOR (`:7185`) 양쪽 `applyMordekaiserProcCast` 호출 parity verify. recast 무관 (self_buff 패턴 + onKillRecast 없음)

--- a/docs/wiki/champions/nasus.md
+++ b/docs/wiki/champions/nasus.md
@@ -9,7 +9,7 @@ traits:
   - 선봉대
 role: Tank   # raw "APTank" → mapGameRole() → sim Tank. ⚠️ NasusCarry augment 활성 시 Fighter 로 변환 (applyHeroCarryTransforms)
 raw_role: APTank
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Flat Health gained 250/350/550/750→300/400/600/800 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: partial
 last_verified: 2026-05-21
 sources:
@@ -24,6 +24,7 @@ sources:
   - "tests/unit/simulator/hero-carry-augments.test.ts:151+ (nasusBonkStack 초기값 + cast kill 누적 회귀 가드)"
   - "tests/unit/simulator/vanguard-trait.test.ts:21 (apNasus 선봉대 시너지 fixture)"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[hero-augment-carry]]"
@@ -44,7 +45,7 @@ related:
 
 ## 메커니즘 (base raw, carry 미활성)
 
-### Stats (raw, 17.3 LIVE)
+### Stats (raw, 17.4 LIVE — 17.3 이후 변경 없음)
 
 | Stat | 값 |
 |------|---|
@@ -107,7 +108,7 @@ NasusCarry augment 활성 시:
 ## sim 적용 상태 — `partial`
 
 ✅ **활성**:
-- stats 17.3 정합 (hp 700, armor/MR 45, AS 0.65, mana 60/120, range 1, dmg 40)
+- stats 17.3/17.4 정합 (hp 700, armor/MR 45, AS 0.65, mana 60/120, range 1, dmg 40)
 - ability pattern `aoe_circle r=1` + `dot 6s` + `selfBuff durability 0.2 for 6s`
 - carry 미활성 시 raw role `APTank` → mapGameRole → **Tank** 자동 분기 (mana on-hit 수령 / weight 3 / damage reduction ×1.0)
 - 선봉대 (Vanguard) `applyVanguardEffects` 보호막 (tick=0)
@@ -141,7 +142,7 @@ NasusCarry augment 활성 시:
 
 - [x] **set17 entity 소속 0단계** — `public/data/tft_set17_champions.json` `TFT17_Nasus` apiName grep 확인 (한글 이름 매칭 금지 — codex PR #149 P2 sub-rule)
 - [x] entity-wide grep `Nasus` + `nasus` — sim 4 site (ability override + applyCarryDamageModifiers #6 + cast loop markTargetDead 직후 + nasusBonkStack field) + test 2 file
-- [x] raw stats 17.3 정합 (`public/data/tft_set17_champions.json` 확인)
+- [x] raw stats 17.3/17.4 정합 (`public/data/tft_set17_champions.json` 확인)
 - [x] **raw role `APTank` → mapGameRole → sim Tank** ([[jax]] 와 동일 매핑)
 - [x] NasusCarry 변환 시 role overwrite `Fighter` (`combatLoop.ts:2265`) + selectedCarryAugment set
 - [x] cast path 3종 — NasusCarry single 패턴 → main pipeline only (OOR/recast 진입 불가, `combatLoop.ts:6594` comment 확인)

--- a/docs/wiki/champions/rammus.md
+++ b/docs/wiki/champions/rammus.md
@@ -9,7 +9,7 @@ traits:
   - 요새
 role: Tank   # raw "APTank" → mapGameRole() → sim Tank (types/index.ts includes('Tank')). carry augment 없음
 raw_role: APTank
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Meeple bonus DR per Meep 4→3 (nerf) / Mana 20/90→20/80 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: partial   # 액티브 「중력 회전」: 보호막(ShieldAP) + 일직선 3칸 마법(DamageAP scaleAP + DamageArmor scaleArmor). scaleArmor 성분은 casterArmorScaleVar 로 main+OOR cast path 에서 caster armor 비례 가산(ability.ts:238 / combatLoop.ts:6589,7466). selfBuff durability 0.3 근사. 정령 패시브(정령족 active 게이트): 20회 피격 후 반경 2칸 magic AoE = PassivePercentArmor★ × armor (applyAstronautEffects precompute :2068 + defender 평타훅 :6436). 정령족 BonusHealth/Meeps applyAstronautEffects 적용 / 요새(ResistTank) teamwide armor/MR 정합. ⚠️ 미구현: 패시브 FlatDR(받는 공격 피해 감소, FlatDRPerMeep) / 패시브 AoE 는 sim 전투 단축(6~12s)으로 20회 threshold 실전만큼 미충족 → calibration 잔여 -74~98% (systemic duration, AS캡 #236 후에도)
 last_verified: 2026-06-15
 sources:
@@ -20,6 +20,7 @@ sources:
   - "src/lib/simulator/engine/combatLoop.ts:2048 applyAstronautEffects (정령족 active 시 rammusPassiveArmorCoef = PassivePercentArmor★ 저장 :2068) / :6436 defender 평타훅 (rammusHitsTaken 20회 → 반경 2칸 magic AoE coef×armor)"
   - "src/lib/simulator/engine/combatLoop.ts:1914 applyBastionEffects 요새(ResistTank) teamwide Armor/MR (:1903 JSDoc) / :2048 정령족(Astronaut) BonusHealth/Meeps"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[stargazer-fountain]]"

--- a/docs/wiki/champions/samira.md
+++ b/docs/wiki/champions/samira.md
@@ -9,7 +9,7 @@ traits:
   - 저격수
 role: Caster   # raw "ADCaster" → mapGameRole() → sim Caster (types/index.ts includes('Caster')). carry augment 없음
 raw_role: ADCaster
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: (17.5b) Mana 0/60→0/65 + Ability CC 1.25s→1s (nerf). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: partial   # active 단일 탄환(Damage scaleAD physical) + stun(공중 띄움) + 우주그루브(SpaceGroove)/저격수(Sniper) trait 정합. P1: passive(onEnemyAirborne 시 PassiveDamage scaleAD scaleAP physical + GrooveDuration TheGroove) 미반영 — onEnemyAirborne 트리거 핸들러 부재(grep 0, onAttack/onKill 만 존재) / P2: active stun 1.0 vs raw StunDuration 1.25 (sim 0.25s 적음) / P2: TheGroove 상태(passive 발동 시 3초) 미반영 (passive 자체 미모델) / P2: passive PassiveAP(scaleAP) — passive 미모델로 무의미
 last_verified: 2026-06-12
 sources:
@@ -22,6 +22,7 @@ sources:
   - "src/lib/simulator/engine/combatLoop.ts:1791 (applySpaceGrooveBuffs 우주 그루브) + :1949 (applySniperEffects 저격수)"
   - "src/lib/simulator/engine/combatLoop.ts:6275/6302 (scaling 핸들러 — onAttack/onKill 만, onEnemyAirborne 분기 없음)"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[teemo]]"

--- a/docs/wiki/champions/teemo.md
+++ b/docs/wiki/champions/teemo.md
@@ -9,7 +9,7 @@ traits:
   - 길잡이
 role: Marksman   # raw "APCarry" → mapGameRole() → sim Marksman (types/index.ts:43 includes('Carry')). carry augment 없음
 raw_role: APCarry
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage(MagicDamage) ★2~ 65/95/170/300→70/105/190/325 (★1=60 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: partial   # onAttack passive 추가 마법(hitDamage scaleAP, ★1=30 filler) ✅ + active selfBuff AS + 우주그루브(SpaceGroove) 정합. P1: 독 DOT(MagicDamage/poisonDamage, PoisonDuration 6초) 미반영 — onAttack extraDamage 핸들러는 단일 hit 만 (Teemo 핵심 지속 피해 누락) / P1: active selfBuff attackSpeed 0.5 vs raw AttackSpeed 1.5 (3배 과소, ability.ts:195 하드코딩) / P2: active "ActiveAttacks 3회 평타 동안" vs sim duration 3 (selfBuff.duration read 0 → 영구) 메커니즘 불일치 / P2: SpaceGroove TheGroove(적 GrooveStacks 5 중첩 시) 미반영 grep 0 / P2: 길잡이(SummonTrait) tier buff 미반영 (소환체 유닛 생성은 builder layer useTeamManagement.ts 존재, combat sim applySummonTrait 부재 — codex P2 PR #222)
 last_verified: 2026-06-12
 sources:
@@ -21,6 +21,7 @@ sources:
   - "public/data/tft_set17_scaling.json (TFT17_Teemo — trigger onAttack, effect extraDamage/magic/ap, hitDamage [100,30,45,100], poisonDamage [60,70,105,190], poisonDuration 6, grooveStacks 5)"
   - "src/lib/simulator/engine/combatLoop.ts:1791 (applySpaceGrooveBuffs — 우주 그루브 매초 ADAP) / 길잡이 TFT17_SummonTrait: combat sim applySummonTrait 부재이나 src/hooks/useTeamManagement.ts:152-180 (syncVoyagerSummonInTeam) + :315-334 (syncTeam) 가 소환체 유닛 생성 (builder layer, partial)"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[ivernminion]]"

--- a/docs/wiki/champions/vex.md
+++ b/docs/wiki/champions/vex.md
@@ -8,7 +8,7 @@ traits:
   - 파멸자
 role: Marksman   # raw "APCarry" → mapGameRole() → sim Marksman (types/index.ts:43 includes('Carry')). ⚠️ 실제 AP 메이지지만 mapGameRole string-match 가 Carry → Marksman 으로 분류 (Caster 아님). carry augment 없음 → role 변환 분기 없음
 raw_role: APCarry
-current_patch_status: active
+current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage AP 130/195→140/210 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
 sim_active: partial   # passive 그림자(ShadowHandDamage scaleAP + spread + amp + lethal) / active 강화타격(ShadowHandMagicDamage scaleAP hitCount 3 split, spell crit 가능) / 파멸자(VexUniqueTrait ADAP 12% 강탈 양팀 snapshot) 핵심 정합. P2 passive NumStrikesForPassive=5 그림자 재타격 미반영 (grep 0 read) / P2 파멸자 표식 트리거 단순화 (combat-start 즉시 일괄 강탈, "적 첫 피해 시" 표식 소모 생략) / P2 active "강화 타격 3회" desc vs sim aoe_circle split (총피해 base×3 / aliveTargets 분배) + NumActiveStrikes raw var 직접 read 아님 (hardcoded 3) / P2 passive "주변 적" spread = 최근접 1명 보수 해석 (raw 반경 변수 없음) / P2 passive 그림자 spell crit 미지원 (평타 hook crit 분기 부재, active cast :6581 만 crit, codex PR #183)
 last_verified: 2026-06-02
 sources:
@@ -24,6 +24,7 @@ sources:
   - "src/lib/simulator/engine/combatLoop.ts:4577 (applyVexDoomBothSides 호출 — combat-start, 다른 unique trait 와 동위치)"
   - "src/lib/simulator/engine/combatLoop.ts:172-182 (readVarByStar filler 판정 — v0>v1 또는 v1/v0>5 → filler, idx=starLevel)"
 related:
+  - "[[patch-17-5]]"
   - "[[role-passive]]"
   - "[[ability-targeting]]"
   - "[[spell-crit]]"

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -22,6 +22,8 @@ updated: 2026-05-21 (PR #151 mordekaiser.md)
 
 ## Patches
 
+- [[patch-17-5]] — 2026-06-10 LIVE (+ 17.5b mid-patch). econ augment 너프 + 저활용 챔프 버프(Bard/Veigar/Fizz/Caitlyn/Mordekaiser) + Meeple/Rammus 너프. ⚠️ **raw data/sim = 17.4 partial 미반영**, calibration 게임(17.1/17.3) 정렬상 17.5b raw 갱신 신중. 이번 세션 sim-fix 챔프(Bard/Ezreal/Rammus 등) 수치 delta source
+- [[patch-17-4]] — 2026-05-27 LIVE. Bel'Veth 너프 revert + Arbiter 대규모 개편 + Sniper/Psionic 일관성. raw data 는 sequence B(Zed/Shen/Jax) 1차만 17.4, 나머지 17.3 기준
 - [[patch-17-3]] — 2026-05-13 LIVE. **공식 패치노트 정상화 후 종합 ingest** (System/Traits/27 챔프/5 신규 aug/15+ 조정 aug/items/bug fixes). Morgana 4코 리워크, Stargazer Fountain 재활성화 + (3)/(5) 4%/7% 확정, carry augment sim drift 5건
 - [[patch-17-2b]] — 2026-04-29 mid-patch. Hero Augment carry 시스템 sim 정식화 + 군체의 심장 disabled (17.3 로 부분 obsoleted)
 - [[patch-17-2]] — Set 17 메이저 패치. carry augment 3종 (Heat Death/Self-Destruct/Shieldmaiden) **게임 도입** + Stargazer Fountain 첫 비활성화. 17.2b/17.3 로 다수 항목 superseded

--- a/docs/wiki/patches/patch-17-4.md
+++ b/docs/wiki/patches/patch-17-4.md
@@ -12,6 +12,7 @@ sources:
   - public/data/tft_set17_traits.json (17.3 기준 — 17.4 갱신 대기)
   - public/data/tft_set17_augments.json (17.3 기준 — 17.4 갱신 대기)
 related:
+  - "[[patch-17-5]]"
   - "[[patch-17-3]]"
   - "[[patch-17-2b]]"
   - "[[zed]]"

--- a/docs/wiki/patches/patch-17-5.md
+++ b/docs/wiki/patches/patch-17-5.md
@@ -20,6 +20,11 @@ related:
   - "[[rammus]]"
   - "[[mordekaiser]]"
   - "[[samira]]"
+  - "[[nasus]]"
+  - "[[teemo]]"
+  - "[[akali]]"
+  - "[[kindred]]"
+  - "[[vex]]"
 ---
 
 # Patch 17.5 + 17.5b (2026-06-10 LIVE)
@@ -47,16 +52,16 @@ related:
 ### Tier 1
 | 챔프 | 항목 | 17.4(데이터) → 17.5 |
 |------|------|---------------------|
-| [[caitlyn]] | Headshot AD | 170/255/510/875 → **190/285/540/925** (buff) |
+| [[caitlyn]] | Headshot AD (★2~, ★1=145 불변) | 170/255/510/875 → **190/285/540/925** (buff) |
 | [[ezreal]] | Ability AD | 160/240/365/620 → **170/255/380/650** (buff) |
-| Nasus | Flat Health gained | 250/350/550/750 → **300/400/600/800** (buff) |
-| [[teemo]] | Spell Damage | 65/95/170/300 → **70/105/190/325** (buff) |
-| Veigar | Spell Damage AP | 310/465/700/1190 → **330/495/750/1200** (buff) |
+| [[nasus]] | Flat Health gained | 250/350/550/750 → **300/400/600/800** (buff) |
+| [[teemo]] | Spell Damage (★2~, ★1=60 불변) | 65/95/170/300 → **70/105/190/325** (buff) |
+| [[veigar]] | Spell Damage AP | 310/465/700/1190 → **330/495/750/1200** (buff) |
 
 ### Tier 2
 | 챔프 | 항목 | 17.4 → 17.5 |
 |------|------|-------------|
-| [[akali]] | Spell Damage AD | 37/56/84 → **39/59/88** (buff) |
+| [[akali]] | Spell Damage AD (★2~, ★1=27 불변) | 37/56/84 → **39/59/88** (buff) |
 | Bel'Veth | Spell Damage AD | 20/30/45 → **22/33/50** (buff) |
 | Gwen | Attack Speed / AoE AP | 0.85→**0.8** / 75/110/190 → **75/110/215** (★3 buff) |
 | [[mordekaiser]] | Initial Shield | 300/375/500 → **350/425/550** (buff) |

--- a/docs/wiki/patches/patch-17-5.md
+++ b/docs/wiki/patches/patch-17-5.md
@@ -1,0 +1,136 @@
+---
+id: patch-17-5
+type: patch
+live_date: 2026-06-10
+status: LIVE
+last_verified: 2026-06-16 (17.5 + 17.5b mid-patch 공식/2차 소스 ingest. **raw data + sim 코드 = 17.4 partial 기준 (17.5/17.5b 미반영)**. ⚠️ calibration 게임은 17.1/17.3 이라 17.5b raw 갱신은 calibration 정렬을 오히려 악화 — 데이터 갱신 신중)
+sources:
+  - https://teamfighttactics.leagueoflegends.com/en-us/news/game-updates/teamfight-tactics-patch-17-5/ (공식)
+  - https://www.gamer.org/tft-patch-17-5-changes-every-buff-nerf-and-meta-shift-explained/ (gamer.org)
+  - https://esports.gg/news/teamfight-tactics/tft-patch-17-5-notes-space-groove-and-ornn-nerfs/ (esports.gg)
+  - public/data/tft_set17_champions.json (meta.patch_version "17.4 LIVE (partial — sequence B 1차)" — 17.5/17.5b 미반영)
+  - public/data/tft_set17_traits.json / tft_set17_items.json / tft_set17_augments.json (17.3~17.4 partial — 17.5/17.5b 미반영)
+related:
+  - "[[patch-17-4]]"
+  - "[[patch-17-3]]"
+  - "[[bard]]"
+  - "[[veigar]]"
+  - "[[caitlyn]]"
+  - "[[ezreal]]"
+  - "[[rammus]]"
+  - "[[mordekaiser]]"
+  - "[[samira]]"
+---
+
+# Patch 17.5 + 17.5b (2026-06-10 LIVE)
+
+> Set 17 Space Gods 의 5번째 메이저 패치 (+ 같은 날 17.5b mid-patch hotfix). 경제 augment 과열 억제(econ aug 너프 / combat aug 버프) + 저활용 챔프 다수 버프(Bard/Veigar/Fizz/Caitlyn/Mordekaiser) + Meeple/Rammus 너프. 본 페이지는 **17.5 + 17.5b 변경을 fact 로 기록**하되, **raw data + sim 코드는 17.4 partial 기준 (17.5/17.5b 미반영)** 임을 명시.
+
+## ⚠️ sim / 데이터 적용 상태 — 미반영 + calibration 정렬 주의
+
+| Asset | 17.5/17.5b 적용 상태 | 비고 |
+|-------|---------------------|------|
+| **raw data** (`public/data/tft_set17_*.json`) | ❌ **미반영** (`meta.patch_version` = "17.4 LIVE (partial — sequence B 1차)") | 17.4 자체도 partial (Zed/Shen/Jax 만 17.4, 나머지 17.3 기준) |
+| **sim 코드** (`combatLoop.ts` / `ability.ts`) | ❌ 17.5/17.5b 수치 미반영 | raw json 갱신 시 자동 반영되는 항목 다수(스탯/damageVar) |
+| **champion 위키 페이지** | ⚠️ **17.4 stats 기준** — 17.5/17.5b 변경 챔프(아래 표)는 페이지 stats 가 live 와 불일치 | 페이지는 데이터(17.4)와 정합. live(17.5b)와는 본 패치 페이지가 delta source |
+
+### 🎯 calibration 정렬 핵심 (raw data 갱신 신중)
+
+- **calibration 게임 = 과거 리플레이, 17.1/17.3 패치**: `game-20260423-001`/`game-20260424-001` = **patch 17.1**, `game-20260519-001` = **patch 17.3** (raw game json `patch` 필드).
+- 즉 현재 raw data(17.4)는 **이미 calibration 게임보다 앞서 있음**. 17.5b 로 갱신하면 sim 이 게임 당시 밸런스에서 더 멀어져 **calibration 정렬이 오히려 악화**.
+- → **17.5/17.5b raw 갱신은 calibration 목적이 아님**. live 17.5b 환경 시뮬레이션(신규 게임 분석)이 필요할 때만 별도 의사결정. 본 패치 페이지는 그때를 위한 delta 기록.
+
+## CHAMPION 변경 (17.5)
+
+> ★ 표기 = 코스트별 스탯 배열. 우리 데이터(17.4) 대비 delta.
+
+### Tier 1
+| 챔프 | 항목 | 17.4(데이터) → 17.5 |
+|------|------|---------------------|
+| [[caitlyn]] | Headshot AD | 170/255/510/875 → **190/285/540/925** (buff) |
+| [[ezreal]] | Ability AD | 160/240/365/620 → **170/255/380/650** (buff) |
+| Nasus | Flat Health gained | 250/350/550/750 → **300/400/600/800** (buff) |
+| [[teemo]] | Spell Damage | 65/95/170/300 → **70/105/190/325** (buff) |
+| Veigar | Spell Damage AP | 310/465/700/1190 → **330/495/750/1200** (buff) |
+
+### Tier 2
+| 챔프 | 항목 | 17.4 → 17.5 |
+|------|------|-------------|
+| [[akali]] | Spell Damage AD | 37/56/84 → **39/59/88** (buff) |
+| Bel'Veth | Spell Damage AD | 20/30/45 → **22/33/50** (buff) |
+| Gwen | Attack Speed / AoE AP | 0.85→**0.8** / 75/110/190 → **75/110/215** (★3 buff) |
+| [[mordekaiser]] | Initial Shield | 300/375/500 → **350/425/550** (buff) |
+
+### Tier 3
+| 챔프 | 항목 | 17.4 → 17.5 |
+|------|------|-------------|
+| Fizz | Dash Damage AP | 120/180/290 → **140/210/310** (buff) |
+| Ornn | Groove Duration | 3s → **2.5s** (nerf) |
+
+### Tier 4
+| 챔프 | 항목 | 17.4 → 17.5 |
+|------|------|-------------|
+| [[kindred]] | Base AD | 55 → **58** (buff) |
+| LeBlanc | Sigil Damage | 80/120 → **85/130** (buff) |
+| [[rammus]] | Meeple bonus DR per Meep / Mana | 4 → **3** (nerf) / 20/90 → **20/80** (buff) |
+
+### Tier 5
+| 챔프 | 항목 | 17.4 → 17.5 |
+|------|------|-------------|
+| [[bard]] | Spell Damage | 220/330 → **240/360** (buff) |
+| [[vex]] | Spell Damage AP | 130/195 → **140/210** (buff) |
+
+> ⚠️ **이번 세션 sim-fix 와 직접 충돌하는 챔프**: [[bard]](220/330→240/360 — perSecond #241 은 구조 fix 라 수치만 stale) / [[ezreal]](#251 ingest 한 ADDamage 160/240/365 가 stale) / [[rammus]](#237 ingest 한 Meeple DR/mana stale) / [[caitlyn]]/[[teemo]]/[[akali]]/[[mordekaiser]]/[[vex]]. 모두 **17.4 데이터 기준이라 페이지는 데이터와 정합** — live 갱신 시 본 표 참조.
+
+## TRAIT 변경 (17.5)
+
+- **결투가(Arbiter)**: 3평타당 Leona 8/12%→**5/8%** / Armor 12/18→**10/16** / 50마나당 Leona 10/15%→**9/12%** (nerf)
+- **미플(Meeple)**: Flat HP 100/400/400/500 → **100/350/450/550** / (10) Meeplord — Big Slam 1100→**1500** AP / AoE Slam 700→**1000** AP / Stun 1.5s→**3s** / Stun Damage 150→**400** AP
+- **별돌보미(Stargazer)/뱀(Serpent) Poison**: 20/40/60% → **18/35/50%** (17.5 nerf) → **17.5b 에서 25/45/60% 로 상향 조정** (아래 17.5b)
+- **양치기(Shepherd)**: Summon AP per Cast 20→**15** / Shield 125/300/300→**100/275/430** (17.5b 추가 조정)
+- **우주 그루브(Space Groove)**: Health Regen per Groovian 0.95%→**0.85%** / (7) Bonus 15%→**10%** (17.5b)
+
+## ITEM 변경 (17.5)
+
+- **Artifact**: The Collector AD 40%→**35%** / Mogul's Mail HP/stack 8→**5**
+- **Radiant**: Deathblade AD 110%→**100%** / Protector's Vow Shield 40%→**50%** / Morellonomicon AP 40→**35** / Quicksilver AS 30%→**40%** / Rabadon AP 110%→**100%** / Rageblade AS 20%→**25%** / Red Buff AS 90%→**80%**
+- **Anima (1~3티어)**: Guiding Hex(Aurora AP) 9→**12** / Rocket Barrage(AD 10%→**15%**, [[jinx]] Bonus 35%→**40%**) / Savage Slicer([[briar]] Hits 10→**15**) / Tentacle Slam([[illaoi]] 35%→**45%**) / The Annihilator(Store 20%→**25%**, ManaRegen 3→**5**) / Searing Shortbow(AP 40→**45**, AD 10%→**15%**) / UwU Blaster(AD 25%→**30%**) / Evolved Embershot(AP 40→**45**)
+
+> ⚠️ **sim 모델 아이템 영향**: UwU Blaster(귀여운 발사기, #217 모델) AD 25→30%, Rocket Barrage([[jinx]] #244 hitCount 관련) — live 갱신 시 STACKING_ITEMS / ITEM_EFFECTS 수치 재확인 필요.
+
+## AUGMENT 변경 (17.5) — 주요만
+
+경제 augment 대거 너프 + combat augment 버프. 대표:
+- Bonk! 280/420/670/1000 → **290/435/730/1250** AD (buff)
+- Call to Chaos(Gold 58→52 / XP 64→58 / Reroll 40→36, nerf) / Late Game Specialist Gold 36→**30** / Risky Moves 30→**26** / Savings Account 4→**2** / Slammin'+ 8→**4** (econ nerf)
+- Early Learnings 1%→**8%** / Climb the Ladder 6%→**7%** / Little Buddies(HP 55→65, AS 6%→7%) / Tiny but Deadly 30%→**33%** / U.R.F(AS 15%→20%, ManaRegen 2→3) (combat buff)
+- Heart of the Swarm Initial Briars 1→**3** / Healing Orbs I/II 220/500→**250/575** / Sunfire Board 15s→**18s**
+
+(전체 augment 목록은 공식 노트 참조 — 본 페이지는 sim 영향 큰 항목 위주.)
+
+## 17.5b MID-PATCH HOTFIX (2026-06-10)
+
+> Riot: "Fast 9 가 17.5 최강 전략이었고, Vex 너프가 과해서 일부 복구 + Bard 버프" — 의도된 메타 변경을 상쇄하던 버그 수정 포함.
+
+| 항목 | 17.5 → 17.5b |
+|------|--------------|
+| [[samira]] Mana | 0/60 → **0/65** (nerf) |
+| [[samira]] Ability CC Duration | 1.25s → **1s** (nerf) |
+| 별돌보미/뱀 Poison Damage | 18/35/50% → **25/45/60%** (17.5 너프 일부 복구 + bug fix) |
+| 양치기 Summon AP per Cast | 20 → **15** |
+| 양치기 Summon Shield | 125/300/300 → **100/275/430** AP |
+| 우주 그루브 (7) Bonus | 15% → **10%** |
+| Two Tanky (augment) Health | 500 → **450** |
+| Pengu's Party | bug fix (returning set trait 조정 — Glacial/Honeymancy/Demacia/Storyweaver/The Crew/Hacker) |
+
+## sim 통합 상태 — 미반영 (17.4 partial 기준)
+
+- raw data / sim 코드 모두 17.5/17.5b 미반영. **calibration 게임(17.1/17.3) 정렬상 raw 갱신은 신중** (위 핵심 박스).
+- 17.5/17.5b 변경 챔프 위키 페이지(stats 표)는 17.4 데이터와 정합 — live delta 는 본 페이지가 single source.
+- live 17.5b 환경 시뮬레이션이 필요해질 때: ① raw json 부분 Edit(변경 필드만, 사용자 raw-data 규칙) ② 변경 챔프 위키 patch-history row 추가 ③ 신규 게임으로 calibration 재기준.
+
+## 관련 문서
+
+- [[patch-17-4]] — 직전 패치 (Arbiter 개편 + Psionic)
+- [[patch-17-3]] — Morgana 4코 리워크 + Stargazer Fountain 재활성화
+- [[bard]] / [[ezreal]] / [[rammus]] — 이번 세션 sim-fix 챔프 중 17.5 수치 변경분


### PR DESCRIPTION
## 요약

사용자 요청: 최신 패치(17.5b) 확인 + 문서 전수 점검·동기화.

## 패치 확인 결과

- **live = 17.5 (2026-06-10) + 17.5b mid-patch**, 우리 데이터 = **17.4 partial**.
- 🎯 **calibration 정렬 핵심**: calibration 게임은 **17.1/17.3** (`game-20260423/424`=17.1, `game-20260519`=17.3). 즉 17.4 도 이미 게임보다 앞서 있어 **17.5b raw 갱신은 정렬을 오히려 악화** → raw 데이터 갱신 안 함이 정답. 패치 사실만 문서화.

## 변경 (문서만, src/raw-data 무변경)

- `docs/wiki/patches/patch-17-5.md` **신규** — 17.5 + 17.5b 전체 delta (champion 16+ / trait / item / augment), sim·데이터 미반영 상태 표, calibration 정렬 주의 박스
- `docs/wiki/index.md` — Patches 섹션에 patch-17-5 + **patch-17-4**(인덱스 누락이었음) 추가
- `docs/wiki/patches/patch-17-4.md` — patch-17-5 backlink
- `docs/meta/sim-accuracy-followups.md` — under-damage 현재 진척(game-424 -30.3→-10.2%, AS캡 지배 레버, perSecond 5종 완결) + 패치 컨텍스트

## 로컬 메모리 동기화 (이 PR 범위 밖, 이미 반영)

- `project_champion_ingest_status.md` — 33→48 + perSecond 완결 + 패치 컨텍스트
- `project_underdamage_calibration.md` — perSecond 5종 + 측정 챔프=조기사망 + 패치
- `MEMORY.md` 인덱스 — stale 라인(champion 24개, under-damage) 갱신

## 직접 충돌 챔프 (17.5 수치 변경, 데이터 미반영)

Bard(220/330→240/360) / Ezreal(160/240/365→170/255/380) / Rammus(Meeple DR 4→3, 마나 20/90→20/80) / Caitlyn / Teemo / Veigar / Akali / Mordekaiser / Vex 등 — 페이지는 17.4 데이터와 정합, live delta 는 patch-17-5 가 source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)