### PR TITLE
docs(wiki): 르블랑(LeBlanc) ingest (doc-only)

### DIFF
--- a/docs/wiki/champions/akali.md
+++ b/docs/wiki/champions/akali.md
@@ -9,7 +9,7 @@ traits:
   - 습격자
 role: Fighter   # raw "ADFighter" → mapGameRole() → sim Fighter (types/index.ts:46 includes('Fighter')). carry augment 없음 → role 변환 분기 없음
 raw_role: ADFighter
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage AD ★2~ 37/56/84→39/59/88 (★1=27 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage AD ★2~ 37/56/84→39/59/88 (★1=27 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: partial   # active line dash 단검 5개(hitCount 5 split, DamageAD scaleAD) + armorReduction debuff + N.O.V.A.(DRX) surge Precision(팀 spellCanCrit)/selector burn[12,18,24]/단검 burn ×1.10 + 습격자(MeleeTrait) 정합. P2 armorReduction sim 15 flat vs raw ArmorShred 1/ArmorShredCrit 2 불일치 (단위 미확인) / P2 secondaryDamage SecondaryDamageModifier 0.4 (2차 적중 40%) 미반영 (grep 0) / P2 DamageAP(scaleAP) 미사용 (auto-detect DamageAD 우선)
 last_verified: 2026-06-04
 sources:

--- a/docs/wiki/champions/bard.md
+++ b/docs/wiki/champions/bard.md
@@ -9,7 +9,7 @@ traits:
   - 전달자
 role: Caster   # raw "APCaster" → mapGameRole() → sim Caster (types/index.ts includes('Caster')). carry augment 없음
 raw_role: APCaster
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage 220/330→240/360 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage 220/330→240/360 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: partial   # ability 「미확인 친절 물체」 비행접시 4초 DOT — DamagePerSecond(초당값)×Duration(4) 을 dot.perSecond 로 모델(#241), aoe_circle radius 1 (SecondaryHexRange). ★ filler ★1=220/★2=330/★3=3000. 정령족(Astronaut)/전달자(ManaTrait) trait 정합. ⚠️ 미반영: SplitDamagePerSecond(주변 적은 DamagePerSecond 가 아닌 split 값이어야 하나 sim 은 aoe 전체에 DamagePerSecond 동일 적용 → 주변 과다) / TankDamageIncrease(탱커 상대 +30%) / AbductChance(납치 — economy, sim 무관) / 정령 추가효과(전투시작 정령족 아군 추가 meep) / cast 빈도·DOT 4초 vs 짧은 전투(duration-bound, 잔여 -84%)
 last_verified: 2026-06-15
 sources:

--- a/docs/wiki/champions/belveth.md
+++ b/docs/wiki/champions/belveth.md
@@ -10,7 +10,7 @@ traits:
   - 습격자
 role: Fighter   # raw "ADFighter" → mapGameRole() → sim Fighter (types/index.ts). carry augment 없음
 raw_role: ADFighter
-current_patch_status: active (⚠️ 17.3 데이터 기준 — raw 17.4 partial dataset 이 Bel'Veth 미갱신. 17.4 pending: ADDamage 18/27/41/69→20/30/45/77 (17.3 너프 revert, [[patch-17-4]]) / 17.5 pending: ADDamage 20/30/45→22/33/50 (buff, [[patch-17-5]]). 모두 데이터/sim 미반영)
+current_patch_status: "active (⚠️ 17.3 데이터 기준 — raw 17.4 partial dataset 이 Bel'Veth 미갱신. 17.4 pending: ADDamage 18/27/41/69→20/30/45/77 (17.3 너프 revert, [[patch-17-4]]) / 17.5 pending: ADDamage 20/30/45→22/33/50 (buff, [[patch-17-5]]). 모두 데이터/sim 미반영)"
 last_verified: 2026-06-16
 sim_active: partial   # ability 「파도 가르기」 SlashDuration(2초) 동안 TotalNumSlashes(scaleAS)회 베기, 각 TotalDamage(=ADDamage scaleAD + APDamage scaleAP) 물리. sim single + hitCount 12(BaseNumSlashes, 곱연산 :6753). auto-detect 주 damageVar 'ADDamage' filler(v0>v1) → ★1=18/★2=27/★3=41. 태고족(Primordian :2275)/도전자(ASTrait :592)/습격자(MeleeTrait :610) trait 반영. ⚠️ slash 수 AS 스케일(TotalNumSlashes scaleAS) 미반영 — sim hitCount 12 고정(도전자 ASTrait+아이템 로 고AS 시 under, 습격자는 AS 부여 아님). APDamage 부차 scaleAP 미반영(auto-detect ADDamage 우선). calibration: game-423/424 부재(미측정)
 sources:

--- a/docs/wiki/champions/caitlyn.md
+++ b/docs/wiki/champions/caitlyn.md
@@ -9,7 +9,7 @@ traits:
   - 운명술사
 role: Specialist   # raw "ADSpecialist" → mapGameRole() → sim Specialist (types/index.ts includes('Specialist')). carry augment 없음. mana 0/0 → active cast 없음 (passive only)
 raw_role: ADSpecialist
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Headshot AD ★2~ 170/255/510/875→190/285/540/925 (★1=145 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Headshot AD ★2~ 170/255/510/875→190/285/540/925 (★1=145 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: partial   # passive 평타 헤드샷(ProcChance 15% + Damage ★1=145/170/255) + N.O.V.A.(DRX) surge AS 20%/selector mark +10% incoming/selector 헤드샷[76,114,222] + 운명술사(Fateweaver) Precision+crit stat 정합. P2 평타 헤드샷 Damage flat (desc scaleAD+scaleAP, BonusDamage(scaleAP) 미사용) / P2 운명술사 Lucky(행운, 확률 두 번 굴림) 미구현 (:1775 후속 PR — Caitlyn ProcChance 단일 roll) / info selector 헤드샷 [76,114,222] 하드코딩 (=(Damage+BonusDamage)[★+1]×0.4, scaleAD/AP 없는 flat) / info 운명술사 Precision(spellCanCrit) Caitlyn ability 없어(mana 0) 실효 제한
 last_verified: 2026-06-05
 sources:

--- a/docs/wiki/champions/ezreal.md
+++ b/docs/wiki/champions/ezreal.md
@@ -9,7 +9,7 @@ traits:
   - 저격수
 role: Caster   # raw "ADCaster" → mapGameRole() → sim Caster (types/index.ts includes('Caster')). carry augment 없음
 raw_role: ADCaster
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Ability AD 160/240/365/620→170/255/380/650 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Ability AD 160/240/365/620→170/255/380/650 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: partial   # ability 「시간의 일격」 단일 파동 TotalDamage(scaleAD scaleAP) 물리. sim single, auto-detect damageVar 'ADDamage'(scaleAD, bonusAD #238). ADDamage filler ★1=160/★2=240/★3=365. 시간 균열자(Timebreaker)/저격수(Sniper RangedTrait) trait 정합. 드론 ✅ 반영 (permanentStacks ezreal_drones → cast 시 DroneDamage, combatLoop :7423-7434 main / :7755-7766 OOR — 단 전투 중 실시간 takedown 누적은 미추적, UI 사전설정 스택 의존). ⚠️ 미반영: APDamage(auto-detect 가 ADDamage 우선 pick) / 전투 중 실시간 takedown 누적 / TakedownsToForm3(60) 변신. calibration -25%(moderate)
 last_verified: 2026-06-16
 sources:

--- a/docs/wiki/champions/fizz.md
+++ b/docs/wiki/champions/fizz.md
@@ -9,7 +9,7 @@ traits:
   - 불한당
 role: Assassin   # raw "APReaper" → mapGameRole() → sim Assassin (types/index.ts includes('Reaper')). carry augment 없음
 raw_role: APReaper
-current_patch_status: active (17.4 변경 없음 — 17.5 patch pending: DashDamage ★2~ 120/180/290→140/210/310 (★1=80 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 변경 없음 — 17.5 patch pending: DashDamage ★2~ 120/180/290→140/210/310 (★1=80 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 last_verified: 2026-06-16
 sim_active: partial   # ability 「정령 미끼」 관통 돌진 DashDamage(scaleAP) 마법 + 3회 사용마다 MegaMeep(ChompDamage=BiteDamageAP + 공중부양 stun 1.25 + 인접 SecondaryDamage 50%). sim line + dash to_target + secondaryDamageVar 'BiteDamageAP'. auto-detect 주 damageVar = DashDamage(fuzzy, no-filler) → ★1=80/★2=120/★3=180. 정령족(Astronaut)/불한당(AssassinTrait AD/AP) trait. ⚠️ **over-model**: secondaryDamageVar BiteDamageAP 가 3회째 MegaMeep nuke 를 매 캐스트·전 라인타겟에 적용(3-cast cadence 없음, line over-application). ⚠️ 미반영: MegaMeep stun(MegaMeepStunDuration 1.25) / 정령족 추가(MeepsPerAstro/BiteDamageMeep, desc computed MeepBonusDamage) / 인접 SecondaryDamage 별도 / 불한당 stealth(HealthThreshold/Duration). calibration: game-423/424 부재(미측정)
 sources:

--- a/docs/wiki/champions/gwen.md
+++ b/docs/wiki/champions/gwen.md
@@ -9,7 +9,7 @@ traits:
   - 불한당
 role: Assassin   # raw "APReaper" → mapGameRole() → sim Assassin (types/index.ts includes('Reaper')). carry augment 없음
 raw_role: APReaper
-current_patch_status: active (⚠️ 17.3 데이터 기준 — raw 17.4 partial dataset(Zed/Shen/Jax 만 갱신)이 Gwen 미갱신. 17.4 pending: armor 45→50, Damage ★3/★4 380/650→410/700 ([[patch-17-4]]:84) / 17.5 pending: AreaDamage ★3 190→215, AS 0.85→0.8 ([[patch-17-5]]). 모두 데이터/sim 미반영)
+current_patch_status: "active (⚠️ 17.3 데이터 기준 — raw 17.4 partial dataset(Zed/Shen/Jax 만 갱신)이 Gwen 미갱신. 17.4 pending: armor 45→50, Damage ★3/★4 380/650→410/700 ([[patch-17-4]]:84) / 17.5 pending: AreaDamage ★3 190→215, AS 0.85→0.8 ([[patch-17-5]]). 모두 데이터/sim 미반영)"
 last_verified: 2026-06-16
 sim_active: partial   # ability 「춤추고 토막내기」 체력 최저 적에 돌진 → 대상 Damage(scaleAP) + 원뿔 AreaDamage(scaleAP) 마법. sim cone r2 + dash to_lowest_hp + secondaryDamageVar 'AreaDamage'. auto-detect 주 damageVar 'Damage' filler(v0>v1) → ★1=145/★2=220/★3=380. AreaDamage filler → ★1=75/★2=110/★3=190. 우주 그루브(SpaceGroove applySpaceGrooveBuffs:1826)/불한당(AssassinTrait AD/AP :579) trait 반영. role Assassin(APReaper). ⚠️ raw 17.3(17.4 partial dataset 미갱신 — armor/Damage 17.4 변경 미반영). 불한당 stealth(HealthThreshold/Duration) 미반영(AD/AP 만). ⚠️ 미반영: 처치 시 recast(ResetDamage 65%, onKillRecast config 없음) / Groove 상태(GrooveThreshold 0.4 자가 트리거) / passive 평타 마법 전환(평타는 sim 물리 유지). ⚠️ cone+secondaryDamageVar over-application(주 대상 포함 전 cone 타겟이 Damage+AreaDamage, combatLoop:6895-6898 공통). calibration: game-423/424 부재(미측정)
 sources:

--- a/docs/wiki/champions/kindred.md
+++ b/docs/wiki/champions/kindred.md
@@ -9,7 +9,7 @@ traits:
   - 도전자
 role: Marksman   # raw "ADCarry" → mapGameRole() → sim Marksman (types/index.ts:43 includes('Carry')). carry augment 없음 → role 변환 분기 없음
 raw_role: ADCarry
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Base AD 55→58 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Base AD 55→58 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: partial   # active multi 화살(ADDamage scaleAD ★1=115/175/900) + 3표식 passive(SpellDamage) + N.O.V.A.(DRX) surge/Tank shield 800/selector +10% damageAmp/4.5초 주기 mark + 도전자(ASTrait) AS+Burst 정합 (AS off-by-one 은 PR #186 수정 완료 — scaling.json leading-0 제거). P2 passive 표식 평타만(desc "기본공격+스킬" 중 스킬 표식 미반영) / P2 passive mark 피해 SpellDamage flat (desc TotalDamage scaleAD+scaleAP — ad/ap scaling 미적용) / P2 active HexDistance(1) 도약 미구현 (기본 공격 AI 이동 위임) / info raw NovaDamageAmp 0.05·NovaRepeatTimer 5 미사용 (sim 17.4 하드코딩 0.10·4.5초, PR #166) / info NumTargets ★4=5 미반영 (★1-3=3, 4코 ★3까지)
 last_verified: 2026-06-04
 sources:

--- a/docs/wiki/champions/leblanc.md
+++ b/docs/wiki/champions/leblanc.md
@@ -9,7 +9,7 @@ traits:
   - 길잡이
 role: Marksman   # raw "APCarry" → mapGameRole() → sim Marksman (types/index.ts includes('Carry')). carry augment 없음
 raw_role: APCarry
-current_patch_status: active (17.4 변경 없음 — 17.5 patch pending: Sigil/Bolt Damage 80/120→85/130 (buff, BoltDamage ★1/★2 추정 — 패치노트 'Sigil' 표기). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 변경 없음 — 17.5 patch pending: Sigil/Bolt Damage 80/120→85/130 (buff, BoltDamage ★1/★2 추정 — 패치노트 'Sigil' 표기). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 last_verified: 2026-06-16
 sim_active: partial   # ability 「현실 분열」 passive 평타 → BasicAttackDamage(scaleAP) 마법 + 사용 시 분신 NumClones(5) 소환해 NumAttacks(5)회 CloneDamageMultiplier% 공격 + 마지막 투사체 BoltDamage(scaleAP) 마법. sim multi maxTargets:3 + damageVar 'BoltDamage' + hitCount 5 → BoltDamage × 5 (3타겟 분배). filler → BoltDamage ★1=80/★2=120/★3=750. 중재자(ADMIN=Arbiter law 시스템 :112)/길잡이(SummonTrait 소환물 materialize) trait. ⚠️ 미반영: passive 평타 마법(BasicAttackDamage — AD=0 라 sim 평타 ~0) / 분신 NumClones×NumAttacks×CloneDamageMultiplier 공격 / 길잡이 tier 버프. calibration: game-423/424 부재(미측정)
 sources:

--- a/docs/wiki/champions/leblanc.md
+++ b/docs/wiki/champions/leblanc.md
@@ -1,0 +1,99 @@
+---
+id: leblanc
+type: champion
+display_name_kr: 르블랑
+api_name: TFT17_Leblanc
+cost: 4
+traits:
+  - 중재자
+  - 길잡이
+role: Marksman   # raw "APCarry" → mapGameRole() → sim Marksman (types/index.ts includes('Carry')). carry augment 없음
+raw_role: APCarry
+current_patch_status: active (17.4 변경 없음 — 17.5 patch pending: Sigil/Bolt Damage 80/120→85/130 (buff, BoltDamage ★1/★2 추정 — 패치노트 'Sigil' 표기). 데이터/sim 미반영, [[patch-17-5]] 참조)
+last_verified: 2026-06-16
+sim_active: partial   # ability 「현실 분열」 passive 평타 → BasicAttackDamage(scaleAP) 마법 + 사용 시 분신 NumClones(5) 소환해 NumAttacks(5)회 CloneDamageMultiplier% 공격 + 마지막 투사체 BoltDamage(scaleAP) 마법. sim multi maxTargets:3 + damageVar 'BoltDamage' + hitCount 5 → BoltDamage × 5 (3타겟 분배). filler → BoltDamage ★1=80/★2=120/★3=750. 중재자(ADMIN=Arbiter law 시스템 :112)/길잡이(SummonTrait 소환물 materialize) trait. ⚠️ 미반영: passive 평타 마법(BasicAttackDamage — AD=0 라 sim 평타 ~0) / 분신 NumClones×NumAttacks×CloneDamageMultiplier 공격 / 길잡이 tier 버프. calibration: game-423/424 부재(미측정)
+sources:
+  - "public/data/tft_set17_champions.json (TFT17_Leblanc entry — cost 4, role APCarry, traits [중재자/길잡이], hp 850, armor/MR 30/30, AD 0, AS 0.8, range 4, mana 0/40, ability '현실 분열' variables BasicAttackDamage/CloneDamageMultiplier/BoltDamage/NumClones/NumAttacks)"
+  - "public/data/tft_set17_traits.json (TFT17_ADMIN = 중재자 bp 2/3 / TFT17_SummonTrait = 길잡이 bp 3/5/7)"
+  - "src/lib/simulator/systems/ability.ts:266 (TFT17_Leblanc: { pattern: 'multi', maxTargets: 3, damageVar: 'BoltDamage', hitCount: 5 })"
+  - "src/lib/simulator/engine/combatLoop.ts:112-114 ArbiterLaw(중재자=TFT17_ADMIN) playerArbiterLaw / 길잡이=TFT17_SummonTrait 소환물 src/hooks/useTeamManagement.ts:152-180(syncVoyagerSummonInTeam)"
+related:
+  - "[[patch-17-5]]"
+  - "[[role-passive]]"
+  - "[[ability-targeting]]"
+  - "[[lissandra]]"
+---
+
+# 르블랑 (LeBlanc)
+
+## 요약
+
+4코스트 **중재자 (`TFT17_ADMIN`)** + **길잡이 (`TFT17_SummonTrait`)** trait. raw role `APCarry`. carry augment 없음.
+
+- **role**: `mapGameRole('APCarry')` → sim **Marksman** ([[role-passive]] — 공격당 10 / 초당 0 / 피격 ❌). AP 캐리지만 role 은 Marksman 으로 매핑. hp 850, range 4, mana 0/40, **AD 0**(평타가 마법 피해로 대체되는 passive).
+- **ability "현실 분열"**: 기본 지속 — 평타 시 `BasicAttackDamage`(scaleAP) 마법으로 대체. 사용 시 분신 `NumClones`(5)명 소환 → 함께 `NumAttacks`(5)회 `CloneDamageMultiplier`% 공격, 마지막 공격에 투사체 `BoltDamage`(scaleAP) 마법.
+
+> 🎯 **LeBlanc 는 분신 소환 AP 캐리** — passive 평타 마법 + 분신 다중 공격 + 투사체 BoltDamage. ⚠️ sim 은 **BoltDamage × 5(multi 3타겟)만** 모델 — passive 평타(AD=0 라 sim ~0)·분신 공격은 미반영.
+
+> ⚠️ **set17 entity confirm**: `TFT17_Leblanc` apiName 으로 소속 확인 (cost 4, traits 중재자/길잡이, role APCarry). 한글명 list 만으로 후보 선정 금지.
+
+## 메커니즘
+
+### Stats (raw, 17.4 LIVE — 17.4 변경 없음)
+
+| Stat | 값 |
+|------|---|
+| hp | 850 |
+| armor / magicResist | 30 / 30 |
+| damage | **0** (평타 → BasicAttackDamage 마법 대체) |
+| attackSpeed | 0.8 |
+| range | 4 |
+| critChance / critMultiplier | 0.25 / 1.4 |
+| initialMana / mana | 0 / 40 |
+
+> ⚠️ **17.5 patch pending** (데이터 미반영, [[patch-17-5]]): Sigil/Bolt Damage `80/120 → 85/130` (buff). ⚠️ 패치노트 'Sigil Damage' 표기 — 수치상 `BoltDamage` ★1/★2(80/120) 로 추정 (raw var 'Sigil' 부재, 룰 #20 raw diff 미확정).
+
+### Role — Marksman
+
+| 형태 | role | weight | 공격당 마나 | 초당 마나 | 피격 시 마나 | 근거 |
+|------|------|--------|-----------|---------|------------|------|
+| base (증강 없음) | **Marksman** | 1 | 10 | 0 | ❌ | `mapGameRole('APCarry')` includes 'Carry' → Marksman ([[role-passive]]) |
+
+### Active — 현실 분열 (분신 + 투사체)
+
+| 변수 | raw value | sim 적용 |
+|------|-----------|---------|
+| BoltDamage | [0, 80, 120, 750, 540, ...] | ✅ `damageVar 'BoltDamage'` filler(v0=0) → ★1=80/★2=120/★3=750 (scaleAP). `hitCount: 5` 곱연산 |
+| NumClones | [5, ...] | (sim hitCount 5 ≈ 분신 5 투사체 근사) |
+| BasicAttackDamage | [0, 62, 93, 250, 450, ...] | ⚠️ **미반영** — passive 평타 마법 대체. LeBlanc AD=0 라 sim 평타 ~0 (filler → ★1=62/★2=93/★3=250) |
+| CloneDamageMultiplier | [0, 0.25, 0.25, 1.5, 1, ...] | ⚠️ **미반영** — 분신 공격 배율 |
+| NumAttacks | [5, ...] | ⚠️ **미반영** — 분신 공격 횟수 |
+
+- sim: `pattern: 'multi', maxTargets: 3, damageVar: 'BoltDamage', hitCount: 5`. 3타겟 분배 `BoltDamage × 5`.
+- ⚠️ **passive 평타 미반영**: LeBlanc AD=0 + 평타→`BasicAttackDamage`(scaleAP) 마법 대체가 sim 미구현 → 평타 데미지 ~0 (AP 캐리 주 지속딜 누락 가능).
+- ⚠️ **분신 공격 미반영**: 분신 5명 × `NumAttacks`(5) × `CloneDamageMultiplier`% 공격 미모델 (BoltDamage 투사체만).
+
+### Trait — 중재자 (ADMIN/Arbiter) / 길잡이 (SummonTrait)
+
+- **중재자** (`TFT17_ADMIN`, bp 2/3): Arbiter 법률 시스템(`ArbiterLaw`, `playerArbiterLaw`/`enemyArbiterLaw` `:112-114`)로 반영. `applyArbiterEffect`(`:4448`)가 effectId `mana`/`ap`/`armor_mr`/`attack_speed`/`permanent_hp`/`shield` 6종 분기 처리, `unitHasTrait(u, '중재자')`(`:5291`)로 식별.
+- **길잡이** (`TFT17_SummonTrait`, bp 3/5/7): 소환물(`TFT17_Summon`)은 `useTeamManagement.syncVoyagerSummonInTeam`(`src/hooks/useTeamManagement.ts:152-180`)로 전투 전 count별 star materialize되어 전투 참여. ⚠️ 길잡이 tier별 전투 버프는 sim trait helper 없음(미반영) ([[lissandra]] 동일).
+
+## sim 통합 상태 — `partial`
+
+✅ **활성**:
+- stats 17.4 정합 (hp 850, armor/MR 30, AD 0, AS 0.8, range 4, mana 0/40)
+- role Marksman (`mapGameRole('APCarry')`)
+- Active `BoltDamage × 5`(multi 3타겟 분배)
+- 중재자(Arbiter law) trait / 길잡이 소환물 materialize
+
+⚠️ **미반영 / mis-model** (Lint 후보):
+- **P2**: passive 평타 마법(`BasicAttackDamage` scaleAP) 미반영 — LeBlanc AD=0 라 sim 평타 ~0 (AP 캐리 주 지속딜 누락)
+- **P2**: 분신 공격(NumClones 5 × NumAttacks 5 × CloneDamageMultiplier) 미반영 — BoltDamage 투사체만
+- **P2**: 길잡이 tier별 전투 버프 미반영 (소환물 materialize 는 됨, [[lissandra]] 동일)
+- calibration: game-423/424 **부재(미측정)**. 17.5 BoltDamage buff(추정) 데이터 미반영([[patch-17-5]]).
+
+## 관련 문서
+
+- [[role-passive]] — Marksman role 마나/타게팅
+- [[lissandra]] — 동류 길잡이 (소환물 materialize 공통)
+- [[ability-targeting]] — multi 타게팅

--- a/docs/wiki/champions/mordekaiser.md
+++ b/docs/wiki/champions/mordekaiser.md
@@ -10,7 +10,7 @@ traits:
   - 선봉대
 role: Tank   # raw "APTank" → mapGameRole() → sim Tank. ⚠️ MordekaiserCarry augment 활성 시 Fighter 로 변환 (applyHeroCarryTransforms) — base 의 helper 메커니즘은 carry 활성 여부와 무관 동작 (mordekaiserCarryShield 만 InitialShield override)
 raw_role: APTank
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Initial Shield 300/375/500→350/425/550 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Initial Shield 300/375/500→350/425/550 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: active   # base raw 메커니즘 거의 완성 (helper 2개 + 별도 shield pool + healRefund + main/OOR cast parity)
 last_verified: 2026-05-26
 sources:

--- a/docs/wiki/champions/nasus.md
+++ b/docs/wiki/champions/nasus.md
@@ -9,7 +9,7 @@ traits:
   - 선봉대
 role: Tank   # raw "APTank" → mapGameRole() → sim Tank. ⚠️ NasusCarry augment 활성 시 Fighter 로 변환 (applyHeroCarryTransforms)
 raw_role: APTank
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Flat Health gained 250/350/550/750→300/400/600/800 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Flat Health gained 250/350/550/750→300/400/600/800 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: partial
 last_verified: 2026-05-21
 sources:

--- a/docs/wiki/champions/rammus.md
+++ b/docs/wiki/champions/rammus.md
@@ -9,7 +9,7 @@ traits:
   - 요새
 role: Tank   # raw "APTank" → mapGameRole() → sim Tank (types/index.ts includes('Tank')). carry augment 없음
 raw_role: APTank
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Meeple bonus DR per Meep 4→3 (nerf) / Mana 20/90→20/80 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Meeple bonus DR per Meep 4→3 (nerf) / Mana 20/90→20/80 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: partial   # 액티브 「중력 회전」: 보호막(ShieldAP) + 일직선 3칸 마법(DamageAP scaleAP + DamageArmor scaleArmor). scaleArmor 성분은 casterArmorScaleVar 로 main+OOR cast path 에서 caster armor 비례 가산(ability.ts:238 / combatLoop.ts:6589,7466). selfBuff durability 0.3 근사. 정령 패시브(정령족 active 게이트): 20회 피격 후 반경 2칸 magic AoE = PassivePercentArmor★ × armor (applyAstronautEffects precompute :2068 + defender 평타훅 :6436). 정령족 BonusHealth/Meeps applyAstronautEffects 적용 / 요새(ResistTank) teamwide armor/MR 정합. ⚠️ 미구현: 패시브 FlatDR(받는 공격 피해 감소, FlatDRPerMeep) / 패시브 AoE 는 sim 전투 단축(6~12s)으로 20회 threshold 실전만큼 미충족 → calibration 잔여 -74~98% (systemic duration, AS캡 #236 후에도)
 last_verified: 2026-06-15
 sources:

--- a/docs/wiki/champions/samira.md
+++ b/docs/wiki/champions/samira.md
@@ -9,7 +9,7 @@ traits:
   - 저격수
 role: Caster   # raw "ADCaster" → mapGameRole() → sim Caster (types/index.ts includes('Caster')). carry augment 없음
 raw_role: ADCaster
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: (17.5b) Mana 0/60→0/65 + Ability CC 1.25s→1s (nerf). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: (17.5b) Mana 0/60→0/65 + Ability CC 1.25s→1s (nerf). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: partial   # active 단일 탄환(Damage scaleAD physical) + stun(공중 띄움) + 우주그루브(SpaceGroove)/저격수(Sniper) trait 정합. P1: passive(onEnemyAirborne 시 PassiveDamage scaleAD scaleAP physical + GrooveDuration TheGroove) 미반영 — onEnemyAirborne 트리거 핸들러 부재(grep 0, onAttack/onKill 만 존재) / P2: active stun 1.0 vs raw StunDuration 1.25 (sim 0.25s 적음) / P2: TheGroove 상태(passive 발동 시 3초) 미반영 (passive 자체 미모델) / P2: passive PassiveAP(scaleAP) — passive 미모델로 무의미
 last_verified: 2026-06-12
 sources:

--- a/docs/wiki/champions/teemo.md
+++ b/docs/wiki/champions/teemo.md
@@ -9,7 +9,7 @@ traits:
   - 길잡이
 role: Marksman   # raw "APCarry" → mapGameRole() → sim Marksman (types/index.ts:43 includes('Carry')). carry augment 없음
 raw_role: APCarry
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage(MagicDamage) ★2~ 65/95/170/300→70/105/190/325 (★1=60 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage(MagicDamage) ★2~ 65/95/170/300→70/105/190/325 (★1=60 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: partial   # onAttack passive 추가 마법(hitDamage scaleAP, ★1=30 filler) ✅ + active selfBuff AS + 우주그루브(SpaceGroove) 정합. P1: 독 DOT(MagicDamage/poisonDamage, PoisonDuration 6초) 미반영 — onAttack extraDamage 핸들러는 단일 hit 만 (Teemo 핵심 지속 피해 누락) / P1: active selfBuff attackSpeed 0.5 vs raw AttackSpeed 1.5 (3배 과소, ability.ts:195 하드코딩) / P2: active "ActiveAttacks 3회 평타 동안" vs sim duration 3 (selfBuff.duration read 0 → 영구) 메커니즘 불일치 / P2: SpaceGroove TheGroove(적 GrooveStacks 5 중첩 시) 미반영 grep 0 / P2: 길잡이(SummonTrait) tier buff 미반영 (소환체 유닛 생성은 builder layer useTeamManagement.ts 존재, combat sim applySummonTrait 부재 — codex P2 PR #222)
 last_verified: 2026-06-12
 sources:

--- a/docs/wiki/champions/veigar.md
+++ b/docs/wiki/champions/veigar.md
@@ -9,7 +9,7 @@ traits:
   - 복제자
 role: Caster   # raw "APCaster" → mapGameRole() → sim Caster (types/index.ts includes('Caster')). carry augment 없음
 raw_role: APCaster
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage(Damage) ★2~ 310/465/700/1190→330/495/750/1200 (★1=250 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage(Damage) ★2~ 310/465/700/1190→330/495/750/1200 (★1=250 불변, buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 last_verified: 2026-06-16
 sim_active: partial   # ability 「정령유성우」 대상 Damage(scaleAP) 마법 + 정령족 추가효과 미니유성 MiniMeepsPerAstro(2)개 각 MiniDamage(scaleAP). sim aoe_circle r1 + secondaryDamageVar 'MiniDamage'(주변 타겟당 1회 full). auto-detect 주 damageVar 'Damage' no-filler → ★1=250/★2=310/★3=465. MiniDamage filler(v0>v1) → ★1=31/★2=47/★3=70. 정령족(Astronaut)/복제자(APTrait) trait 정합. ⚠️ 미니유성 mis-model 3중: (a) MiniMeepsPerAstro(×2) 미반영(under) + (b) 정령족 active 게이팅 없이 무조건 적용(over) + (c) secondaryDamageVar 가 aoe_circle 전 타겟(주 대상 포함)에 MiniDamage 가산(over, combatLoop:6895-6898 공통 구조) → 부분 상쇄. calibration: game-424 -64% — per-cast 정상(★2 255/cast)이나 cost1 squishy 2캐스트 후 사망(조기사망 duration-bound, 모델링 아님)
 sources:

--- a/docs/wiki/champions/vex.md
+++ b/docs/wiki/champions/vex.md
@@ -8,7 +8,7 @@ traits:
   - 파멸자
 role: Marksman   # raw "APCarry" → mapGameRole() → sim Marksman (types/index.ts:43 includes('Carry')). ⚠️ 실제 AP 메이지지만 mapGameRole string-match 가 Carry → Marksman 으로 분류 (Caster 아님). carry augment 없음 → role 변환 분기 없음
 raw_role: APCarry
-current_patch_status: active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage AP 130/195→140/210 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)
+current_patch_status: "active (17.4 데이터 기준 — 17.5/17.5b patch pending: Spell Damage AP 130/195→140/210 (buff). 데이터/sim 미반영, [[patch-17-5]] 참조)"
 sim_active: partial   # passive 그림자(ShadowHandDamage scaleAP + spread + amp + lethal) / active 강화타격(ShadowHandMagicDamage scaleAP hitCount 3 split, spell crit 가능) / 파멸자(VexUniqueTrait ADAP 12% 강탈 양팀 snapshot) 핵심 정합. P2 passive NumStrikesForPassive=5 그림자 재타격 미반영 (grep 0 read) / P2 파멸자 표식 트리거 단순화 (combat-start 즉시 일괄 강탈, "적 첫 피해 시" 표식 소모 생략) / P2 active "강화 타격 3회" desc vs sim aoe_circle split (총피해 base×3 / aliveTargets 분배) + NumActiveStrikes raw var 직접 read 아님 (hardcoded 3) / P2 passive "주변 적" spread = 최근접 1명 보수 해석 (raw 반경 변수 없음) / P2 passive 그림자 spell crit 미지원 (평타 hook crit 분기 부재, active cast :6581 만 crit, codex PR #183)
 last_verified: 2026-06-02
 sources:

--- a/docs/wiki/lint-rules.md
+++ b/docs/wiki/lint-rules.md
@@ -200,6 +200,7 @@ read 위치 없으면 → 본문에 "🔍 sim 효과 검증 필요" 표기 또�
 | **신규 carry augment 도입 시 관련 mechanic page (spell-crit / mana / cast path / role-passive) 의 cast roll / trigger / 호출처 리스트 stale 검증 + last_verified 갱신** (룰 #14, PR #155 도입) | 신규 carry / cast path 변경 시 | Jax carry hero augment (PR #135/#147) 가 5번째/6번째 spellCanCrit cast roll 추가 → spell-crit.md last_verified 갱신 누락 (#154 P1-1) |
 | **본문에 P0 lint case (sim 미반영) 등록 시 frontmatter `sim_active: active` 유지 → page-internal contradiction P1 raise + `partial` 강등 권장** (룰 #15, PR #155 도입, 룰 #8 의 carry-augment / champion 일반화) | P0 lint case 등록 시 | leona-carry frontmatter active ↔ 본문 Lint #10/#11 등록 모순 (#154 codex P2) |
 | **sim fix guidance 작성 시 적용 분기 명시 필수** (룰 #17, PR #160 도입, 룰 #11/#12 보강) | Lint 후보 fix 항목 작성 시 | Blitzcrank B1 "UppercutDamage `secondaryDamageVar` 추가" guidance 잘못 — per-target loop 적용 (PR #158 Codex P2 catch). fix guidance 는 적용 분기 (primary single / per-target / cast-time 1회 helper / combat-start helper) 명시 필수 |
+| **frontmatter scalar 값에 `: `(콜론+공백) 포함 시 quote 필수 — YAML 유효성** (룰 #21, PR #262 도입, codex P2 학습) | frontmatter 필드 값(특히 `current_patch_status`/`sim_active` 가 아닌 quote 안 쓰는 필드)에 콜론 포함 시 | `current_patch_status: active (... patch pending: armor 45→50 ...)` 처럼 unquoted 값에 `pending: ` 콜론이 있으면 YAML 파서가 `mapping values are not allowed in this context` 로 거부 → 16개 champion 페이지 무효 (PR #262 codex P2). 값을 `"..."` 로 quote. 검출: frontmatter 각 라인 `key: value` 의 value 가 unquoted 인데 `: ` 포함하면 P1 (lint/indexing tooling 파싱 실패) |
 
 ## Page-internal Cross-check (PR #152 retro pilot 도입)
 


### PR DESCRIPTION
## 요약

champion ingest **54/65** — 르블랑(LeBlanc). 4코 중재자/길잡이 APCarry→Marksman.

「현실 분열」 passive 평타 마법(`BasicAttackDamage`, AD=0) + 분신 5명 + 투사체 `BoltDamage`. sim multi maxTargets:3 + BoltDamage + hitCount 5.

## doc-only (sim 무변경)

- ⚠️ 미반영(P2): passive 평타 마법(LeBlanc AD=0 라 sim 평타 ~0 — AP carry 주 지속딜 누락) / 분신 공격(NumClones 5 × NumAttacks 5 × CloneDamageMultiplier) / 길잡이 tier 버프(소환물 materialize 는 됨, [[lissandra]] 동일)
- 중재자(ADMIN=Arbiter law `applyArbiterEffect:4448`, 6종 effectId)/길잡이(소환물 materialize) trait 반영
- 17.4 미변경, 17.5 Sigil/Bolt Damage 80/120→85/130(BoltDamage ★1/★2 추정, raw diff 미확정) pending
- 미측정

## 검증

- wiki-ingest-verifier: **P0 0 / P1 0 / P2 1** → 중재자 effectId 구체화 반영. 미반영 sim/+hooks/ 전수 grep, trait 전수 grep(중재자 Arbiter law 반영 / 길잡이 소환물 materialize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)