### PR TITLE
feat(deploy): Docker + GitHub Actions 배포 1단계 (ghcr)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# deps & build artifacts
+node_modules
+.next
+*.tsbuildinfo
+
+# vcs & ci
+.git
+.github
+.githooks
+
+# env / secrets
+.env
+.env.*
+!.env.example
+
+# docs & data & tests (런타임 불필요)
+docs
+tests
+raw-data
+actual-data
+scripts
+
+# tooling caches
+.bkit
+.claude
+.superpowers
+.understand-anything
+.playwright-mcp
+
+# os
+.DS_Store

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/keyy1315/tft_sim
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm test
+
+  build-push:
+    needs: quality
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          build-args: |
+            NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH deploy to Lightsail
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LIGHTSAIL_HOST }}
+          username: ${{ secrets.LIGHTSAIL_USER }}
+          key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
+          script: |
+            cd ~/app
+            echo "${{ secrets.GHCR_PULL_TOKEN }}" | docker login ghcr.io -u keyy1315 --password-stdin
+            docker compose pull
+            docker compose up -d
+            docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ next-env.d.ts
 !/docs/meta/
 !/docs/superpowers/
 !/docs/wiki/
+!/docs/deploy/
 /scripts/*.playwright-mcp/
 raw-data/
 scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+
+# ---- deps: 의존성 설치 (lockfile 기반) ----
+FROM node:24-alpine AS deps
+RUN corepack enable
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# ---- build: NEXT_PUBLIC ARG 주입 후 빌드 ----
+FROM node:24-alpine AS build
+RUN corepack enable
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
+ENV NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN pnpm build
+
+# ---- runner: standalone 산출물만 복사한 경량 실행 이미지 ----
+FROM node:24-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup -g 1001 -S nodejs && adduser -S nextjs -u 1001
+
+COPY --from=build /app/public ./public
+COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -166,6 +166,24 @@ src/
 - **React Compiler 준수** — `useEffect` 내 `setState` 금지, 의존성 배열 누락 금지. `eslint-disable` 로 우회하지 않고 코드 수정으로 해결.
 - **좌표계 규약** — `useTeamManagement.playerTeam` 은 row 0-3, `combatLoop` 입력은 row 4-7 (전투 시 `toEightRowCoords(+4)` 매핑). 경계 레이어에서만 변환.
 
+## 배포 (Docker + GitHub Actions)
+
+`main` 푸시 시 GitHub Actions가 `lint·typecheck·test` → 이미지 빌드(ghcr) →
+Lightsail SSH 배포를 자동 수행한다.
+
+- 설계: `docs/superpowers/specs/2026-06-17-docker-github-actions-deploy-design.md`
+- 셋업/Secrets: `docs/deploy/lightsail-setup.md`
+
+로컬 컨테이너 실행:
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_SUPABASE_URL="..." \
+  --build-arg NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY="..." \
+  -t tft_sim:local .
+docker run --rm -p 3000:3000 -e RIOT_API_KEY="..." tft_sim:local
+```
+
 ## 라이선스
 
 이 프로젝트는 [Riot Games](https://www.riotgames.com/)의 공식 프로젝트가 아닙니다.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  app:
+    image: ghcr.io/keyy1315/tft_sim:latest
+    container_name: tft_sim
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - RIOT_API_KEY=${RIOT_API_KEY}
+    restart: unless-stopped

--- a/docs/deploy/lightsail-setup.md
+++ b/docs/deploy/lightsail-setup.md
@@ -1,0 +1,76 @@
+# Lightsail 배포 셋업 (1단계: ghcr)
+
+자동 배포 파이프라인이 동작하려면 **GitHub Secrets 등록**과 **서버 1회 셋업**이 필요하다.
+
+## 1. GitHub Secrets (레포 Settings → Secrets and variables → Actions)
+
+| Secret | 값 | 용도 |
+|--------|----|----|
+| `NEXT_PUBLIC_SUPABASE_URL` | 로컬 `.env`와 동일 | 빌드 ARG |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | 로컬 `.env`와 동일 | 빌드 ARG |
+| `LIGHTSAIL_HOST` | Lightsail 고정 IP | SSH 대상 |
+| `LIGHTSAIL_USER` | `ubuntu` (Ubuntu 이미지) | SSH 계정 |
+| `LIGHTSAIL_SSH_KEY` | SSH 개인키 전체 내용 | SSH 인증 |
+| `GHCR_PULL_TOKEN` | `read:packages` 스코프 PAT | 서버에서 private 이미지 pull |
+
+> ghcr **푸시**는 워크플로우 기본 `GITHUB_TOKEN`으로 처리되어 별도 토큰이 필요 없다.
+> 서버 **pull**은 별도 세션이라 `GHCR_PULL_TOKEN`(PAT)이 필요하다.
+
+## 2. Lightsail 인스턴스 셋업 (1회)
+
+```bash
+# (1) 고정 IP: Lightsail 콘솔 → Networking → Static IP 생성·연결
+# (2) 방화벽: Lightsail 콘솔 → Networking → IPv4 Firewall → Custom TCP 3000 허용
+#     (가능하면 접속 소스 IP를 본인 IP로 제한)
+
+# (3) 서버 접속 후 Docker 설치
+ssh ubuntu@<LIGHTSAIL_IP>
+curl -fsSL https://get.docker.com | sudo sh
+sudo usermod -aG docker ubuntu
+# 재로그인하여 docker 그룹 적용
+exit && ssh ubuntu@<LIGHTSAIL_IP>
+docker --version && docker compose version
+
+# (4) 배포 디렉토리 + compose 파일 + 런타임 .env
+mkdir -p ~/app && cd ~/app
+# 레포의 docker-compose.yml 내용을 그대로 배치 (scp 또는 편집기로 작성)
+printf 'RIOT_API_KEY=<실제_키>\n' > .env
+chmod 600 .env
+
+# (5) ghcr 로그인 (private 이미지 pull용)
+echo "<GHCR_PULL_TOKEN>" | docker login ghcr.io -u keyy1315 --password-stdin
+```
+
+## 3. Actions가 쓸 SSH 키 등록
+
+```bash
+# 로컬에서 배포 전용 키페어 생성 (이미 Lightsail 키페어가 있으면 그걸 사용)
+ssh-keygen -t ed25519 -f ~/.ssh/lightsail_deploy -N ""
+# 공개키를 서버 authorized_keys에 추가
+ssh-copy-id -i ~/.ssh/lightsail_deploy.pub ubuntu@<LIGHTSAIL_IP>
+# 개인키(~/.ssh/lightsail_deploy 전체 내용)를 LIGHTSAIL_SSH_KEY 시크릿에 등록
+```
+
+## 4. 첫 배포 & 검증
+
+```bash
+# main에 푸시하면 파이프라인 자동 실행 (또는 Actions 탭에서 workflow_dispatch 수동 실행)
+# 서버에서 확인:
+ssh ubuntu@<LIGHTSAIL_IP>
+docker ps                       # tft_sim 컨테이너 Up 상태
+curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:3000   # 200
+# 외부에서: 브라우저로 http://<LIGHTSAIL_IP>:3000 접속
+```
+
+## 5. 롤백
+
+```bash
+cd ~/app
+# docker-compose.yml의 image 태그를 :latest → :<이전_git_sha>로 수정 후
+docker compose up -d
+```
+
+## 6. Vercel 정리 (이전 검증 후)
+
+Lightsail 배포가 안정적으로 확인되면 Vercel 프로젝트의 Git 연동(자동 배포)을
+끄거나 프로젝트를 보관 처리한다. 양쪽 동시 배포 방지.

--- a/docs/superpowers/plans/2026-06-17-docker-gha-deploy-stage1.md
+++ b/docs/superpowers/plans/2026-06-17-docker-gha-deploy-stage1.md
@@ -1,0 +1,507 @@
+# Docker + GitHub Actions 배포 (1단계: ghcr) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `main` 푸시 시 GitHub Actions가 lint·typecheck·test를 통과한 뒤 Next.js 앱을 Docker 이미지로 빌드해 `ghcr.io`에 푸시하고, SSH로 Lightsail에 접속해 컨테이너를 pull·재시작하는 자동 배포 파이프라인을 구축한다.
+
+**Architecture:** Next.js `output: 'standalone'` + 멀티스테이지 Dockerfile로 경량 이미지 생성. `NEXT_PUBLIC_*`(Supabase)는 빌드 ARG, `RIOT_API_KEY`는 서버 런타임 env로 분리. GitHub Actions 3-잡(quality → build-push → deploy) 파이프라인. 내부 IP:3000 노출, HTTPS/도메인 없음.
+
+**Tech Stack:** Next.js 16, Node 24(alpine), pnpm 10, Docker 멀티스테이지, GitHub Actions, ghcr.io, AWS Lightsail(amd64), docker compose.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-docker-github-actions-deploy-design.md`
+
+**전제:** 로컬에 Docker Desktop이 설치·실행 중이어야 한다(`docker --version` 확인). 레포 이미지 경로는 `ghcr.io/keyy1315/tft_sim`(소문자).
+
+---
+
+## Task 1: Next.js standalone 출력 활성화
+
+**Files:**
+- Modify: `next.config.ts`
+
+- [ ] **Step 1: `next.config.ts`에 `output: 'standalone'` 추가**
+
+현재 내용:
+```ts
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  reactCompiler: true,
+}
+
+export default nextConfig
+```
+
+다음으로 변경:
+```ts
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  reactCompiler: true,
+  output: 'standalone',
+}
+
+export default nextConfig
+```
+
+- [ ] **Step 2: 빌드 실행해 standalone 산출물이 생기는지 검증**
+
+Run: `pnpm build`
+Expected: 빌드 성공. 종료 후 다음 경로가 존재해야 한다.
+
+Run: `ls .next/standalone/server.js && ls -d .next/standalone/.next .next/static`
+Expected: `server.js`와 두 디렉토리 경로가 출력됨(에러 없음). 없으면 standalone 설정이 적용되지 않은 것.
+
+- [ ] **Step 3: typecheck 통과 확인**
+
+Run: `pnpm typecheck`
+Expected: 에러 없이 종료(exit 0).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add next.config.ts
+git commit -m "feat(deploy): Next.js standalone 출력 활성화"
+```
+
+---
+
+## Task 2: `.dockerignore` 작성
+
+**Files:**
+- Create: `.dockerignore`
+
+- [ ] **Step 1: `.dockerignore` 생성**
+
+빌드 컨텍스트에서 불필요/민감 파일을 제외한다. `.env*`를 제외해 시크릿이 이미지에 안 들어가게 한다.
+
+```
+# deps & build artifacts
+node_modules
+.next
+*.tsbuildinfo
+
+# vcs & ci
+.git
+.github
+.githooks
+
+# env / secrets
+.env
+.env.*
+!.env.example
+
+# docs & data & tests (런타임 불필요)
+docs
+tests
+raw-data
+actual-data
+scripts
+
+# tooling caches
+.bkit
+.claude
+.superpowers
+.understand-anything
+.playwright-mcp
+
+# os
+.DS_Store
+```
+
+- [ ] **Step 2: 무시 규칙이 올바른지 확인**
+
+Run: `git check-ignore -v node_modules .env docs 2>/dev/null; echo "---"; test -f .dockerignore && echo ".dockerignore exists"`
+Expected: 마지막 줄에 `.dockerignore exists` 출력(파일 생성 확인). (`git check-ignore`는 `.gitignore` 기준이라 참고용일 뿐 — 핵심은 파일 존재.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .dockerignore
+git commit -m "feat(deploy): .dockerignore 추가"
+```
+
+---
+
+## Task 3: `Dockerfile` 작성 및 로컬 빌드·실행 검증
+
+**Files:**
+- Create: `Dockerfile`
+
+- [ ] **Step 1: `Dockerfile` 생성 (멀티스테이지)**
+
+```dockerfile
+# syntax=docker/dockerfile:1
+
+# ---- deps: 의존성 설치 (lockfile 기반) ----
+FROM node:24-alpine AS deps
+RUN corepack enable
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# ---- build: NEXT_PUBLIC ARG 주입 후 빌드 ----
+FROM node:24-alpine AS build
+RUN corepack enable
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
+ENV NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN pnpm build
+
+# ---- runner: standalone 산출물만 복사한 경량 실행 이미지 ----
+FROM node:24-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup -g 1001 -S nodejs && adduser -S nextjs -u 1001
+
+COPY --from=build /app/public ./public
+COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+CMD ["node", "server.js"]
+```
+
+> 주의: `RIOT_API_KEY`는 의도적으로 빌드에 넣지 않는다(런타임 주입). `NEXT_PUBLIC_*`만 빌드 ARG.
+
+- [ ] **Step 2: 로컬 빌드 (NEXT_PUBLIC 값은 `.env`에서 주입)**
+
+Run:
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_SUPABASE_URL="$(grep '^NEXT_PUBLIC_SUPABASE_URL=' .env | cut -d= -f2-)" \
+  --build-arg NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY="$(grep '^NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=' .env | cut -d= -f2-)" \
+  -t tft_sim:local .
+```
+Expected: 빌드가 끝까지 성공(`naming to docker.io/library/tft_sim:local` 또는 `writing image ... done`). build 스테이지에서 `pnpm build`가 통과해야 함.
+
+- [ ] **Step 3: 컨테이너 실행 후 응답 검증**
+
+Run:
+```bash
+docker run -d --rm --name tft_local -p 3000:3000 \
+  -e RIOT_API_KEY="$(grep '^RIOT_API_KEY=' .env | cut -d= -f2-)" \
+  tft_sim:local
+sleep 3
+curl -sS -o /dev/null -w "%{http_code}\n" http://localhost:3000
+```
+Expected: `200` 출력. (앱 첫 페이지 HTTP 200.)
+
+- [ ] **Step 4: 이미지에 Riot 키가 박히지 않았는지 확인**
+
+Run:
+```bash
+docker run --rm --entrypoint sh tft_sim:local -c "grep -rl 'RIOT_API_KEY' / 2>/dev/null | head; echo done"
+```
+Expected: 마지막 줄 `done`만 보이거나, 코드 파일(소스에 등장하는 변수명)만 잡히고 **실제 키 값 문자열은 없음**. (확인 보조용 — 핵심은 Dockerfile에 `RIOT_API_KEY` ARG/ENV가 없다는 점.)
+
+- [ ] **Step 5: 컨테이너 정리**
+
+Run: `docker stop tft_local`
+Expected: `tft_local` 출력(중지됨, `--rm`이라 자동 삭제).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "feat(deploy): 멀티스테이지 Dockerfile 추가 (standalone 런타임)"
+```
+
+---
+
+## Task 4: `docker-compose.yml` 작성
+
+**Files:**
+- Create: `docker-compose.yml`
+
+- [ ] **Step 1: `docker-compose.yml` 생성 (서버 실행 정의)**
+
+서버에 배치되며 레포에도 보관한다. 런타임 시크릿은 서버의 `.env`에서 주입.
+
+```yaml
+services:
+  app:
+    image: ghcr.io/keyy1315/tft_sim:latest
+    container_name: tft_sim
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - RIOT_API_KEY=${RIOT_API_KEY}
+    restart: unless-stopped
+```
+
+- [ ] **Step 2: compose 파일 문법 검증**
+
+Run: `docker compose -f docker-compose.yml config -q && echo "compose ok"`
+Expected: `compose ok` 출력. (`${RIOT_API_KEY}` 미설정 경고가 떠도 문법 검증은 통과.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "feat(deploy): 서버용 docker-compose.yml 추가"
+```
+
+---
+
+## Task 5: GitHub Actions 워크플로우 작성
+
+**Files:**
+- Create: `.github/workflows/deploy.yml`
+
+- [ ] **Step 1: `.github/workflows/deploy.yml` 생성**
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/keyy1315/tft_sim
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm test
+
+  build-push:
+    needs: quality
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          build-args: |
+            NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH deploy to Lightsail
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LIGHTSAIL_HOST }}
+          username: ${{ secrets.LIGHTSAIL_USER }}
+          key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
+          script: |
+            cd ~/app
+            echo "${{ secrets.GHCR_PULL_TOKEN }}" | docker login ghcr.io -u keyy1315 --password-stdin
+            docker compose pull
+            docker compose up -d
+            docker image prune -f
+```
+
+- [ ] **Step 2: 워크플로우 YAML 문법 검증 (로컬)**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/deploy.yml')); print('yaml ok')"`
+Expected: `yaml ok` 출력.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "feat(deploy): GitHub Actions 파이프라인(quality→build-push→deploy)"
+```
+
+---
+
+## Task 6: Lightsail 셋업 + Secrets 운영 문서
+
+**Files:**
+- Create: `docs/deploy/lightsail-setup.md`
+
+- [ ] **Step 1: `docs/deploy/lightsail-setup.md` 생성**
+
+````markdown
+# Lightsail 배포 셋업 (1단계: ghcr)
+
+자동 배포 파이프라인이 동작하려면 **GitHub Secrets 등록**과 **서버 1회 셋업**이 필요하다.
+
+## 1. GitHub Secrets (레포 Settings → Secrets and variables → Actions)
+
+| Secret | 값 | 용도 |
+|--------|----|----|
+| `NEXT_PUBLIC_SUPABASE_URL` | 로컬 `.env`와 동일 | 빌드 ARG |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | 로컬 `.env`와 동일 | 빌드 ARG |
+| `LIGHTSAIL_HOST` | Lightsail 고정 IP | SSH 대상 |
+| `LIGHTSAIL_USER` | `ubuntu` (Ubuntu 이미지) | SSH 계정 |
+| `LIGHTSAIL_SSH_KEY` | SSH 개인키 전체 내용 | SSH 인증 |
+| `GHCR_PULL_TOKEN` | `read:packages` 스코프 PAT | 서버에서 private 이미지 pull |
+
+> ghcr **푸시**는 워크플로우 기본 `GITHUB_TOKEN`으로 처리되어 별도 토큰이 필요 없다.
+> 서버 **pull**은 별도 세션이라 `GHCR_PULL_TOKEN`(PAT)이 필요하다.
+
+## 2. Lightsail 인스턴스 셋업 (1회)
+
+```bash
+# (1) 고정 IP: Lightsail 콘솔 → Networking → Static IP 생성·연결
+# (2) 방화벽: Lightsail 콘솔 → Networking → IPv4 Firewall → Custom TCP 3000 허용
+#     (가능하면 소스 IP를 본인 IP로 제한)
+
+# (3) 서버 접속 후 Docker 설치
+ssh ubuntu@<LIGHTSAIL_IP>
+curl -fsSL https://get.docker.com | sudo sh
+sudo usermod -aG docker ubuntu
+# 재로그인하여 docker 그룹 적용
+exit && ssh ubuntu@<LIGHTSAIL_IP>
+docker --version && docker compose version
+
+# (4) 배포 디렉토리 + compose 파일 + 런타임 .env
+mkdir -p ~/app && cd ~/app
+# 레포의 docker-compose.yml 내용을 그대로 배치
+#   (scp 또는 직접 편집기로 작성)
+printf 'RIOT_API_KEY=<실제_키>\n' > .env
+chmod 600 .env
+
+# (5) ghcr 로그인 (private 이미지 pull용)
+echo "<GHCR_PULL_TOKEN>" | docker login ghcr.io -u keyy1315 --password-stdin
+```
+
+## 3. Actions가 쓸 SSH 키 등록
+
+```bash
+# 로컬에서 배포 전용 키페어 생성 (이미 Lightsail 키페어가 있으면 그걸 사용)
+ssh-keygen -t ed25519 -f ~/.ssh/lightsail_deploy -N ""
+# 공개키를 서버 authorized_keys에 추가
+ssh-copy-id -i ~/.ssh/lightsail_deploy.pub ubuntu@<LIGHTSAIL_IP>
+# 개인키(~/.ssh/lightsail_deploy 전체 내용)를 LIGHTSAIL_SSH_KEY 시크릿에 등록
+```
+
+## 4. 첫 배포 & 검증
+
+```bash
+# main에 푸시하면 파이프라인 자동 실행 (또는 Actions 탭에서 workflow_dispatch 수동 실행)
+# 서버에서 확인:
+ssh ubuntu@<LIGHTSAIL_IP>
+docker ps                       # tft_sim 컨테이너 Up 상태
+curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:3000   # 200
+# 외부에서: 브라우저로 http://<LIGHTSAIL_IP>:3000 접속
+```
+
+## 5. 롤백
+
+```bash
+# 특정 커밋 이미지로 되돌리기
+cd ~/app
+# docker-compose.yml의 image 태그를 :latest → :<이전_git_sha>로 수정 후
+docker compose up -d
+```
+
+## 6. Vercel 정리 (이전 검증 후)
+
+Lightsail 배포가 안정적으로 확인되면 Vercel 프로젝트의 Git 연동(자동 배포)을
+끄거나 프로젝트를 보관 처리한다. 양쪽 동시 배포 방지.
+````
+
+- [ ] **Step 2: 문서 링크 무결성 가벼운 확인**
+
+Run: `test -f docs/deploy/lightsail-setup.md && grep -c 'GHCR_PULL_TOKEN' docs/deploy/lightsail-setup.md`
+Expected: `2` 이상(Secrets 표 + 셋업 명령에 등장).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/deploy/lightsail-setup.md
+git commit -m "docs(deploy): Lightsail 셋업 + Secrets 운영 가이드"
+```
+
+---
+
+## Task 7: README에 배포 섹션 링크 추가
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: README 끝에 배포 안내 섹션 추가**
+
+`README.md` 맨 끝에 다음을 추가:
+
+```markdown
+
+## 배포 (Docker + GitHub Actions)
+
+`main` 푸시 시 GitHub Actions가 lint·typecheck·test → 이미지 빌드(ghcr) →
+Lightsail SSH 배포를 자동 수행한다.
+
+- 설계: `docs/superpowers/specs/2026-06-17-docker-github-actions-deploy-design.md`
+- 셋업/Secrets: `docs/deploy/lightsail-setup.md`
+
+로컬 컨테이너 실행:
+\`\`\`bash
+docker build \
+  --build-arg NEXT_PUBLIC_SUPABASE_URL="..." \
+  --build-arg NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY="..." \
+  -t tft_sim:local .
+docker run --rm -p 3000:3000 -e RIOT_API_KEY="..." tft_sim:local
+\`\`\`
+```
+
+- [ ] **Step 2: 변경 확인**
+
+Run: `grep -c '배포 (Docker' README.md`
+Expected: `1`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: README에 배포 섹션 추가"
+```
+
+---
+
+## 완료 기준 (전체 검증)
+
+1. `pnpm build` 후 `.next/standalone/server.js` 존재 (Task 1)
+2. 로컬 `docker build` 성공 + `docker run` 후 `curl localhost:3000` → 200 (Task 3)
+3. `.github/workflows/deploy.yml` YAML 유효 (Task 5)
+4. GitHub Secrets 6종 등록 + Lightsail 1회 셋업 완료 (Task 6, 수동)
+5. `main` 푸시 → Actions 3잡(quality→build-push→deploy) 순차 통과
+6. `http://<LIGHTSAIL_IP>:3000` 외부 접속 200
+7. lint/typecheck/test 중 하나를 일부러 깨뜨리면 배포 중단(게이트 동작 확인)
+
+> 주의: 5~7은 GitHub Secrets/서버 셋업(Task 6)이 끝나야 검증 가능. 코드 산출물(Task 1~5, 7)은 로컬에서 독립 검증된다.

--- a/docs/superpowers/specs/2026-06-17-docker-github-actions-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-17-docker-github-actions-deploy-design.md
@@ -4,6 +4,21 @@
 - **대상 레포**: `keyy1315/tft_sim`
 - **이미지 경로**: `ghcr.io/keyy1315/tft_sim`
 - **현 상태**: Vercel Git 연동 배포 → AWS Lightsail VPS(자체 호스팅)로 이전
+- **목적**: 배포 학습 (실무에서 차장님이 "프론트 서버도 GitHub Actions로 도커 이미지 말아서 올려라" 지시)
+
+---
+
+## 0. 학습 맥락 / 실무 정렬
+
+- **왜 하는가**: 프로덕션이 아니라 **배포 파이프라인 학습**이 1차 목적.
+- **실무 환경**: API 서버가 이미 GitHub Actions + Docker + **EC2**로 운영 중.
+  프론트(Next.js)도 동일 패턴으로 컨테이너화하는 것이 차장님의 요구.
+- **연습 환경 전이성**: Lightsail은 EC2 위의 추상화 → **SSH + docker pull/run 패턴이
+  실무 EC2에 거의 그대로 전이**된다. 라이트세일로 익힌 워크플로우를 실무에 이식 가능.
+- **단계적 학습 경로**:
+  - **1단계 (이번 구현 범위)**: ghcr.io로 전체 파이프라인 완성 → 도커·액션 흐름 자체를 이해
+  - **2단계 (후속)**: 레지스트리를 ECR로 전환 → AWS IAM/OIDC 자격증명 학습, 실무 EC2 환경과 동일 패턴 재현
+  > 자세한 전환 포인트는 §9 참조.
 
 ---
 
@@ -13,6 +28,7 @@
 `main` 브랜치 푸시 시, GitHub Actions가 품질 게이트를 통과한 뒤 Docker 이미지를 빌드해
 GitHub Container Registry(`ghcr.io`)에 푸시하고, SSH로 Lightsail 인스턴스에 접속해
 새 이미지를 pull·재시작하는 **완전 자동 배포 파이프라인**을 구축한다.
+(1단계 = ghcr 기반. ECR 전환은 2단계 후속 — §9)
 
 ### 결정 사항 (브레인스토밍 합의)
 | 항목 | 결정 |
@@ -20,11 +36,12 @@ GitHub Container Registry(`ghcr.io`)에 푸시하고, SSH로 Lightsail 인스턴
 | 배포 타겟 | AWS Lightsail VPS (x86/amd64, 이미 인스턴스 생성됨) |
 | 공개 방식 | 내부 IP:포트(`3000`)만. 도메인·HTTPS·reverse proxy 없음 |
 | 배포 트리거 | 방식 A: ghcr 푸시 + SSH pull (`docker compose pull && up -d`) |
-| 레지스트리 | `ghcr.io` (private, 워크플로우 `GITHUB_TOKEN`으로 푸시) |
+| 레지스트리 | **1단계 `ghcr.io`** (private, 워크플로우 `GITHUB_TOKEN`으로 푸시) → 2단계 ECR 전환 (§9) |
 | 품질 게이트 | 배포 전 `pnpm lint && typecheck && test` 강제 (실패 시 배포 중단) |
 | 베이스 이미지 | `node:24-alpine` (로컬 Node 24와 통일) |
 
-### 범위 밖 (YAGNI)
+### 범위 밖 (YAGNI / 후속)
+- **ECR 전환** → 2단계 후속 (§9). 1단계는 ghcr로 완성
 - 도메인 연결, HTTPS/TLS, reverse proxy(Nginx/Caddy/Traefik)
 - 무중단 블루-그린/카나리 배포 (단일 컨테이너 `up -d` 재시작으로 충분)
 - 멀티 아키텍처 빌드 (Lightsail amd64 단일 타겟)
@@ -186,3 +203,24 @@ services:
 - **포트 방화벽**: Lightsail 방화벽(콘솔)과 OS 방화벽(ufw) 둘 다 확인 필요.
 - **아키텍처**: Lightsail amd64 가정. 혹시 ARM 인스턴스라면 build-push에 `platforms: linux/arm64` 필요(현재 범위 밖).
 - **Vercel 중복 배포**: 이전 완료 전까지 Vercel 연동을 끄지 않으면 양쪽 배포. 검증 후 Vercel 측 정리.
+
+---
+
+## 9. 학습 로드맵 — 2단계 ECR 전환 (후속)
+
+1단계(ghcr)로 도커·액션 흐름을 이해한 뒤, 실무 EC2 환경과 동일하게 ECR로 전환한다.
+**1단계와 달라지는 부분만** 정리(Dockerfile·compose·앱 코드는 그대로 재사용):
+
+| 구성요소 | 1단계 (ghcr) | 2단계 (ECR) |
+|----------|-------------|-------------|
+| 레지스트리 | `ghcr.io/keyy1315/tft_sim` | `<acct>.dkr.ecr.<region>.amazonaws.com/tft_sim` |
+| Actions 인증 | `docker/login-action` + `GITHUB_TOKEN` | `aws-actions/configure-aws-credentials` (**OIDC** 권장) + `amazon-ecr-login` |
+| 서버 pull 인증 | `read:packages` PAT 로그인 | 인스턴스 IAM Role(ECR read) → `aws ecr get-login-password` |
+| 레포지토리 생성 | 자동(첫 푸시) | ECR 레포 사전 생성 필요 |
+
+**학습 포인트**:
+- GitHub OIDC ↔ AWS IAM Role 신뢰관계(정적 키 없는 단기 자격증명)
+- 인스턴스 프로파일(IAM Role)로 서버에서 PAT 없이 pull
+- 실무 백엔드 워크플로우와 비교하며 차이 학습 (가능하면 사내 yml 참고)
+
+> 2단계는 **별도 스펙 → 플랜 사이클**로 진행한다. 본 문서는 1단계에 집중.

--- a/docs/superpowers/specs/2026-06-17-docker-github-actions-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-17-docker-github-actions-deploy-design.md
@@ -1,0 +1,188 @@
+# Docker + GitHub Actions 배포 설계 (Vercel → 자체 VPS)
+
+- **작성일**: 2026-06-17
+- **대상 레포**: `keyy1315/tft_sim`
+- **이미지 경로**: `ghcr.io/keyy1315/tft_sim`
+- **현 상태**: Vercel Git 연동 배포 → AWS Lightsail VPS(자체 호스팅)로 이전
+
+---
+
+## 1. 목표와 범위
+
+### 목표
+`main` 브랜치 푸시 시, GitHub Actions가 품질 게이트를 통과한 뒤 Docker 이미지를 빌드해
+GitHub Container Registry(`ghcr.io`)에 푸시하고, SSH로 Lightsail 인스턴스에 접속해
+새 이미지를 pull·재시작하는 **완전 자동 배포 파이프라인**을 구축한다.
+
+### 결정 사항 (브레인스토밍 합의)
+| 항목 | 결정 |
+|------|------|
+| 배포 타겟 | AWS Lightsail VPS (x86/amd64, 이미 인스턴스 생성됨) |
+| 공개 방식 | 내부 IP:포트(`3000`)만. 도메인·HTTPS·reverse proxy 없음 |
+| 배포 트리거 | 방식 A: ghcr 푸시 + SSH pull (`docker compose pull && up -d`) |
+| 레지스트리 | `ghcr.io` (private, 워크플로우 `GITHUB_TOKEN`으로 푸시) |
+| 품질 게이트 | 배포 전 `pnpm lint && typecheck && test` 강제 (실패 시 배포 중단) |
+| 베이스 이미지 | `node:24-alpine` (로컬 Node 24와 통일) |
+
+### 범위 밖 (YAGNI)
+- 도메인 연결, HTTPS/TLS, reverse proxy(Nginx/Caddy/Traefik)
+- 무중단 블루-그린/카나리 배포 (단일 컨테이너 `up -d` 재시작으로 충분)
+- 멀티 아키텍처 빌드 (Lightsail amd64 단일 타겟)
+- Vercel 프로젝트 정리/삭제 (이전 검증 후 사용자가 별도 판단)
+
+---
+
+## 2. 환경변수 분류 (핵심)
+
+| 변수 | 시점 | 처리 방식 | 비고 |
+|------|------|----------|------|
+| `NEXT_PUBLIC_SUPABASE_URL` | **빌드타임** | Dockerfile `ARG` → 번들 인라인 | publishable, 노출 무방 |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | **빌드타임** | Dockerfile `ARG` → 번들 인라인 | publishable, 노출 무방 |
+| `RIOT_API_KEY` | **런타임** | 컨테이너 실행 시 주입 (서버 `.env`) | 시크릿. 이미지에 박지 않음 |
+
+> `NEXT_PUBLIC_*`는 `next build` 시점에 클라이언트 번들에 문자열로 박힌다.
+> 런타임 주입으로는 바꿀 수 없으므로 **반드시 빌드 ARG로 전달**한다.
+> `RIOT_API_KEY`는 서버 사이드(API route)에서만 쓰이므로 런타임 env로 주입한다.
+
+---
+
+## 3. 산출물 (생성/수정 파일)
+
+### 3.1 `next.config.ts` (수정)
+```ts
+const nextConfig: NextConfig = {
+  reactCompiler: true,
+  output: 'standalone',   // 추가: 최소 실행본(.next/standalone) 생성
+}
+```
+
+### 3.2 `Dockerfile` (신규, 멀티스테이지)
+- **stage `deps`**: `node:24-alpine` + corepack(pnpm) → `pnpm install --frozen-lockfile`
+- **stage `build`**:
+  - `ARG NEXT_PUBLIC_SUPABASE_URL`, `ARG NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
+  - 해당 ARG를 `ENV`로 노출 후 `pnpm build`
+  - 출력: `.next/standalone`, `.next/static`, `public`
+- **stage `runner`**:
+  - `node:24-alpine`, `NODE_ENV=production`
+  - non-root 유저(`node`) 사용
+  - standalone 결과물 + `.next/static` + `public` 복사
+  - `EXPOSE 3000`, `CMD ["node", "server.js"]`
+  - `RIOT_API_KEY`는 복사/박지 않음 (런타임 주입)
+
+### 3.3 `.dockerignore` (신규)
+제외 대상: `node_modules`, `.next`, `.git`, `.github`, `docs`, `tests`, `raw-data`,
+`actual-data`, `.bkit`, `.claude`, `.superpowers`, `.understand-anything`,
+`.playwright-mcp`, `*.tsbuildinfo`, `.env*`
+
+### 3.4 `docker-compose.yml` (신규, 서버 배치용 — 레포에도 보관)
+```yaml
+services:
+  app:
+    image: ghcr.io/keyy1315/tft_sim:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - RIOT_API_KEY=${RIOT_API_KEY}
+      - NODE_ENV=production
+    restart: unless-stopped
+```
+- 서버에는 `RIOT_API_KEY=...`만 담은 `.env`를 같은 디렉토리에 둔다.
+
+### 3.5 `.github/workflows/deploy.yml` (신규)
+**잡 1 — `quality`** (게이트):
+- checkout → pnpm 셋업 → `pnpm install --frozen-lockfile`
+- `pnpm lint` → `pnpm typecheck` → `pnpm test`
+- 하나라도 실패 시 워크플로우 종료 (이후 잡 미실행)
+
+**잡 2 — `build-push`** (`needs: quality`):
+- ghcr 로그인 (`docker/login-action`, `GITHUB_TOKEN`)
+- `docker/build-push-action`:
+  - `build-args`로 `NEXT_PUBLIC_*` 두 개 전달 (Actions Secrets에서)
+  - 태그: `:latest` + `:${{ github.sha }}`
+  - 캐시: `cache-from/to: type=gha`
+
+**잡 3 — `deploy`** (`needs: build-push`):
+- `appleboy/ssh-action`으로 Lightsail 접속
+- 배포 디렉토리에서:
+  ```
+  echo $GHCR_TOKEN | docker login ghcr.io -u keyy1315 --password-stdin
+  docker compose pull
+  docker compose up -d
+  docker image prune -f
+  ```
+
+트리거: `on: push: branches: [main]` + `workflow_dispatch` (수동 재배포용)
+
+---
+
+## 4. GitHub Secrets
+
+| Secret | 용도 |
+|--------|------|
+| `NEXT_PUBLIC_SUPABASE_URL` | 빌드 ARG |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | 빌드 ARG |
+| `LIGHTSAIL_HOST` | SSH 대상 IP (Lightsail 고정 IP 권장) |
+| `LIGHTSAIL_USER` | SSH 계정 (Ubuntu 이미지면 `ubuntu`) |
+| `LIGHTSAIL_SSH_KEY` | SSH 개인키 (Lightsail 키페어) |
+| `GHCR_PULL_TOKEN` | 서버에서 private 이미지 pull용 PAT (`read:packages`) |
+
+> ghcr **푸시**는 워크플로우 기본 `GITHUB_TOKEN`으로 가능(별도 토큰 불필요).
+> 서버 **pull**은 별도 세션이라 `read:packages` 스코프 PAT가 필요하다.
+
+---
+
+## 5. Lightsail 1회성 셋업 가이드 (문서로 남김)
+
+1. **인스턴스 OS 확인**: Ubuntu LTS 가정 (SSH 유저 `ubuntu`)
+2. **고정 IP 할당**: Lightsail → Networking → Static IP 연결 (재부팅 시 IP 변경 방지)
+3. **방화벽**: Lightsail → Networking → IPv4 Firewall → Custom TCP **3000** 허용
+   (가능하면 접속 소스 IP 제한)
+4. **Docker + Compose 설치**: `get.docker.com` 스크립트 → `ubuntu` 유저 docker 그룹 추가
+5. **배포 디렉토리 준비**: 예) `~/app/` 에 `docker-compose.yml` 배치 + `.env`(RIOT_API_KEY) 생성
+6. **ghcr 로그인**: `GHCR_PULL_TOKEN`으로 `docker login ghcr.io`
+7. **SSH 키**: Actions가 쓸 키페어를 `authorized_keys`에 등록, 개인키는 `LIGHTSAIL_SSH_KEY` 시크릿에
+
+---
+
+## 6. 데이터 흐름 / 컴포넌트 경계
+
+```
+[개발자] --push main--> [GitHub]
+                           |
+                  (1) quality 잡: lint/typecheck/test
+                           | pass
+                  (2) build-push 잡
+                     - NEXT_PUBLIC_* ARG 주입하여 build
+                     - ghcr.io/keyy1315/tft_sim:{latest,sha} push
+                           |
+                  (3) deploy 잡: SSH --> [Lightsail VPS]
+                                           - docker compose pull
+                                           - docker compose up -d
+                                           - RIOT_API_KEY는 서버 .env에서 주입
+                                           |
+                                    [컨테이너 :3000] <-- 사용자 (IP:3000)
+```
+
+- **빌드 책임**: GitHub Actions (서버는 빌드 안 함 → Lightsail 부하 최소)
+- **시크릿 경계**: 빌드 시크릿(Supabase)은 Actions, 런타임 시크릿(Riot)은 서버 `.env`로 분리
+- **롤백**: `docker-compose.yml`의 태그를 `:latest` → `:<이전 sha>`로 바꿔 `up -d`
+
+---
+
+## 7. 검증 시나리오 (구현 후 확인 항목)
+
+1. 로컬에서 `docker build` 성공 + `docker run -p 3000:3000` 후 페이지 정상 렌더
+2. 빌드된 번들에 Supabase URL이 인라인됐는지(클라이언트 동작), `RIOT_API_KEY`는 이미지에 없음 확인
+3. main 푸시 → Actions 3개 잡 순차 통과(quality → build-push → deploy)
+4. Lightsail에서 `docker ps`로 컨테이너 running, IP:3000 외부 접속 확인
+5. lint/typecheck/test 중 하나를 일부러 깨뜨려 배포가 중단되는지 확인(게이트 동작)
+
+---
+
+## 8. 리스크 / 주의
+
+- **NEXT_PUBLIC 누락**: build-args 전달을 빠뜨리면 런타임에 Supabase 연결 실패(빌드 후엔 못 고침). 검증 2번으로 차단.
+- **ghcr private pull 실패**: 서버에 `read:packages` PAT 로그인 누락 시 `pull` 실패. 셋업 6번으로 차단.
+- **포트 방화벽**: Lightsail 방화벽(콘솔)과 OS 방화벽(ufw) 둘 다 확인 필요.
+- **아키텍처**: Lightsail amd64 가정. 혹시 ARM 인스턴스라면 build-push에 `platforms: linux/arm64` 필요(현재 범위 밖).
+- **Vercel 중복 배포**: 이전 완료 전까지 Vercel 연동을 끄지 않으면 양쪽 배포. 검증 후 Vercel 측 정리.

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  output: 'standalone',
 }
 
 export default nextConfig


### PR DESCRIPTION
## 개요

Vercel Git 연동 배포 → 자체 VPS(AWS Lightsail) 컨테이너 배포로 이전하는 **1단계(ghcr)** 구현.
`main` 푸시 시 GitHub Actions가 품질 게이트 → 이미지 빌드(ghcr) → SSH로 Lightsail에 pull·재시작.

- 설계: `docs/superpowers/specs/2026-06-17-docker-github-actions-deploy-design.md`
- 플랜: `docs/superpowers/plans/2026-06-17-docker-gha-deploy-stage1.md`
- 셋업: `docs/deploy/lightsail-setup.md`

## 변경 사항

| 파일 | 내용 |
|------|------|
| `next.config.ts` | `output: 'standalone'` |
| `Dockerfile` | 멀티스테이지(deps/build/runner), `NEXT_PUBLIC_*` 빌드 ARG, `RIOT_API_KEY` 런타임 주입, non-root |
| `.dockerignore` | 빌드 컨텍스트 경량화 |
| `docker-compose.yml` | 서버 배치용 (이미지·포트·런타임 env) |
| `.github/workflows/deploy.yml` | `quality`(lint/typecheck/test) → `build-push`(ghcr) → `deploy`(SSH) |
| `docs/deploy/lightsail-setup.md` | Secrets 6종 + 서버 1회 셋업 가이드 |
| `README.md` | 배포 섹션 |

## 로컬 검증

- ✅ `pnpm build` standalone 산출물 생성
- ✅ `docker build` → `tft_sim:local` (403MB)
- ✅ `docker run` → `curl localhost:3000` **HTTP 200**
- ✅ `RIOT_API_KEY` 값 이미지 미인라인 (변수 참조만, 런타임 평가)
- ✅ `typecheck` 0 errors / `lint` 0 errors / workflow YAML 유효

## ⚠️ 머지 전 필수 (수동 셋업)

이 PR이 머지되면 `deploy.yml`이 main push로 트리거됩니다. **아래를 먼저 끝내지 않으면 `build-push`/`deploy` 잡이 실패**합니다:

1. **GitHub Secrets 6종**: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, `LIGHTSAIL_HOST`, `LIGHTSAIL_USER`, `LIGHTSAIL_SSH_KEY`, `GHCR_PULL_TOKEN`
2. **Lightsail 서버 셋업**: Docker 설치, ghcr 로그인, `~/app`에 compose+`.env`, 방화벽 3000 개방

## 후속 (별도 사이클)

- 2단계: 레지스트리 ghcr → **ECR** 전환 (OIDC/IAM) — 실무 EC2 환경 정렬. 설계 §9 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)